### PR TITLE
[Bug fix] Ensure string env var s3.connect-timeout is cast to float

### DIFF
--- a/pyiceberg/io/fsspec.py
+++ b/pyiceberg/io/fsspec.py
@@ -130,7 +130,7 @@ def _s3(properties: Properties) -> AbstractFileSystem:
         config_kwargs["proxies"] = {"http": proxy_uri, "https": proxy_uri}
 
     if connect_timeout := properties.get(S3_CONNECT_TIMEOUT):
-        config_kwargs["connect_timeout"] = connect_timeout
+        config_kwargs["connect_timeout"] = float(connect_timeout)
 
     fs = S3FileSystem(client_kwargs=client_kwargs, config_kwargs=config_kwargs)
 

--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -333,7 +333,7 @@ class PyArrowFileIO(FileIO):
                 client_kwargs["proxy_options"] = proxy_uri
 
             if connect_timeout := self.properties.get(S3_CONNECT_TIMEOUT):
-                client_kwargs["connect_timeout"] = connect_timeout
+                client_kwargs["connect_timeout"] = float(connect_timeout)
 
             return S3FileSystem(**client_kwargs)
         elif scheme == "hdfs":


### PR DESCRIPTION
```
%env PYICEBERG_CATALOG__LACUS__S3.CONNECT-TIMEOUT=60

from pyiceberg.catalog import load_catalog
catalog = load_catalog("test")
tbl = catalog.load_table("test.test")
tbl.scan().to_arrow().to_pandas()

```
Stacktrace:

```
TypeError                                 Traceback (most recent call last)
/tmp/ipykernel_734/2954162570.py in <cell line: 2>()
      1 tbl = catalog.load_table("test.table")
----> 2 tbl.scan().to_arrow().to_pandas()

/layers/com.bloomberg.ds.buildpacks.pip/requirements/lib/python3.10/site-packages/pyiceberg/table/__init__.py in to_arrow(self)
   1290 
   1291         return project_table(
-> 1292             self.plan_files(),
   1293             self.table,
   1294             self.row_filter,

/layers/com.bloomberg.ds.buildpacks.pip/requirements/lib/python3.10/site-packages/pyiceberg/table/__init__.py in plan_files(self)
   1232         manifests = [
   1233             manifest_file
-> 1234             for manifest_file in snapshot.manifests(io)
   1235             if manifest_evaluators[manifest_file.partition_spec_id](manifest_file)
   1236         ]

/layers/com.bloomberg.ds.buildpacks.pip/requirements/lib/python3.10/site-packages/pyiceberg/table/snapshots.py in manifests(self, io)
    157     def manifests(self, io: FileIO) -> List[ManifestFile]:
    158         if self.manifest_list is not None:
--> 159             file = io.new_input(self.manifest_list)
    160             return list(read_manifest_list(file))
    161         return []

/layers/com.bloomberg.ds.buildpacks.pip/requirements/lib/python3.10/site-packages/pyiceberg/io/pyarrow.py in new_input(self, location)
    392         scheme, netloc, path = self.parse_location(location)
    393         return PyArrowFile(
--> 394             fs=self.fs_by_scheme(scheme, netloc),
    395             location=location,
    396             path=path,

/layers/com.bloomberg.ds.buildpacks.pip/requirements/lib/python3.10/site-packages/pyiceberg/io/pyarrow.py in _initialize_fs(self, scheme, netloc)
    340                 client_kwargs["connect_timeout"] = connect_timeout
    341 
--> 342             return S3FileSystem(**client_kwargs)
    343         elif scheme == "hdfs":
    344             from pyarrow.fs import HadoopFileSystem

/layers/com.bloomberg.ds.buildpacks.pip/requirements/lib/python3.10/site-packages/pyarrow/_s3fs.pyx in pyarrow._s3fs.S3FileSystem.__init__()

TypeError: must be real number, not str
```