### PR TITLE
Don't fail on warning when releasing

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -69,7 +69,7 @@ jobs:
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8,<3.12"
           CIBW_TEST_REQUIRES: "pytest==7.4.2 moto==4.2.2"
           CIBW_TEST_EXTRAS: "s3fs,glue"
-          CIBW_TEST_COMMAND: "pytest -Werror {project}/tests/avro/test_decoder.py"
+          CIBW_TEST_COMMAND: "pytest {project}/tests/avro/test_decoder.py"
           # There is an upstream issue with installing on MacOSX
           # https://github.com/pypa/cibuildwheel/issues/1603
           # Ignore tests for pypy since not all dependencies are compiled for it


### PR DESCRIPTION
When we test the binaries, we also fail on errors, which is more strict than in our regular CI