### PR TITLE
preserve field order in `Schema.select`

### DIFF
--- a/pyiceberg/schema.py
+++ b/pyiceberg/schema.py
@@ -291,13 +291,17 @@ class Schema(IcebergBaseModel):
         """
         try:
             if case_sensitive:
-                ids = {self._name_to_id[name] for name in names}
+                ids = [self._name_to_id[name] for name in names]
             else:
-                ids = {self._lazy_name_to_id_lower[name.lower()] for name in names}
+                ids = [self._lazy_name_to_id_lower[name.lower()] for name in names]
         except KeyError as e:
             raise ValueError(f"Could not find column: {e}") from e
 
-        return prune_columns(self, ids)
+        pruned_schema = prune_columns(self, set(ids))
+
+        fields = sorted(pruned_schema.fields, key=lambda f: ids.index(f.field_id))
+
+        return Schema(*fields, schema_id=pruned_schema.schema_id, identifier_field_ids=pruned_schema.identifier_field_ids)
 
     @property
     def field_ids(self) -> Set[int]:

--- a/tests/table/test_init.py
+++ b/tests/table/test_init.py
@@ -278,6 +278,17 @@ def test_table_scan_projection_single_column(table_v2: Table) -> None:
     )
 
 
+def test_table_scan_select_preserves_order(table_v2: Table) -> None:
+    scan = table_v2.scan()
+    assert scan.select("y", "x", "z").projection() == Schema(
+        NestedField(field_id=2, name="y", field_type=LongType(), required=True, doc="comment"),
+        NestedField(field_id=1, name="x", field_type=LongType(), required=True),
+        NestedField(field_id=3, name="z", field_type=LongType(), required=True),
+        schema_id=1,
+        identifier_field_ids=[1, 2],
+    )
+
+
 def test_table_scan_projection_single_column_case_sensitive(table_v2: Table) -> None:
     scan = table_v2.scan()
     assert scan.with_case_sensitive(False).select("Y").projection() == Schema(


### PR DESCRIPTION
Closes #26 

Hi  👋 , this PR intends to preserve the order of fields passed in as arguments to `Schema.select` in the output.

It is implemented as an additional step after pruning the schema where the fields are reordered according the to the order of the arguments.


