### PR TITLE
Fix Github Pages path

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -45,7 +45,7 @@ github:
   collaborators:  # Note: the number of collaborators is limited to 10
     - ajantha-bhat
   ghp_branch: gh-pages
-  ghp_path: ~
+  ghp_path: /
 
 notifications:
     commits:      commits@iceberg.apache.org


### PR DESCRIPTION
`~` is not a valid path, updating this to `/`.

From https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features:

![image](https://github.com/apache/iceberg-python/assets/1134248/c2fa6c41-2484-444c-8194-cea96f403d60)
