### PR TITLE
Doc: Fix "Verifying Checksums" script in verify-release.md

### DIFF
--- a/mkdocs/docs/verify-release.md
+++ b/mkdocs/docs/verify-release.md
@@ -59,7 +59,7 @@ done
 
 ```sh
 cd  /tmp/pyiceberg/
-for name in $(ls /tmp/pyiceberg/pyiceberg-*.whl.asc.sha512 /tmp/pyiceberg/pyiceberg-*.tar.gz.asc.sha512)
+for name in $(ls /tmp/pyiceberg/pyiceberg-*.whl.sha512 /tmp/pyiceberg/pyiceberg-*.tar.gz.sha512)
 do
     shasum -a 512 --check ${name}
 done


### PR DESCRIPTION
This PR removes the additional `.asc` in the script for verifying checksums