### PR TITLE
Run dependabot daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,11 +22,9 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: "daily"
     open-pull-requests-limit: 5
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: "daily"


### PR DESCRIPTION
I would love to run dependabot daily instead of weekly. Now we're in our own repository, we'll introduce less noise. This would have helped us to identify the issue with Pydantic earlier.