### PR TITLE
Support catalog name in table identifier during load, rename, drop, and purge

### DIFF
--- a/pyiceberg/catalog/__init__.py
+++ b/pyiceberg/catalog/__init__.py
@@ -536,6 +536,20 @@ class Catalog(ABC):
 
         return tuple_identifier[0], tuple_identifier[1]
 
+    def identifier_to_tuple_without_catalog(self, identifier: Union[str, Identifier]) -> Identifier:
+        """Convert an identifier to a tuple and drop this catalog's name from the first element.
+
+        Args:
+            identifier (str | Identifier): Table identifier.
+
+        Returns:
+            Identifier: a tuple of strings with this catalog's name removed
+        """
+        identifier_tuple = Catalog.identifier_to_tuple(identifier)
+        if len(identifier_tuple) >= 3 and identifier_tuple[0] == self.name:
+            identifier_tuple = identifier_tuple[1:]
+        return identifier_tuple
+
     def purge_table(self, identifier: Union[str, Identifier]) -> None:
         """Drop a table and purge all data and metadata files.
 
@@ -547,8 +561,9 @@ class Catalog(ABC):
         Raises:
             NoSuchTableError: If a table with the name does not exist, or the identifier is invalid.
         """
-        table = self.load_table(identifier)
-        self.drop_table(identifier)
+        identifier_tuple = self.identifier_to_tuple_without_catalog(identifier)
+        table = self.load_table(identifier_tuple)
+        self.drop_table(identifier_tuple)
         io = load_file_io(self.properties, table.metadata_location)
         metadata = table.metadata
         manifest_lists_to_delete = set()

--- a/pyiceberg/catalog/dynamodb.py
+++ b/pyiceberg/catalog/dynamodb.py
@@ -213,7 +213,8 @@ class DynamoDbCatalog(Catalog):
         Raises:
             NoSuchTableError: If a table with the name does not exist, or the identifier is invalid.
         """
-        database_name, table_name = self.identifier_to_database_and_table(identifier, NoSuchTableError)
+        identifier_tuple = self.identifier_to_tuple_without_catalog(identifier)
+        database_name, table_name = self.identifier_to_database_and_table(identifier_tuple, NoSuchTableError)
         dynamo_table_item = self._get_iceberg_table_item(database_name=database_name, table_name=table_name)
         return self._convert_dynamo_table_item_to_iceberg_table(dynamo_table_item=dynamo_table_item)
 
@@ -226,7 +227,8 @@ class DynamoDbCatalog(Catalog):
         Raises:
             NoSuchTableError: If a table with the name does not exist, or the identifier is invalid.
         """
-        database_name, table_name = self.identifier_to_database_and_table(identifier, NoSuchTableError)
+        identifier_tuple = self.identifier_to_tuple_without_catalog(identifier)
+        database_name, table_name = self.identifier_to_database_and_table(identifier_tuple, NoSuchTableError)
 
         try:
             self._delete_dynamo_item(
@@ -256,7 +258,8 @@ class DynamoDbCatalog(Catalog):
             NoSuchPropertyException: When from table miss some required properties.
             NoSuchNamespaceError: When the destination namespace doesn't exist.
         """
-        from_database_name, from_table_name = self.identifier_to_database_and_table(from_identifier, NoSuchTableError)
+        from_identifier_tuple = self.identifier_to_tuple_without_catalog(from_identifier)
+        from_database_name, from_table_name = self.identifier_to_database_and_table(from_identifier_tuple, NoSuchTableError)
         to_database_name, to_table_name = self.identifier_to_database_and_table(to_identifier)
 
         from_table_item = self._get_iceberg_table_item(database_name=from_database_name, table_name=from_table_name)
@@ -287,7 +290,7 @@ class DynamoDbCatalog(Catalog):
             raise TableAlreadyExistsError(f"Table {to_database_name}.{to_table_name} already exists") from e
 
         try:
-            self.drop_table(from_identifier)
+            self.drop_table(from_identifier_tuple)
         except (NoSuchTableError, GenericDynamoDbError) as e:
             log_message = f"Failed to drop old table {from_database_name}.{from_table_name}. "
 

--- a/pyiceberg/catalog/glue.py
+++ b/pyiceberg/catalog/glue.py
@@ -265,7 +265,8 @@ class GlueCatalog(Catalog):
         Raises:
             NoSuchTableError: If a table with the name does not exist, or the identifier is invalid.
         """
-        database_name, table_name = self.identifier_to_database_and_table(identifier, NoSuchTableError)
+        identifier_tuple = self.identifier_to_tuple_without_catalog(identifier)
+        database_name, table_name = self.identifier_to_database_and_table(identifier_tuple, NoSuchTableError)
         try:
             load_table_response = self.glue.get_table(DatabaseName=database_name, Name=table_name)
         except self.glue.exceptions.EntityNotFoundException as e:
@@ -282,7 +283,8 @@ class GlueCatalog(Catalog):
         Raises:
             NoSuchTableError: If a table with the name does not exist, or the identifier is invalid.
         """
-        database_name, table_name = self.identifier_to_database_and_table(identifier, NoSuchTableError)
+        identifier_tuple = self.identifier_to_tuple_without_catalog(identifier)
+        database_name, table_name = self.identifier_to_database_and_table(identifier_tuple, NoSuchTableError)
         try:
             self.glue.delete_table(DatabaseName=database_name, Name=table_name)
         except self.glue.exceptions.EntityNotFoundException as e:
@@ -307,7 +309,8 @@ class GlueCatalog(Catalog):
             NoSuchPropertyException: When from table miss some required properties.
             NoSuchNamespaceError: When the destination namespace doesn't exist.
         """
-        from_database_name, from_table_name = self.identifier_to_database_and_table(from_identifier, NoSuchTableError)
+        from_identifier_tuple = self.identifier_to_tuple_without_catalog(from_identifier)
+        from_database_name, from_table_name = self.identifier_to_database_and_table(from_identifier_tuple, NoSuchTableError)
         to_database_name, to_table_name = self.identifier_to_database_and_table(to_identifier)
         try:
             get_table_response = self.glue.get_table(DatabaseName=from_database_name, Name=from_table_name)

--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -347,7 +347,8 @@ class HiveCatalog(Catalog):
         Raises:
             NoSuchTableError: If a table with the name does not exist, or the identifier is invalid.
         """
-        database_name, table_name = self.identifier_to_database_and_table(identifier, NoSuchTableError)
+        identifier_tuple = self.identifier_to_tuple_without_catalog(identifier)
+        database_name, table_name = self.identifier_to_database_and_table(identifier_tuple, NoSuchTableError)
         try:
             with self._client as open_client:
                 hive_table = open_client.get_table(dbname=database_name, tbl_name=table_name)
@@ -366,7 +367,8 @@ class HiveCatalog(Catalog):
         Raises:
             NoSuchTableError: If a table with the name does not exist, or the identifier is invalid.
         """
-        database_name, table_name = self.identifier_to_database_and_table(identifier, NoSuchTableError)
+        identifier_tuple = self.identifier_to_tuple_without_catalog(identifier)
+        database_name, table_name = self.identifier_to_database_and_table(identifier_tuple, NoSuchTableError)
         try:
             with self._client as open_client:
                 open_client.drop_table(dbname=database_name, name=table_name, deleteData=False)
@@ -393,7 +395,8 @@ class HiveCatalog(Catalog):
             NoSuchTableError: When a table with the name does not exist.
             NoSuchNamespaceError: When the destination namespace doesn't exist.
         """
-        from_database_name, from_table_name = self.identifier_to_database_and_table(from_identifier, NoSuchTableError)
+        from_identifier_tuple = self.identifier_to_tuple_without_catalog(from_identifier)
+        from_database_name, from_table_name = self.identifier_to_database_and_table(from_identifier_tuple, NoSuchTableError)
         to_database_name, to_table_name = self.identifier_to_database_and_table(to_identifier)
         try:
             with self._client as open_client:

--- a/pyiceberg/catalog/rest.py
+++ b/pyiceberg/catalog/rest.py
@@ -302,19 +302,20 @@ class RestCatalog(Catalog):
         # Update URI based on overrides
         self.uri = config[URI]
 
-    def _split_identifier_for_path(self, identifier: Union[str, Identifier, TableIdentifier]) -> Properties:
-        if isinstance(identifier, TableIdentifier):
-            return {"namespace": NAMESPACE_SEPARATOR.join(identifier.namespace.root[1:]), "table": identifier.name}
-
+    def _identifier_to_validated_tuple(self, identifier: Union[str, Identifier]) -> Identifier:
         identifier_tuple = self.identifier_to_tuple(identifier)
         if len(identifier_tuple) <= 1:
             raise NoSuchTableError(f"Missing namespace or invalid identifier: {'.'.join(identifier_tuple)}")
+        return identifier_tuple
+
+    def _split_identifier_for_path(self, identifier: Union[str, Identifier, TableIdentifier]) -> Properties:
+        if isinstance(identifier, TableIdentifier):
+            return {"namespace": NAMESPACE_SEPARATOR.join(identifier.namespace.root[1:]), "table": identifier.name}
+        identifier_tuple = self._identifier_to_validated_tuple(identifier)
         return {"namespace": NAMESPACE_SEPARATOR.join(identifier_tuple[:-1]), "table": identifier_tuple[-1]}
 
     def _split_identifier_for_json(self, identifier: Union[str, Identifier]) -> Dict[str, Union[Identifier, str]]:
-        identifier_tuple = self.identifier_to_tuple(identifier)
-        if len(identifier_tuple) <= 1:
-            raise NoSuchTableError(f"Missing namespace or invalid identifier: {identifier_tuple}")
+        identifier_tuple = self._identifier_to_validated_tuple(identifier)
         return {"namespace": identifier_tuple[:-1], "name": identifier_tuple[-1]}
 
     def _handle_non_200_response(self, exc: HTTPError, error_handler: Dict[int, Type[Exception]]) -> None:
@@ -499,12 +500,10 @@ class RestCatalog(Catalog):
         return [(*table.namespace, table.name) for table in ListTablesResponse(**response.json()).identifiers]
 
     def load_table(self, identifier: Union[str, Identifier]) -> Table:
-        identifier_tuple = self.identifier_to_tuple(identifier)
-
-        if len(identifier_tuple) <= 1:
-            raise NoSuchTableError(f"Missing namespace or invalid identifier: {identifier}")
-
-        response = self._session.get(self.url(Endpoints.load_table, prefixed=True, **self._split_identifier_for_path(identifier)))
+        identifier_tuple = self.identifier_to_tuple_without_catalog(identifier)
+        response = self._session.get(
+            self.url(Endpoints.load_table, prefixed=True, **self._split_identifier_for_path(identifier_tuple))
+        )
         try:
             response.raise_for_status()
         except HTTPError as exc:
@@ -514,8 +513,11 @@ class RestCatalog(Catalog):
         return self._response_to_table(identifier_tuple, table_response)
 
     def drop_table(self, identifier: Union[str, Identifier], purge_requested: bool = False) -> None:
+        identifier_tuple = self.identifier_to_tuple_without_catalog(identifier)
         response = self._session.delete(
-            self.url(Endpoints.drop_table, prefixed=True, purge=purge_requested, **self._split_identifier_for_path(identifier)),
+            self.url(
+                Endpoints.drop_table, prefixed=True, purge=purge_requested, **self._split_identifier_for_path(identifier_tuple)
+            ),
         )
         try:
             response.raise_for_status()
@@ -526,8 +528,9 @@ class RestCatalog(Catalog):
         self.drop_table(identifier=identifier, purge_requested=True)
 
     def rename_table(self, from_identifier: Union[str, Identifier], to_identifier: Union[str, Identifier]) -> Table:
+        from_identifier_tuple = self.identifier_to_tuple_without_catalog(from_identifier)
         payload = {
-            "source": self._split_identifier_for_json(from_identifier),
+            "source": self._split_identifier_for_json(from_identifier_tuple),
             "destination": self._split_identifier_for_json(to_identifier),
         }
         response = self._session.post(self.url(Endpoints.rename_table), json=payload)

--- a/pyiceberg/catalog/sql.py
+++ b/pyiceberg/catalog/sql.py
@@ -231,7 +231,8 @@ class SqlCatalog(Catalog):
         Raises:
             NoSuchTableError: If a table with the name does not exist.
         """
-        database_name, table_name = self.identifier_to_database_and_table(identifier, NoSuchTableError)
+        identifier_tuple = self.identifier_to_tuple_without_catalog(identifier)
+        database_name, table_name = self.identifier_to_database_and_table(identifier_tuple, NoSuchTableError)
         with Session(self.engine) as session:
             stmt = select(IcebergTables).where(
                 IcebergTables.catalog_name == self.name,
@@ -252,7 +253,8 @@ class SqlCatalog(Catalog):
         Raises:
             NoSuchTableError: If a table with the name does not exist.
         """
-        database_name, table_name = self.identifier_to_database_and_table(identifier, NoSuchTableError)
+        identifier_tuple = self.identifier_to_tuple_without_catalog(identifier)
+        database_name, table_name = self.identifier_to_database_and_table(identifier_tuple, NoSuchTableError)
         with Session(self.engine) as session:
             res = session.execute(
                 delete(IcebergTables).where(
@@ -280,7 +282,8 @@ class SqlCatalog(Catalog):
             TableAlreadyExistsError: If a table with the new name already exist.
             NoSuchNamespaceError: If the target namespace does not exist.
         """
-        from_database_name, from_table_name = self.identifier_to_database_and_table(from_identifier, NoSuchTableError)
+        from_identifier_tuple = self.identifier_to_tuple_without_catalog(from_identifier)
+        from_database_name, from_table_name = self.identifier_to_database_and_table(from_identifier_tuple, NoSuchTableError)
         to_database_name, to_table_name = self.identifier_to_database_and_table(to_identifier)
         if not self._namespace_exists(to_database_name):
             raise NoSuchNamespaceError(f"Namespace does not exist: {to_database_name}")

--- a/tests/catalog/test_base.py
+++ b/tests/catalog/test_base.py
@@ -149,14 +149,14 @@ class InMemoryCatalog(Catalog):
         )
 
     def load_table(self, identifier: Union[str, Identifier]) -> Table:
-        identifier = Catalog.identifier_to_tuple(identifier)
+        identifier = self.identifier_to_tuple_without_catalog(identifier)
         try:
             return self.__tables[identifier]
         except KeyError as error:
             raise NoSuchTableError(f"Table does not exist: {identifier}") from error
 
     def drop_table(self, identifier: Union[str, Identifier]) -> None:
-        identifier = Catalog.identifier_to_tuple(identifier)
+        identifier = self.identifier_to_tuple_without_catalog(identifier)
         try:
             self.__tables.pop(identifier)
         except KeyError as error:
@@ -166,7 +166,7 @@ class InMemoryCatalog(Catalog):
         self.drop_table(identifier)
 
     def rename_table(self, from_identifier: Union[str, Identifier], to_identifier: Union[str, Identifier]) -> Table:
-        from_identifier = Catalog.identifier_to_tuple(from_identifier)
+        from_identifier = self.identifier_to_tuple_without_catalog(from_identifier)
         try:
             table = self.__tables.pop(from_identifier)
         except KeyError as error:
@@ -352,6 +352,16 @@ def test_load_table(catalog: InMemoryCatalog) -> None:
     assert table == given_table
 
 
+def test_load_table_from_self_identifier(catalog: InMemoryCatalog) -> None:
+    # Given
+    given_table = given_catalog_has_a_table(catalog)
+    # When
+    intermediate = catalog.load_table(TEST_TABLE_IDENTIFIER)
+    table = catalog.load_table(intermediate.identifier)
+    # Then
+    assert table == given_table
+
+
 def test_table_raises_error_on_table_not_found(catalog: InMemoryCatalog) -> None:
     with pytest.raises(NoSuchTableError, match=NO_SUCH_TABLE_ERROR):
         catalog.load_table(TEST_TABLE_IDENTIFIER)
@@ -363,6 +373,18 @@ def test_drop_table(catalog: InMemoryCatalog) -> None:
     # When
     catalog.drop_table(TEST_TABLE_IDENTIFIER)
     # Then
+    with pytest.raises(NoSuchTableError, match=NO_SUCH_TABLE_ERROR):
+        catalog.load_table(TEST_TABLE_IDENTIFIER)
+
+
+def test_drop_table_from_self_identifier(catalog: InMemoryCatalog) -> None:
+    # Given
+    table = given_catalog_has_a_table(catalog)
+    # When
+    catalog.drop_table(table.identifier)
+    # Then
+    with pytest.raises(NoSuchTableError, match=NO_SUCH_TABLE_ERROR):
+        catalog.load_table(table.identifier)
     with pytest.raises(NoSuchTableError, match=NO_SUCH_TABLE_ERROR):
         catalog.load_table(TEST_TABLE_IDENTIFIER)
 
@@ -401,6 +423,31 @@ def test_rename_table(catalog: InMemoryCatalog) -> None:
     assert ("new", "namespace") in catalog.list_namespaces()
 
     # And
+    with pytest.raises(NoSuchTableError, match=NO_SUCH_TABLE_ERROR):
+        catalog.load_table(TEST_TABLE_IDENTIFIER)
+
+
+def test_rename_table_from_self_identifier(catalog: InMemoryCatalog) -> None:
+    # Given
+    table = given_catalog_has_a_table(catalog)
+
+    # When
+    new_table_name = "new.namespace.new_table"
+    new_table = catalog.rename_table(table.identifier, new_table_name)
+
+    # Then
+    assert new_table.identifier == Catalog.identifier_to_tuple(new_table_name)
+
+    # And
+    new_table = catalog.load_table(new_table.identifier)
+    assert new_table.identifier == Catalog.identifier_to_tuple(new_table_name)
+
+    # And
+    assert ("new", "namespace") in catalog.list_namespaces()
+
+    # And
+    with pytest.raises(NoSuchTableError, match=NO_SUCH_TABLE_ERROR):
+        catalog.load_table(table.identifier)
     with pytest.raises(NoSuchTableError, match=NO_SUCH_TABLE_ERROR):
         catalog.load_table(TEST_TABLE_IDENTIFIER)
 

--- a/tests/catalog/test_dynamodb.py
+++ b/tests/catalog/test_dynamodb.py
@@ -176,6 +176,23 @@ def test_load_table(
 
 
 @mock_dynamodb
+def test_load_table_from_self_identifier(
+    _bucket_initialize: None, _patch_aiobotocore: None, table_schema_nested: Schema, database_name: str, table_name: str
+) -> None:
+    catalog_name = "test_ddb_catalog"
+    identifier = (database_name, table_name)
+    test_catalog = DynamoDbCatalog(
+        catalog_name, **{"warehouse": f"s3://{BUCKET_NAME}", "py-io-impl": "pyiceberg.io.fsspec.FsspecFileIO"}
+    )
+    test_catalog.create_namespace(namespace=database_name)
+    test_catalog.create_table(identifier, table_schema_nested)
+    intermediate = test_catalog.load_table(identifier)
+    table = test_catalog.load_table(intermediate.identifier)
+    assert table.identifier == (catalog_name,) + identifier
+    assert TABLE_METADATA_LOCATION_REGEX.match(table.metadata_location)
+
+
+@mock_dynamodb
 def test_load_non_exist_table(_bucket_initialize: None, _patch_aiobotocore: None, database_name: str, table_name: str) -> None:
     identifier = (database_name, table_name)
     test_catalog = DynamoDbCatalog("test_ddb_catalog", warehouse=f"s3://{BUCKET_NAME}")
@@ -201,6 +218,27 @@ def test_drop_table(
     test_catalog.drop_table(identifier)
     with pytest.raises(NoSuchTableError):
         test_catalog.load_table(identifier)
+
+
+@mock_dynamodb
+def test_drop_table_from_self_identifier(
+    _bucket_initialize: None, _patch_aiobotocore: None, table_schema_nested: Schema, database_name: str, table_name: str
+) -> None:
+    catalog_name = "test_ddb_catalog"
+    identifier = (database_name, table_name)
+    test_catalog = DynamoDbCatalog(
+        catalog_name, **{"warehouse": f"s3://{BUCKET_NAME}", "py-io-impl": "pyiceberg.io.fsspec.FsspecFileIO"}
+    )
+    test_catalog.create_namespace(namespace=database_name)
+    test_catalog.create_table(identifier, table_schema_nested)
+    table = test_catalog.load_table(identifier)
+    assert table.identifier == (catalog_name,) + identifier
+    assert TABLE_METADATA_LOCATION_REGEX.match(table.metadata_location)
+    test_catalog.drop_table(table.identifier)
+    with pytest.raises(NoSuchTableError):
+        test_catalog.load_table(identifier)
+    with pytest.raises(NoSuchTableError):
+        test_catalog.load_table(table.identifier)
 
 
 @mock_dynamodb
@@ -234,6 +272,33 @@ def test_rename_table(
     # old table should be dropped
     with pytest.raises(NoSuchTableError):
         test_catalog.load_table(identifier)
+
+
+@mock_dynamodb
+def test_rename_table_from_self_identifier(
+    _bucket_initialize: None, _patch_aiobotocore: None, table_schema_nested: Schema, database_name: str, table_name: str
+) -> None:
+    catalog_name = "test_ddb_catalog"
+    new_table_name = f"{table_name}_new"
+    identifier = (database_name, table_name)
+    new_identifier = (database_name, new_table_name)
+    test_catalog = DynamoDbCatalog(
+        catalog_name, **{"warehouse": f"s3://{BUCKET_NAME}", "py-io-impl": "pyiceberg.io.fsspec.FsspecFileIO"}
+    )
+    test_catalog.create_namespace(namespace=database_name)
+    table = test_catalog.create_table(identifier, table_schema_nested)
+    assert table.identifier == (catalog_name,) + identifier
+    assert TABLE_METADATA_LOCATION_REGEX.match(table.metadata_location)
+    test_catalog.rename_table(table.identifier, new_identifier)
+    new_table = test_catalog.load_table(new_identifier)
+    assert new_table.identifier == (catalog_name,) + new_identifier
+    # the metadata_location should not change
+    assert new_table.metadata_location == table.metadata_location
+    # old table should be dropped
+    with pytest.raises(NoSuchTableError):
+        test_catalog.load_table(identifier)
+    with pytest.raises(NoSuchTableError):
+        test_catalog.load_table(table.identifier)
 
 
 @mock_dynamodb

--- a/tests/catalog/test_glue.py
+++ b/tests/catalog/test_glue.py
@@ -154,6 +154,22 @@ def test_load_table(
 
 
 @mock_glue
+def test_load_table_from_self_identifier(
+    _bucket_initialize: None, _patch_aiobotocore: None, table_schema_nested: Schema, database_name: str, table_name: str
+) -> None:
+    catalog_name = "glue"
+    identifier = (database_name, table_name)
+    test_catalog = GlueCatalog(
+        catalog_name, **{"py-io-impl": "pyiceberg.io.fsspec.FsspecFileIO", "warehouse": f"s3://{BUCKET_NAME}/"}
+    )
+    test_catalog.create_namespace(namespace=database_name)
+    intermediate = test_catalog.create_table(identifier, table_schema_nested)
+    table = test_catalog.load_table(intermediate.identifier)
+    assert table.identifier == (catalog_name,) + identifier
+    assert TABLE_METADATA_LOCATION_REGEX.match(table.metadata_location)
+
+
+@mock_glue
 def test_load_non_exist_table(_bucket_initialize: None, _patch_aiobotocore: None, database_name: str, table_name: str) -> None:
     identifier = (database_name, table_name)
     test_catalog = GlueCatalog("glue", **{"py-io-impl": "pyiceberg.io.fsspec.FsspecFileIO", "warehouse": f"s3://{BUCKET_NAME}/"})
@@ -179,6 +195,27 @@ def test_drop_table(
     test_catalog.drop_table(identifier)
     with pytest.raises(NoSuchTableError):
         test_catalog.load_table(identifier)
+
+
+@mock_glue
+def test_drop_table_from_self_identifier(
+    _bucket_initialize: None, _patch_aiobotocore: None, table_schema_nested: Schema, database_name: str, table_name: str
+) -> None:
+    catalog_name = "glue"
+    identifier = (database_name, table_name)
+    test_catalog = GlueCatalog(
+        catalog_name, **{"py-io-impl": "pyiceberg.io.fsspec.FsspecFileIO", "warehouse": f"s3://{BUCKET_NAME}/"}
+    )
+    test_catalog.create_namespace(namespace=database_name)
+    test_catalog.create_table(identifier, table_schema_nested)
+    table = test_catalog.load_table(identifier)
+    assert table.identifier == (catalog_name,) + identifier
+    assert TABLE_METADATA_LOCATION_REGEX.match(table.metadata_location)
+    test_catalog.drop_table(table.identifier)
+    with pytest.raises(NoSuchTableError):
+        test_catalog.load_table(identifier)
+    with pytest.raises(NoSuchTableError):
+        test_catalog.load_table(table.identifier)
 
 
 @mock_glue
@@ -210,6 +247,31 @@ def test_rename_table(
     # old table should be dropped
     with pytest.raises(NoSuchTableError):
         test_catalog.load_table(identifier)
+
+
+@mock_glue
+def test_rename_table_from_self_identifier(
+    _bucket_initialize: None, _patch_aiobotocore: None, table_schema_nested: Schema, database_name: str, table_name: str
+) -> None:
+    catalog_name = "glue"
+    new_table_name = f"{table_name}_new"
+    identifier = (database_name, table_name)
+    new_identifier = (database_name, new_table_name)
+    test_catalog = GlueCatalog("glue", **{"py-io-impl": "pyiceberg.io.fsspec.FsspecFileIO", "warehouse": f"s3://{BUCKET_NAME}/"})
+    test_catalog.create_namespace(namespace=database_name)
+    table = test_catalog.create_table(identifier, table_schema_nested)
+    assert table.identifier == (catalog_name,) + identifier
+    assert TABLE_METADATA_LOCATION_REGEX.match(table.metadata_location)
+    test_catalog.rename_table(table.identifier, new_identifier)
+    new_table = test_catalog.load_table(new_identifier)
+    assert new_table.identifier == (catalog_name,) + new_identifier
+    # the metadata_location should not change
+    assert new_table.metadata_location == table.metadata_location
+    # old table should be dropped
+    with pytest.raises(NoSuchTableError):
+        test_catalog.load_table(identifier)
+    with pytest.raises(NoSuchTableError):
+        test_catalog.load_table(table.identifier)
 
 
 @mock_glue

--- a/tests/catalog/test_hive.py
+++ b/tests/catalog/test_hive.py
@@ -15,8 +15,9 @@
 #  specific language governing permissions and limitations
 #  under the License.
 # pylint: disable=protected-access,redefined-outer-name
+import copy
 import uuid
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from hive_metastore.ttypes import (
@@ -394,6 +395,155 @@ def test_load_table(hive_table: HiveTable) -> None:
     assert expected == table.metadata
 
 
+def test_load_table_from_self_identifier(hive_table: HiveTable) -> None:
+    catalog = HiveCatalog(HIVE_CATALOG_NAME, uri=HIVE_METASTORE_FAKE_URL)
+
+    catalog._client = MagicMock()
+    catalog._client.__enter__().get_table.return_value = hive_table
+    intermediate = catalog.load_table(("default", "new_tabl2e"))
+    table = catalog.load_table(intermediate.identifier)
+
+    catalog._client.__enter__().get_table.assert_called_with(dbname="default", tbl_name="new_tabl2e")
+
+    expected = TableMetadataV2(
+        location="s3://bucket/test/location",
+        table_uuid=uuid.UUID("9c12d441-03fe-4693-9a96-a0705ddf69c1"),
+        last_updated_ms=1602638573590,
+        last_column_id=3,
+        schemas=[
+            Schema(
+                NestedField(field_id=1, name="x", field_type=LongType(), required=True),
+                schema_id=0,
+                identifier_field_ids=[],
+            ),
+            Schema(
+                NestedField(field_id=1, name="x", field_type=LongType(), required=True),
+                NestedField(field_id=2, name="y", field_type=LongType(), required=True, doc="comment"),
+                NestedField(field_id=3, name="z", field_type=LongType(), required=True),
+                schema_id=1,
+                identifier_field_ids=[1, 2],
+            ),
+        ],
+        current_schema_id=1,
+        partition_specs=[
+            PartitionSpec(PartitionField(source_id=1, field_id=1000, transform=IdentityTransform(), name="x"), spec_id=0)
+        ],
+        default_spec_id=0,
+        last_partition_id=1000,
+        properties={"read.split.target.size": "134217728"},
+        current_snapshot_id=3055729675574597004,
+        snapshots=[
+            Snapshot(
+                snapshot_id=3051729675574597004,
+                parent_snapshot_id=None,
+                sequence_number=0,
+                timestamp_ms=1515100955770,
+                manifest_list="s3://a/b/1.avro",
+                summary=Summary(operation=Operation.APPEND),
+                schema_id=None,
+            ),
+            Snapshot(
+                snapshot_id=3055729675574597004,
+                parent_snapshot_id=3051729675574597004,
+                sequence_number=1,
+                timestamp_ms=1555100955770,
+                manifest_list="s3://a/b/2.avro",
+                summary=Summary(operation=Operation.APPEND),
+                schema_id=1,
+            ),
+        ],
+        snapshot_log=[
+            SnapshotLogEntry(snapshot_id=3051729675574597004, timestamp_ms=1515100955770),
+            SnapshotLogEntry(snapshot_id=3055729675574597004, timestamp_ms=1555100955770),
+        ],
+        metadata_log=[MetadataLogEntry(metadata_file="s3://bucket/.../v1.json", timestamp_ms=1515100)],
+        sort_orders=[
+            SortOrder(
+                SortField(
+                    source_id=2, transform=IdentityTransform(), direction=SortDirection.ASC, null_order=NullOrder.NULLS_FIRST
+                ),
+                SortField(
+                    source_id=3,
+                    transform=BucketTransform(num_buckets=4),
+                    direction=SortDirection.DESC,
+                    null_order=NullOrder.NULLS_LAST,
+                ),
+                order_id=3,
+            )
+        ],
+        default_sort_order_id=3,
+        refs={
+            "test": SnapshotRef(
+                snapshot_id=3051729675574597004,
+                snapshot_ref_type=SnapshotRefType.TAG,
+                min_snapshots_to_keep=None,
+                max_snapshot_age_ms=None,
+                max_ref_age_ms=10000000,
+            ),
+            "main": SnapshotRef(
+                snapshot_id=3055729675574597004,
+                snapshot_ref_type=SnapshotRefType.BRANCH,
+                min_snapshots_to_keep=None,
+                max_snapshot_age_ms=None,
+                max_ref_age_ms=None,
+            ),
+        },
+        format_version=2,
+        last_sequence_number=34,
+    )
+
+    assert table.identifier == (HIVE_CATALOG_NAME, "default", "new_tabl2e")
+    assert expected == table.metadata
+
+
+def test_rename_table(hive_table: HiveTable) -> None:
+    catalog = HiveCatalog(HIVE_CATALOG_NAME, uri=HIVE_METASTORE_FAKE_URL)
+
+    renamed_table = copy.deepcopy(hive_table)
+    renamed_table.dbName = "default"
+    renamed_table.tableName = "new_tabl3e"
+
+    catalog._client = MagicMock()
+    catalog._client.__enter__().get_table.side_effect = [hive_table, renamed_table]
+    catalog._client.__enter__().alter_table.return_value = None
+
+    from_identifier = ("default", "new_tabl2e")
+    to_identifier = ("default", "new_tabl3e")
+    table = catalog.rename_table(from_identifier, to_identifier)
+
+    assert table.identifier == ("hive",) + to_identifier
+
+    calls = [call(dbname="default", tbl_name="new_tabl2e"), call(dbname="default", tbl_name="new_tabl3e")]
+    catalog._client.__enter__().get_table.assert_has_calls(calls)
+    catalog._client.__enter__().alter_table.assert_called_with(dbname="default", tbl_name="new_tabl2e", new_tbl=renamed_table)
+
+
+def test_rename_table_from_self_identifier(hive_table: HiveTable) -> None:
+    catalog = HiveCatalog(HIVE_CATALOG_NAME, uri=HIVE_METASTORE_FAKE_URL)
+
+    catalog._client = MagicMock()
+    catalog._client.__enter__().get_table.return_value = hive_table
+
+    from_identifier = ("default", "new_tabl2e")
+    from_table = catalog.load_table(from_identifier)
+    catalog._client.__enter__().get_table.assert_called_with(dbname="default", tbl_name="new_tabl2e")
+
+    renamed_table = copy.deepcopy(hive_table)
+    renamed_table.dbName = "default"
+    renamed_table.tableName = "new_tabl3e"
+
+    catalog._client.__enter__().get_table.side_effect = [hive_table, renamed_table]
+    catalog._client.__enter__().alter_table.return_value = None
+    to_identifier = ("default", "new_tabl3e")
+    table = catalog.rename_table(from_table.identifier, to_identifier)
+
+    assert table.identifier == ("hive",) + to_identifier
+
+    calls = [call(dbname="default", tbl_name="new_tabl2e"), call(dbname="default", tbl_name="new_tabl3e")]
+    catalog._client.__enter__().get_table.assert_has_calls(calls)
+    catalog._client.__enter__().alter_table.assert_called_with(dbname="default", tbl_name="new_tabl2e", new_tbl=renamed_table)
+
+
 def test_rename_table_from_does_not_exists() -> None:
     catalog = HiveCatalog(HIVE_CATALOG_NAME, uri=HIVE_METASTORE_FAKE_URL)
 
@@ -487,6 +637,19 @@ def test_drop_table() -> None:
     catalog.drop_table(("default", "table"))
 
     catalog._client.__enter__().drop_table.assert_called_with(dbname="default", name="table", deleteData=False)
+
+
+def test_drop_table_from_self_identifier(hive_table: HiveTable) -> None:
+    catalog = HiveCatalog(HIVE_CATALOG_NAME, uri=HIVE_METASTORE_FAKE_URL)
+
+    catalog._client = MagicMock()
+    catalog._client.__enter__().get_table.return_value = hive_table
+    table = catalog.load_table(("default", "new_tabl2e"))
+
+    catalog._client.__enter__().get_all_databases.return_value = ["namespace1", "namespace2"]
+    catalog.drop_table(table.identifier)
+
+    catalog._client.__enter__().drop_table.assert_called_with(dbname="default", name="new_tabl2e", deleteData=False)
 
 
 def test_drop_table_does_not_exists() -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -354,6 +354,133 @@ def all_avro_types() -> Dict[str, Any]:
     }
 
 
+EXAMPLE_TABLE_METADATA_WITH_SNAPSHOT_V1 = {
+    "format-version": 1,
+    "table-uuid": "b55d9dda-6561-423a-8bfc-787980ce421f",
+    "location": "s3://warehouse/database/table",
+    "last-updated-ms": 1646787054459,
+    "last-column-id": 2,
+    "schema": {
+        "type": "struct",
+        "schema-id": 0,
+        "fields": [
+            {"id": 1, "name": "id", "required": False, "type": "int"},
+            {"id": 2, "name": "data", "required": False, "type": "string"},
+        ],
+    },
+    "current-schema-id": 0,
+    "schemas": [
+        {
+            "type": "struct",
+            "schema-id": 0,
+            "fields": [
+                {"id": 1, "name": "id", "required": False, "type": "int"},
+                {"id": 2, "name": "data", "required": False, "type": "string"},
+            ],
+        }
+    ],
+    "partition-spec": [],
+    "default-spec-id": 0,
+    "partition-specs": [{"spec-id": 0, "fields": []}],
+    "last-partition-id": 999,
+    "default-sort-order-id": 0,
+    "sort-orders": [{"order-id": 0, "fields": []}],
+    "properties": {
+        "owner": "bryan",
+        "write.metadata.compression-codec": "gzip",
+    },
+    "current-snapshot-id": 3497810964824022504,
+    "refs": {"main": {"snapshot-id": 3497810964824022504, "type": "branch"}},
+    "snapshots": [
+        {
+            "snapshot-id": 3497810964824022504,
+            "timestamp-ms": 1646787054459,
+            "summary": {
+                "operation": "append",
+                "spark.app.id": "local-1646787004168",
+                "added-data-files": "1",
+                "added-records": "1",
+                "added-files-size": "697",
+                "changed-partition-count": "1",
+                "total-records": "1",
+                "total-files-size": "697",
+                "total-data-files": "1",
+                "total-delete-files": "0",
+                "total-position-deletes": "0",
+                "total-equality-deletes": "0",
+            },
+            "manifest-list": "s3://warehouse/database/table/metadata/snap-3497810964824022504-1-c4f68204-666b-4e50-a9df-b10c34bf6b82.avro",
+            "schema-id": 0,
+        }
+    ],
+    "snapshot-log": [{"timestamp-ms": 1646787054459, "snapshot-id": 3497810964824022504}],
+    "metadata-log": [
+        {
+            "timestamp-ms": 1646787031514,
+            "metadata-file": "s3://warehouse/database/table/metadata/00000-88484a1c-00e5-4a07-a787-c0e7aeffa805.gz.metadata.json",
+        }
+    ],
+}
+
+
+@pytest.fixture
+def example_table_metadata_with_snapshot_v1() -> Dict[str, Any]:
+    return EXAMPLE_TABLE_METADATA_WITH_SNAPSHOT_V1
+
+
+EXAMPLE_TABLE_METADATA_NO_SNAPSHOT_V1 = {
+    "format-version": 1,
+    "table-uuid": "bf289591-dcc0-4234-ad4f-5c3eed811a29",
+    "location": "s3://warehouse/database/table",
+    "last-updated-ms": 1657810967051,
+    "last-column-id": 3,
+    "schema": {
+        "type": "struct",
+        "schema-id": 0,
+        "identifier-field-ids": [2],
+        "fields": [
+            {"id": 1, "name": "foo", "required": False, "type": "string"},
+            {"id": 2, "name": "bar", "required": True, "type": "int"},
+            {"id": 3, "name": "baz", "required": False, "type": "boolean"},
+        ],
+    },
+    "current-schema-id": 0,
+    "schemas": [
+        {
+            "type": "struct",
+            "schema-id": 0,
+            "identifier-field-ids": [2],
+            "fields": [
+                {"id": 1, "name": "foo", "required": False, "type": "string"},
+                {"id": 2, "name": "bar", "required": True, "type": "int"},
+                {"id": 3, "name": "baz", "required": False, "type": "boolean"},
+            ],
+        }
+    ],
+    "partition-spec": [],
+    "default-spec-id": 0,
+    "last-partition-id": 999,
+    "default-sort-order-id": 0,
+    "sort-orders": [{"order-id": 0, "fields": []}],
+    "properties": {
+        "write.delete.parquet.compression-codec": "zstd",
+        "write.metadata.compression-codec": "gzip",
+        "write.summary.partition-limit": "100",
+        "write.parquet.compression-codec": "zstd",
+    },
+    "current-snapshot-id": -1,
+    "refs": {},
+    "snapshots": [],
+    "snapshot-log": [],
+    "metadata-log": [],
+}
+
+
+@pytest.fixture
+def example_table_metadata_no_snapshot_v1() -> Dict[str, Any]:
+    return EXAMPLE_TABLE_METADATA_NO_SNAPSHOT_V1
+
+
 EXAMPLE_TABLE_METADATA_V2 = {
     "format-version": 2,
     "table-uuid": "9c12d441-03fe-4693-9a96-a0705ddf69c1",


### PR DESCRIPTION
**Related Issue**: https://github.com/apache/iceberg-python/issues/123

**Validations Run**: 
`make test`
`make test-integration`
`make lint`

**Description**:
This PR fixes a bug where `Catalog` APIs returning a table (e.g. `catalog.load_table()`, `catalog.create_table()`, etc.) return a `Table` whose identifier has the catalog name prepended, but providing this identifier to catalog APIs to locate this table raises a `NoSuchTable` error due to the prepended catalog name.

This implementation simply removes the prepended catalog name from the identifier whenever it is composed of at least 3 elements and the catalog name matches the current catalog implementation in use. 

It currently only removes the catalog name in cases where a table identifier refers to the location of an existing table, such as in `catalog.load_table()`, the `from_identifier` of `catalog.rename_table()`, `catalog.drop_table()`, and `catalog.purge_table()`. 

One side-effect of this implementation decision is illustrated in the following code, which fails to load a table with a 2-part namespace whose first element is identical to the catalog name:
```python
catalog = RestCatalog("rest", uri=TEST_URI, token=TEST_TOKEN)
table_identifier = ("rest", "pdames", "table")
table = catalog.create_table(identifier=table_identifier, ...)  # table.identifier string is "rest.rest.pdames.table"
loaded_table = catalog.load_table(table.identifier)  # loads the created table successfully
catalog.load_table(table_identifier)  # NoSuchTable error due to removing the namespace that matches the catalog name 
```
In this case, we could fallback to again trying to load the table with the catalog name included after catching the `NoSuchTable` error, but this may  result in us loading a different table than intended since we don't know if the first identifier element is meant to refer to a namespace or a catalog name. 

I'm curious to hear reviewers opinions about how concerning these types of side-effects are, potential fixes, and if this calls for further refactoring to add the missing context in the form of identifier metadata, type-differentiated identifier elements, etc.