### PR TITLE
allow override env-variables in load_catalog

### DIFF
--- a/pyiceberg/utils/config.py
+++ b/pyiceberg/utils/config.py
@@ -43,7 +43,7 @@ def merge_config(lhs: RecursiveDict, rhs: RecursiveDict) -> RecursiveDict:
                 new_config[rhs_key] = merge_config(lhs_value, rhs_value)
             else:
                 # Take the non-null value, with precedence on rhs
-                new_config[rhs_key] = lhs_value or rhs_value
+                new_config[rhs_key] = rhs_value or lhs_value
         else:
             # New key
             new_config[rhs_key] = rhs_value

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -20,7 +20,7 @@ from unittest import mock
 import pytest
 from strictyaml import as_document
 
-from pyiceberg.utils.config import Config, _lowercase_dictionary_keys
+from pyiceberg.utils.config import Config, _lowercase_dictionary_keys, merge_config
 
 EXAMPLE_ENV = {"PYICEBERG_CATALOG__PRODUCTION__URI": "https://service.io/api"}
 
@@ -54,3 +54,10 @@ def test_lowercase_dictionary_keys() -> None:
     uppercase_keys = {"UPPER": {"NESTED_UPPER": {"YES"}}}
     expected = {"upper": {"nested_upper": {"YES"}}}
     assert _lowercase_dictionary_keys(uppercase_keys) == expected  # type: ignore
+
+def test_merge_config() -> None:
+    lhs = {"common_key": "abc123"}
+    rhs = {"common_key": "xyz789"}
+    result = merge_config(lhs, rhs)
+    assert result["common_key"] == rhs["common_key"]
+

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -20,6 +20,7 @@ from unittest import mock
 import pytest
 from strictyaml import as_document
 
+from pyiceberg.typedef import RecursiveDict
 from pyiceberg.utils.config import Config, _lowercase_dictionary_keys, merge_config
 
 EXAMPLE_ENV = {"PYICEBERG_CATALOG__PRODUCTION__URI": "https://service.io/api"}
@@ -55,9 +56,9 @@ def test_lowercase_dictionary_keys() -> None:
     expected = {"upper": {"nested_upper": {"YES"}}}
     assert _lowercase_dictionary_keys(uppercase_keys) == expected  # type: ignore
 
+
 def test_merge_config() -> None:
-    lhs = {"common_key": "abc123"}
-    rhs = {"common_key": "xyz789"}
+    lhs: RecursiveDict = {"common_key": "abc123"}
+    rhs: RecursiveDict = {"common_key": "xyz789"}
     result = merge_config(lhs, rhs)
     assert result["common_key"] == rhs["common_key"]
-


### PR DESCRIPTION
I found that I was unable to change a catalog URI after it had been configured by an environment variable. Example, 

```
import os
os.environ["PYICEBERG_CATALOG__SOMEDB__URI"] = "https://service-one.io"
from pyiceberg.catalog import load_catalog
catalog = load_catalog("somedb", uri="https://service-two.io")
```

[tries to connect to `https://service-one.io`]

I think the more intuitive behavior is that the URI would be initialized based on the environment variable (if present) but that the argument passed to `load_catalog` would be able to override the value. This PR updates the behavior so that the passed in argument takes precedence, by swapping the lhs and rhs preference in the `merge_config` method.

