### PR TITLE
Remove `example` since it is deprecated

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -418,7 +418,6 @@ class Namespace(IcebergRootModel[List[str]]):
     root: List[str] = Field(
         ...,
         description='Reference to one or more levels of a namespace',
-        example=['accounting', 'tax'],
     )
 
 


### PR DESCRIPTION
The `examples` is deprecated
```
  E   pydantic.warnings.PydanticDeprecatedSince20: Using extra keyword arguments on `Field` is deprecated and will be removed. Use `json_schema_extra` instead. (Extra keys: 'example'). Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.4/migration/
```