### PR TITLE
Fix Iceberg to Avro Schema Conversion: Fixed, Decimal, UUID

### DIFF
--- a/tests/avro/test_file.py
+++ b/tests/avro/test_file.py
@@ -286,5 +286,12 @@ def test_all_primitive_types(is_required: bool) -> None:
             it = iter(avro_reader)
             avro_entry = next(it)
 
+        # read with fastavro
+        with open(tmp_avro_file, "rb") as fo:
+            r = reader(fo=fo)
+            it_fastavro = iter(r)
+            avro_entry_read_with_fastavro = list(next(it_fastavro).values())
+
     for idx, field in enumerate(all_primitives_schema.as_struct()):
         assert record[idx] == avro_entry[idx], f"Invalid {field}"
+        assert record[idx] == avro_entry_read_with_fastavro[idx], f"Invalid {field} read with fastavro"


### PR DESCRIPTION
Fix #14 

This PR fixes incorrect schema conversion from Iceberg's Fixed, Decimal, and UUID to Avro's:
- Fixed and UUID: missing required field "name"
- Decimal: According to spec and the current avro writer implementation, decimal is written as a "fixed" type instead of "bytes"