### PR TITLE
Bug fix falsy value of zero

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -545,7 +545,7 @@ class Table:
 
     def current_snapshot(self) -> Optional[Snapshot]:
         """Get the current snapshot for this table, or None if there is no current snapshot."""
-        if snapshot_id := self.metadata.current_snapshot_id:
+        if (snapshot_id := self.metadata.current_snapshot_id) is not None or isinstance(snapshot_id, int):
             return self.snapshot_by_id(snapshot_id)
         return None
 

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -545,8 +545,8 @@ class Table:
 
     def current_snapshot(self) -> Optional[Snapshot]:
         """Get the current snapshot for this table, or None if there is no current snapshot."""
-        if (snapshot_id := self.metadata.current_snapshot_id) is not None or isinstance(snapshot_id, int):
-            return self.snapshot_by_id(snapshot_id)
+        if self.metadata.current_snapshot_id is not None:
+            return self.snapshot_by_id(self.metadata.current_snapshot_id)
         return None
 
     def snapshot_by_id(self, snapshot_id: int) -> Optional[Snapshot]:


### PR DESCRIPTION
Resolves: [232](https://github.com/apache/iceberg-python/issues/232)

Python, certain values are considered False in a boolean context. These include None, 0, empty sequences/collections (`''`, `[]`, `{}`), and others. This is often referred to as “falsy” values.

With the current implementation of  ->    

```
def current_snapshot(self) -> Optional[Snapshot]
      if snapshot_id := self.metadata.current_snapshot_id:
      
```

The walrus operator in the if condition will assign a value to snapshot_id, but it will marked as false in case of zero and None hence will skip snapshot_id = 0 as well, to solve this raise this PR


