### PR TITLE
Rest Catalog Support for a Separate OAuth Server URI

### DIFF
--- a/mkdocs/docs/configuration.md
+++ b/mkdocs/docs/configuration.md
@@ -129,14 +129,15 @@ catalog:
       cabundle: /absolute/path/to/cabundle.pem
 ```
 
-| Key                 | Example                 | Description                                                                |
-| ------------------- | ----------------------- | -------------------------------------------------------------------------- |
-| uri                 | https://rest-catalog/ws | URI identifying the REST Server                                            |
-| credential          | t-1234:secret           | Credential to use for OAuth2 credential flow when initializing the catalog |
-| token               | FEW23.DFSDF.FSDF        | Bearer token value to use for `Authorization` header                       |
-| rest.sigv4-enabled  | true                    | Sign requests to the REST Server using AWS SigV4 protocol                  |
-| rest.signing-region | us-east-1               | The region to use when SigV4 signing a request                             |
-| rest.signing-name   | execute-api             | The service signing name to use when SigV4 signing a request               |
+| Key                    | Example                 | Description                                                                                        |
+| ---------------------- | ----------------------- | -------------------------------------------------------------------------------------------------- |
+| uri                    | https://rest-catalog/ws | URI identifying the REST Server                                                                    |
+| credential             | t-1234:secret           | Credential to use for OAuth2 credential flow when initializing the catalog                         |
+| token                  | FEW23.DFSDF.FSDF        | Bearer token value to use for `Authorization` header                                               |
+| rest.sigv4-enabled     | true                    | Sign requests to the REST Server using AWS SigV4 protocol                                          |
+| rest.signing-region    | us-east-1               | The region to use when SigV4 signing a request                                                     |
+| rest.signing-name      | execute-api             | The service signing name to use when SigV4 signing a request                                       |
+| rest.authorization-url | https://auth-service/cc | Authentication URL to use for client credentials authentication (default: uri + 'v1/oauth/tokens') |
 
 ## SQL Catalog
 

--- a/pyiceberg/catalog/rest.py
+++ b/pyiceberg/catalog/rest.py
@@ -268,7 +268,6 @@ class RestCatalog(Catalog):
 
     @property
     def auth_url(self) -> str:
-        print(f"DEBUG: {self.properties}")
         if url := self.properties.get(AUTH_URL):
             return url
         else:

--- a/pyiceberg/catalog/rest.py
+++ b/pyiceberg/catalog/rest.py
@@ -109,6 +109,7 @@ SSL = "ssl"
 SIGV4 = "rest.sigv4-enabled"
 SIGV4_REGION = "rest.signing-region"
 SIGV4_SERVICE = "rest.signing-name"
+AUTH_URL = "rest.authorization-url"
 
 NAMESPACE_SEPARATOR = b"\x1F".decode(UTF8)
 
@@ -265,15 +266,22 @@ class RestCatalog(Catalog):
 
         return url + endpoint.format(**kwargs)
 
+    @property
+    def auth_url(self) -> str:
+        print(f"DEBUG: {self.properties}")
+        if url := self.properties.get(AUTH_URL):
+            return url
+        else:
+            return self.url(Endpoints.get_token, prefixed=False)
+
     def _fetch_access_token(self, session: Session, credential: str) -> str:
         if SEMICOLON in credential:
             client_id, client_secret = credential.split(SEMICOLON)
         else:
             client_id, client_secret = None, credential
         data = {GRANT_TYPE: CLIENT_CREDENTIALS, CLIENT_ID: client_id, CLIENT_SECRET: client_secret, SCOPE: CATALOG_SCOPE}
-        url = self.url(Endpoints.get_token, prefixed=False)
         # Uses application/x-www-form-urlencoded by default
-        response = session.post(url=url, data=data)
+        response = session.post(url=self.auth_url, data=data)
         try:
             response.raise_for_status()
         except HTTPError as exc:


### PR DESCRIPTION
Closes: https://github.com/apache/iceberg-python/issues/230

This PR introduces support for **Separation of Roles** in OAuth authorization when using the REST Catalog, by allowing the user to use a distinct Authorization Server to fetch the access token and use it against the REST Catalog. In this scenario, the responsibility of the REST Catalog lies in validating the access token, instead of taking their secrets and deducing their identity and authorization.

This will allow PyIceberg to re-authorize the client using the stored credentials against the appropriate auth server if AuthorizationExpiredError is detected (Refreshing access_token is out of scope of this PR)