### PR TITLE
Expression: Fix for when multiple and/or expressions are specified via string

### DIFF
--- a/pyiceberg/expressions/parser.py
+++ b/pyiceberg/expressions/parser.py
@@ -233,11 +233,11 @@ def handle_not(result: ParseResults) -> Not:
 
 
 def handle_and(result: ParseResults) -> And:
-    return And(result[0][0], result[0][1])
+    return And(*result[0])
 
 
 def handle_or(result: ParseResults) -> Or:
-    return Or(result[0][0], result[0][1])
+    return Or(*result[0])
 
 
 boolean_expression = infix_notation(

--- a/tests/expressions/test_parser.py
+++ b/tests/expressions/test_parser.py
@@ -160,6 +160,14 @@ def test_and_or_with_parens() -> None:
     )
 
 
+def test_multiple_and_or() -> None:
+    assert And(EqualTo("foo", 1), EqualTo("bar", 2), EqualTo("baz", 3)) == parser.parse("foo = 1 and bar = 2 and baz = 3")
+    assert Or(EqualTo("foo", 1), EqualTo("foo", 2), EqualTo("foo", 3)) == parser.parse("foo = 1 or foo = 2 or foo = 3")
+    assert Or(
+        And(NotNull("foo"), LessThan("foo", 5)), And(GreaterThan("foo", 10), LessThan("foo", 100), IsNull("bar"))
+    ) == parser.parse("foo is not null and foo < 5 or (foo > 10 and foo < 100 and bar is null)")
+
+
 def test_starts_with() -> None:
     assert StartsWith("foo", "data") == parser.parse("foo LIKE 'data'")
 


### PR DESCRIPTION
Fixes #64 . If there are multiple and/or conditions currently, our expression parser will ignore anything after the second predicate. This change fixes the issue by forwarding the remaining predicates as the argument to `*rest: BooleanExpression` for And and Or.