### PR TITLE
Fix the nullability of `snapshot-id` on `AssertRefSnapshotId`

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -374,7 +374,7 @@ class AssertRefSnapshotId(TableRequirement):
 
     type: Literal["assert-ref-snapshot-id"] = Field(default="assert-ref-snapshot-id")
     ref: str
-    snapshot_id: int = Field(..., alias="snapshot-id")
+    snapshot_id: Optional[int] = Field(default=None, alias="snapshot-id")
 
 
 class AssertLastAssignedFieldId(TableRequirement):


### PR DESCRIPTION
It is not super clear from the current structure:

https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.py#L304-L329

This is because I had to deconstruct the object. It would be great to get  https://github.com/apache/iceberg/pull/7710 in.