### PR TITLE
fix snapshot schema issue: wrong usage of walrus operator

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -944,8 +944,8 @@ class TableScan(ABC):
     def projection(self) -> Schema:
         snapshot_schema = self.table.schema()
         if snapshot := self.snapshot():
-            if snapshot_schema_id := snapshot.schema_id:
-                snapshot_schema = self.table.schemas()[snapshot_schema_id]
+            snapshot_schema_id = snapshot.schema_id
+            snapshot_schema = self.table.schemas()[snapshot_schema_id]
 
         if "*" in self.selected_fields:
             return snapshot_schema


### PR DESCRIPTION
When given the first snapshot-id of the table, the schema got should have schema_id = 0.
But under origin code's conditional statements, the use of walrus operator will cause the condition that when schema_id = 0, it will not pass the if statement, thus the schema will not change.