### PR TITLE
Make `next_sequence_number` private

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -533,7 +533,7 @@ class Table:
     def last_sequence_number(self) -> int:
         return self.metadata.last_sequence_number
 
-    def next_sequence_number(self) -> int:
+    def _next_sequence_number(self) -> int:
         return INITIAL_SEQUENCE_NUMBER if self.format_version == 1 else self.last_sequence_number + 1
 
     def new_snapshot_id(self) -> int:


### PR DESCRIPTION
We should only use this in the table module.

Follow up on https://github.com/apache/iceberg-python/pull/60#discussion_r1355656751