### PR TITLE
Api docs refactor

### DIFF
--- a/mkdocs/docs/api.md
+++ b/mkdocs/docs/api.md
@@ -129,6 +129,7 @@ sort_order = SortOrder(SortField(source_id=2, transform=IdentityTransform()))
 catalog.create_table(
     identifier="docs_example.bids",
     schema=schema,
+    location="s3://pyiceberg",
     partition_spec=partition_spec,
     sort_order=sort_order,
 )

--- a/mkdocs/docs/api.md
+++ b/mkdocs/docs/api.md
@@ -53,6 +53,11 @@ catalog = load_catalog(
     }
 )
 ```
+If the catalog has not been initialized before, you need to run:
+
+```python
+catalog.create_tables()
+```
 
 Let's create a namespace:
 

--- a/mkdocs/docs/api.md
+++ b/mkdocs/docs/api.md
@@ -53,6 +53,7 @@ catalog = load_catalog(
     }
 )
 ```
+
 If the catalog has not been initialized before, you need to run:
 
 ```python


### PR DESCRIPTION
Fixes #78 

- Adds the `location` parameter to the `catalog.create_table(...)` example for more context.
- Adds the code to initialize the catalog in a database if this was not done previously