### PR TITLE
Fix column rename doc example to reflect correct API

### DIFF
--- a/mkdocs/docs/api.md
+++ b/mkdocs/docs/api.md
@@ -195,9 +195,9 @@ Renaming a field in an Iceberg table is simple:
 
 ```python
 with table.update_schema() as update:
-    update.rename("retries", "num_retries")
+    update.rename_column("retries", "num_retries")
     # This will rename `confirmed_by` to `exchange`
-    update.rename("properties.confirmed_by", "exchange")
+    update.rename_column("properties.confirmed_by", "exchange")
 ```
 
 ### Move column


### PR DESCRIPTION
* Rename column example in [this](https://py.iceberg.apache.org/api/#rename-column) doc is incorrect. 
* This PR updates the example to use `update.rename_column(...)` instead of `update.rename(...)`.

After PR

```
with table.update_schema() as update:
    update.rename_column("retries", "num_retries")
    # This will rename `confirmed_by` to `exchange`
    update.rename_column("properties.confirmed_by", "exchange")
```