### PR TITLE
Make to_arrow function capable of handling parquet files with sanitized name due to Avro restirction

### DIFF
--- a/dev/provision.py
+++ b/dev/provision.py
@@ -301,3 +301,23 @@ TBLPROPERTIES (
 );
 """
 )
+
+spark.sql(
+    """
+CREATE TABLE default.test_table_sanitized_character (
+    `letter/abc` string
+)
+USING iceberg
+TBLPROPERTIES (
+    'format-version'='1'
+);
+"""
+)
+
+spark.sql(
+    f"""
+INSERT INTO default.test_table_sanitized_character
+VALUES
+    ('123')
+"""
+)

--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -113,7 +113,7 @@ from pyiceberg.schema import (
     pre_order_visit,
     promote,
     prune_columns,
-    sanitize_columns,
+    sanitize_column_names,
     visit,
     visit_with_partner,
 )
@@ -831,7 +831,7 @@ def _task_to_table(
             bound_file_filter = bind(file_schema, translated_row_filter, case_sensitive=case_sensitive)
             pyarrow_filter = expression_to_pyarrow(bound_file_filter)
 
-        file_project_schema = sanitize_columns(prune_columns(file_schema, projected_field_ids, select_full_types=False))
+        file_project_schema = sanitize_column_names(prune_columns(file_schema, projected_field_ids, select_full_types=False))
 
         if file_schema is None:
             raise ValueError(f"Missing Iceberg schema in Metadata for file: {path}")

--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -113,6 +113,7 @@ from pyiceberg.schema import (
     pre_order_visit,
     promote,
     prune_columns,
+    sanitize_columns,
     visit,
     visit_with_partner,
 )
@@ -830,7 +831,7 @@ def _task_to_table(
             bound_file_filter = bind(file_schema, translated_row_filter, case_sensitive=case_sensitive)
             pyarrow_filter = expression_to_pyarrow(bound_file_filter)
 
-        file_project_schema = prune_columns(file_schema, projected_field_ids, select_full_types=False)
+        file_project_schema = sanitize_columns(prune_columns(file_schema, projected_field_ids, select_full_types=False))
 
         if file_schema is None:
             raise ValueError(f"Missing Iceberg schema in Metadata for file: {path}")

--- a/pyiceberg/schema.py
+++ b/pyiceberg/schema.py
@@ -1349,7 +1349,7 @@ class _SanitizeColumnsVisitor(SchemaVisitor[Optional[IcebergType]]):
         )
 
     def struct(self, struct: StructType, field_results: List[Optional[IcebergType]]) -> Optional[IcebergType]:
-        return StructType(*[field.get() for field in field_results if field is not None])
+        return StructType(*[field for field in field_results if field is not None])
 
     def list(self, list_type: ListType, element_result: Optional[IcebergType]) -> Optional[IcebergType]:
         return ListType(element_id=list_type.element_id, element_type=element_result, element_required=list_type.element_required)

--- a/pyiceberg/schema.py
+++ b/pyiceberg/schema.py
@@ -1282,20 +1282,18 @@ def make_compatible_name(name: str) -> str:
 
 def _valid_avro_name(name: str) -> bool:
     length = len(name)
-    assert length > 0, "Empty name"
+    assert length > 0, ValueError("Can not validate empty avro name")
     first = name[0]
     if not (first.isalpha() or first == '_'):
         return False
 
-    for i in range(1, length):
-        character = name[i]
+    for character in name[1:]:
         if not (character.isalnum() or character == '_'):
             return False
     return True
 
 
 def _sanitize_name(name: str) -> str:
-    length = len(name)
     sb = []
     first = name[0]
     if not (first.isalpha() or first == '_'):
@@ -1303,8 +1301,7 @@ def _sanitize_name(name: str) -> str:
     else:
         sb.append(first)
 
-    for i in range(1, length):
-        character = name[i]
+    for character in name[1:]:
         if not (character.isalnum() or character == '_'):
             sb.append(_sanitize_char(character))
         else:
@@ -1313,13 +1310,14 @@ def _sanitize_name(name: str) -> str:
 
 
 def _sanitize_char(character: str) -> str:
-    if character.isdigit():
-        return "_" + character
-    return "_x" + hex(ord(character))[2:].upper()
+    return "_" + character if character.isdigit() else "_x" + hex(ord(character))[2:].upper()
 
 
 def sanitize_column_names(schema: Schema) -> Schema:
     """Sanitize column names to make them compatible with Avro.
+
+    The column name should be starting with '_' or digit followed by a string only contains '_', digit or alphabet,
+    otherwise it will be sanitized to conform the avro naming convention.
 
     Args:
         schema: The schema to be sanitized.

--- a/tests/io/test_pyarrow.py
+++ b/tests/io/test_pyarrow.py
@@ -66,7 +66,7 @@ from pyiceberg.io.pyarrow import (
 )
 from pyiceberg.manifest import DataFile, DataFileContent, FileFormat
 from pyiceberg.partitioning import PartitionSpec
-from pyiceberg.schema import Schema, visit
+from pyiceberg.schema import Schema, make_compatible_name, visit
 from pyiceberg.table import FileScanTask, Table
 from pyiceberg.table.metadata import TableMetadataV2
 from pyiceberg.types import (
@@ -1542,3 +1542,8 @@ def test_parse_location() -> None:
 
     check_results("/root/foo.txt", "file", "", "/root/foo.txt")
     check_results("/root/tmp/foo.txt", "file", "", "/root/tmp/foo.txt")
+
+
+def test_make_compatible_name() -> None:
+    assert make_compatible_name("label/abc") == "label_x2Fabc"
+    assert make_compatible_name("label?abc") == "label_x3Fabc"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -87,10 +87,10 @@ def table_test_all_types(catalog: Catalog) -> Table:
 def table_test_table_version(catalog: Catalog) -> Table:
     return catalog.load_table("default.test_table_version")
 
+
 @pytest.fixture()
 def table_test_table_sanitized_character(catalog: Catalog) -> Table:
     return catalog.load_table("default.test_table_sanitized_character")
-
 
 
 TABLE_NAME = ("default", "t1")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -396,3 +396,13 @@ def test_upgrade_table_version(table_test_table_version: Table) -> None:
         with table_test_table_version.transaction() as transaction:
             transaction.upgrade_table_version(format_version=3)
     assert "Unsupported table format version: 3" in str(e.value)
+
+
+@pytest.fixture()
+def table_test_table_sanitized_character(catalog: Catalog) -> Table:
+    return catalog.load_table("default.test_table_sanitized_character")
+
+
+@pytest.mark.integration
+def test_reproduce_issue(table_test_table_sanitized_character: Table) -> None:
+    table = table_test_table_sanitized_character.scan().to_arrow()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -87,6 +87,11 @@ def table_test_all_types(catalog: Catalog) -> Table:
 def table_test_table_version(catalog: Catalog) -> Table:
     return catalog.load_table("default.test_table_version")
 
+@pytest.fixture()
+def table_test_table_sanitized_character(catalog: Catalog) -> Table:
+    return catalog.load_table("default.test_table_sanitized_character")
+
+
 
 TABLE_NAME = ("default", "t1")
 
@@ -398,11 +403,9 @@ def test_upgrade_table_version(table_test_table_version: Table) -> None:
     assert "Unsupported table format version: 3" in str(e.value)
 
 
-@pytest.fixture()
-def table_test_table_sanitized_character(catalog: Catalog) -> Table:
-    return catalog.load_table("default.test_table_sanitized_character")
-
-
 @pytest.mark.integration
 def test_reproduce_issue(table_test_table_sanitized_character: Table) -> None:
-    table = table_test_table_sanitized_character.scan().to_arrow()
+    arrow_table = table_test_table_sanitized_character.scan().to_arrow()
+    assert len(arrow_table.schema.names), 1
+    assert len(table_test_table_sanitized_character.schema().fields), 1
+    assert arrow_table.schema.names[0] == table_test_table_sanitized_character.schema().fields[0].name

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -28,7 +28,7 @@ from pyiceberg.schema import (
     build_position_accessors,
     promote,
     prune_columns,
-    sanitize_columns,
+    sanitize_column_names,
 )
 from pyiceberg.typedef import EMPTY_DICT, StructProtocol
 from pyiceberg.types import (
@@ -448,8 +448,7 @@ def test_sanitize() -> None:
                 key_id=5,
                 key_type=StringType(),
                 value_id=6,
-                value_type=MapType(key_id=7, key_type=StringType(), value_id=10, value_type=IntegerType(),
-                                   value_required=True),
+                value_type=MapType(key_id=7, key_type=StringType(), value_id=10, value_type=IntegerType(), value_required=True),
                 value_required=True,
             ),
             required=True,
@@ -510,8 +509,7 @@ def test_sanitize() -> None:
                 key_id=5,
                 key_type=StringType(),
                 value_id=6,
-                value_type=MapType(key_id=7, key_type=StringType(), value_id=10, value_type=IntegerType(),
-                                   value_required=True),
+                value_type=MapType(key_id=7, key_type=StringType(), value_id=10, value_type=IntegerType(), value_required=True),
                 value_required=True,
             ),
             required=True,
@@ -557,7 +555,7 @@ def test_sanitize() -> None:
         schema_id=1,
         identifier_field_ids=[1],
     )
-    assert sanitize_columns(before_sanitized) == expected_schema
+    assert sanitize_column_names(before_sanitized) == expected_schema
 
 
 def test_prune_columns_string(table_schema_nested_with_struct_key_map: Schema) -> None:


### PR DESCRIPTION
We sanitized column name to meet the Avro restriction when writing parquet data (https://github.com/apache/iceberg/blob/ad602a379584512d1d96eda557c20cf2af21d1b2/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java#L429).

This PR fix issues https://github.com/apache/iceberg-python/issues/81.