### PR TITLE
fix(bucket transform): bad comparison for truthy value

### DIFF
--- a/pyiceberg/transforms.py
+++ b/pyiceberg/transforms.py
@@ -262,7 +262,7 @@ class BucketTransform(Transform[S, int]):
             raise ValueError(f"Unknown type {source}")
 
         if bucket:
-            return lambda v: (hash_func(v) & IntegerType.max) % self._num_buckets if v else None
+            return lambda v: (hash_func(v) & IntegerType.max) % self._num_buckets if v is not None else None
         return hash_func
 
     def __repr__(self) -> str:

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -135,6 +135,7 @@ def test_bucket_hash_values(test_input: Any, test_type: PrimitiveType, expected:
 @pytest.mark.parametrize(
     "transform,value,expected",
     [
+        (BucketTransform(2).transform(IntegerType()), 0, 0),
         (BucketTransform(100).transform(IntegerType()), 34, 79),
         (BucketTransform(100).transform(LongType()), 34, 79),
         (BucketTransform(100).transform(DateType()), 17486, 26),


### PR DESCRIPTION
This was a bad comparison due to comparing the truthy value of arbitrary objects. This failed in the case where `v` is equal to 0, as the truthy value of 0 is `False`. 

I have added a test that was failing before the change I made, and passes after the change was made.

Resolves #173 