### PR TITLE
Add `spec_id` back to data file

### DIFF
--- a/pyiceberg/manifest.py
+++ b/pyiceberg/manifest.py
@@ -610,9 +610,12 @@ def read_manifest_list(input_file: InputFile) -> Iterator[ManifestFile]:
 
 
 def _inherit_from_manifest(entry: ManifestEntry, manifest: ManifestFile) -> ManifestEntry:
-    """Inherits below properties from manifest file:
-        - sequence numbers.
-        - partition spec id.
+    """
+    Inherits properties from manifest file.
+
+    The properties that will be inherited are:
+    - sequence numbers
+    - partition spec id.
 
     More information about inheriting sequence numbers: https://iceberg.apache.org/spec/#sequence-number-inheritance
 

--- a/pyiceberg/manifest.py
+++ b/pyiceberg/manifest.py
@@ -182,6 +182,7 @@ DATA_FILE_TYPE: Dict[int, StructType] = {
             doc="Splittable offsets",
         ),
         NestedField(field_id=140, name="sort_order_id", field_type=IntegerType(), required=False, doc="Sort order ID"),
+        NestedField(field_id=141, name="spec_id", field_type=IntegerType(), required=False, doc="Partition spec ID"),
     ),
     2: StructType(
         NestedField(
@@ -277,6 +278,13 @@ DATA_FILE_TYPE: Dict[int, StructType] = {
             required=False,
             doc="ID representing sort order for this file",
         ),
+        NestedField(
+            field_id=141,
+            name="spec_id",
+            field_type=IntegerType(),
+            required=False,
+            doc="ID representing spec id for this file",
+        ),
     ),
 }
 
@@ -346,6 +354,7 @@ class DataFile(Record):
         "split_offsets",
         "equality_ids",
         "sort_order_id",
+        "spec_id",
     )
     content: DataFileContent
     file_path: str
@@ -363,6 +372,7 @@ class DataFile(Record):
     split_offsets: Optional[List[int]]
     equality_ids: Optional[List[int]]
     sort_order_id: Optional[int]
+    spec_id: Optional[int]
 
     def __setattr__(self, name: str, value: Any) -> None:
         """Assign a key/value to a DataFile."""

--- a/tests/avro/test_file.py
+++ b/tests/avro/test_file.py
@@ -135,7 +135,6 @@ def test_write_manifest_entry_with_iceberg_read_with_fastavro_v1() -> None:
         split_offsets=[4, 133697593],
         equality_ids=[],
         sort_order_id=4,
-        spec_id=3,
     )
     entry = ManifestEntry(
         status=ManifestEntryStatus.ADDED,

--- a/tests/avro/test_file.py
+++ b/tests/avro/test_file.py
@@ -135,6 +135,7 @@ def test_write_manifest_entry_with_iceberg_read_with_fastavro_v1() -> None:
         split_offsets=[4, 133697593],
         equality_ids=[],
         sort_order_id=4,
+        spec_id=3,
     )
     entry = ManifestEntry(
         status=ManifestEntryStatus.ADDED,
@@ -256,6 +257,7 @@ def test_write_manifest_entry_with_fastavro_read_with_iceberg(format_version: in
         split_offsets=[4, 133697593],
         equality_ids=[],
         sort_order_id=4,
+        spec_id=3,
     )
     if format_version == 1:
         data_file.block_size_in_bytes = DEFAULT_BLOCK_SIZE

--- a/tests/test_integration_manifest.py
+++ b/tests/test_integration_manifest.py
@@ -101,6 +101,7 @@ def test_write_sample_manifest(table_test_all_types: Table) -> None:
         split_offsets=entry.data_file.split_offsets,
         equality_ids=entry.data_file.equality_ids,
         sort_order_id=entry.data_file.sort_order_id,
+        spec_id=entry.data_file.spec_id,
     )
     wrapped_entry_v2 = ManifestEntry(*entry.record_fields())
     wrapped_entry_v2.data_file = wrapped_data_file_v2_debug

--- a/tests/test_integration_manifest.py
+++ b/tests/test_integration_manifest.py
@@ -26,11 +26,7 @@ from fastavro import reader
 
 from pyiceberg.catalog import Catalog, load_catalog
 from pyiceberg.io.pyarrow import PyArrowFileIO
-from pyiceberg.manifest import (
-    DataFile,
-    ManifestEntry,
-    write_manifest,
-)
+from pyiceberg.manifest import DataFile, ManifestEntry, _inherit_from_manifest, write_manifest
 from pyiceberg.table import Table
 from pyiceberg.utils.lazydict import LazyDict
 
@@ -105,6 +101,7 @@ def test_write_sample_manifest(table_test_all_types: Table) -> None:
     )
     wrapped_entry_v2 = ManifestEntry(*entry.record_fields())
     wrapped_entry_v2.data_file = wrapped_data_file_v2_debug
+    wrapped_entry_v2.snapshot_id = test_manifest_file.added_snapshot_id
     with TemporaryDirectory() as tmpdir:
         tmp_avro_file = tmpdir + "/test_write_manifest.avro"
         output = PyArrowFileIO().new_output(tmp_avro_file)

--- a/tests/test_integration_manifest.py
+++ b/tests/test_integration_manifest.py
@@ -26,7 +26,7 @@ from fastavro import reader
 
 from pyiceberg.catalog import Catalog, load_catalog
 from pyiceberg.io.pyarrow import PyArrowFileIO
-from pyiceberg.manifest import DataFile, ManifestEntry, _inherit_from_manifest, write_manifest
+from pyiceberg.manifest import DataFile, ManifestEntry, write_manifest
 from pyiceberg.table import Table
 from pyiceberg.utils.lazydict import LazyDict
 
@@ -101,7 +101,6 @@ def test_write_sample_manifest(table_test_all_types: Table) -> None:
     )
     wrapped_entry_v2 = ManifestEntry(*entry.record_fields())
     wrapped_entry_v2.data_file = wrapped_data_file_v2_debug
-    wrapped_entry_v2.snapshot_id = test_manifest_file.added_snapshot_id
     with TemporaryDirectory() as tmpdir:
         tmp_avro_file = tmpdir + "/test_write_manifest.avro"
         output = PyArrowFileIO().new_output(tmp_avro_file)

--- a/tests/test_integration_manifest.py
+++ b/tests/test_integration_manifest.py
@@ -101,6 +101,10 @@ def test_write_sample_manifest(table_test_all_types: Table) -> None:
     )
     wrapped_entry_v2 = ManifestEntry(*entry.record_fields())
     wrapped_entry_v2.data_file = wrapped_data_file_v2_debug
+    wrapped_entry_v2_dict = todict(wrapped_entry_v2)
+    # This one should not be written
+    del wrapped_entry_v2_dict['data_file']['spec_id']
+
     with TemporaryDirectory() as tmpdir:
         tmp_avro_file = tmpdir + "/test_write_manifest.avro"
         output = PyArrowFileIO().new_output(tmp_avro_file)
@@ -119,4 +123,4 @@ def test_write_sample_manifest(table_test_all_types: Table) -> None:
             it = iter(r)
             fa_entry = next(it)
 
-            assert fa_entry == todict(wrapped_entry_v2)
+            assert fa_entry == wrapped_entry_v2_dict


### PR DESCRIPTION
Spec id was removed in https://github.com/apache/iceberg-python/pull/40/files to wait for the decision of https://github.com/apache/iceberg/pull/8730. This PR adds it back and is needed to unblock issue https://github.com/apache/iceberg-python/issues/46