### PR TITLE
Add SqlCatalog _commit_table support

### DIFF
--- a/pyiceberg/catalog/sql.py
+++ b/pyiceberg/catalog/sql.py
@@ -336,7 +336,7 @@ class SqlCatalog(Catalog):
             tuple(table_request.identifier.namespace.root + [table_request.identifier.name])
         )
         current_table = self.load_table(identifier_tuple)
-        from_database_name, from_table_name = self.identifier_to_database_and_table(identifier_tuple, NoSuchTableError)
+        database_name, table_name = self.identifier_to_database_and_table(identifier_tuple, NoSuchTableError)
         base_metadata = current_table.metadata
         for requirement in table_request.requirements:
             requirement.validate(base_metadata)
@@ -356,8 +356,8 @@ class SqlCatalog(Catalog):
                 update(IcebergTables)
                 .where(
                     IcebergTables.catalog_name == self.name,
-                    IcebergTables.table_namespace == from_database_name,
-                    IcebergTables.table_name == from_table_name,
+                    IcebergTables.table_namespace == database_name,
+                    IcebergTables.table_name == table_name,
                     IcebergTables.metadata_location == current_table.metadata_location,
                 )
                 .values(metadata_location=new_metadata_location, previous_metadata_location=current_table.metadata_location)

--- a/pyiceberg/catalog/sql.py
+++ b/pyiceberg/catalog/sql.py
@@ -283,7 +283,7 @@ class SqlCatalog(Catalog):
                 try:
                     tbl = (
                         session.query(IcebergTables)
-                        .with_for_update(of=IcebergTables, nowait=True)
+                        .with_for_update(of=IcebergTables)
                         .filter(
                             IcebergTables.catalog_name == self.name,
                             IcebergTables.table_namespace == database_name,
@@ -335,7 +335,7 @@ class SqlCatalog(Catalog):
                     try:
                         tbl = (
                             session.query(IcebergTables)
-                            .with_for_update(of=IcebergTables, nowait=True)
+                            .with_for_update(of=IcebergTables)
                             .filter(
                                 IcebergTables.catalog_name == self.name,
                                 IcebergTables.table_namespace == from_database_name,
@@ -405,7 +405,7 @@ class SqlCatalog(Catalog):
                 try:
                     tbl = (
                         session.query(IcebergTables)
-                        .with_for_update(of=IcebergTables, nowait=True)
+                        .with_for_update(of=IcebergTables)
                         .filter(
                             IcebergTables.catalog_name == self.name,
                             IcebergTables.table_namespace == database_name,

--- a/pyiceberg/catalog/sql.py
+++ b/pyiceberg/catalog/sql.py
@@ -398,9 +398,7 @@ class SqlCatalog(Catalog):
                 )
                 result = session.execute(stmt)
                 if result.rowcount < 1:
-                    raise CommitFailedException(
-                        "Commit was unsuccessful as a conflicting concurrent commit was made to the database."
-                    )
+                    raise CommitFailedException(f"Table has been updated by another process: {database_name}.{table_name}")
             else:
                 try:
                     tbl = (
@@ -417,9 +415,7 @@ class SqlCatalog(Catalog):
                     tbl.metadata_location = new_metadata_location
                     tbl.previous_metadata_location = current_table.metadata_location
                 except NoResultFound as e:
-                    raise CommitFailedException(
-                        "Commit was unsuccessful as a conflicting concurrent commit was made to the database."
-                    ) from e
+                    raise CommitFailedException(f"Table has been updated by another process: {database_name}.{table_name}") from e
             session.commit()
 
         return CommitTableResponse(metadata=updated_metadata, metadata_location=new_metadata_location)

--- a/tests/catalog/test_sql.py
+++ b/tests/catalog/test_sql.py
@@ -96,7 +96,6 @@ def catalog_sqlite_without_rowcount(warehouse: Path) -> Generator[SqlCatalog, No
     }
     catalog = SqlCatalog("test_sql_catalog", **props)
     catalog.engine.dialect.supports_sane_rowcount = False
-    print(f"DEBUG: {catalog.engine.dialect.supports_sane_rowcount=}")
     catalog.create_tables()
     yield catalog
     catalog.destroy_tables()

--- a/tests/catalog/test_sql.py
+++ b/tests/catalog/test_sql.py
@@ -88,6 +88,20 @@ def catalog_sqlite(warehouse: Path) -> Generator[SqlCatalog, None, None]:
     catalog.destroy_tables()
 
 
+@pytest.fixture(scope="module")
+def catalog_sqlite_without_rowcount(warehouse: Path) -> Generator[SqlCatalog, None, None]:
+    props = {
+        "uri": "sqlite:////tmp/sql-catalog.db",
+        "warehouse": f"file://{warehouse}",
+    }
+    catalog = SqlCatalog("test_sql_catalog", **props)
+    catalog.engine.dialect.supports_sane_rowcount = False
+    print(f"DEBUG: {catalog.engine.dialect.supports_sane_rowcount=}")
+    catalog.create_tables()
+    yield catalog
+    catalog.destroy_tables()
+
+
 def test_creation_with_no_uri() -> None:
     with pytest.raises(NoSuchPropertyException):
         SqlCatalog("test_ddb_catalog", not_uri="unused")
@@ -306,6 +320,7 @@ def test_load_table_from_self_identifier(catalog: SqlCatalog, table_schema_neste
     [
         lazy_fixture('catalog_memory'),
         lazy_fixture('catalog_sqlite'),
+        lazy_fixture('catalog_sqlite_without_rowcount'),
     ],
 )
 def test_drop_table(catalog: SqlCatalog, table_schema_nested: Schema, random_identifier: Identifier) -> None:
@@ -323,6 +338,7 @@ def test_drop_table(catalog: SqlCatalog, table_schema_nested: Schema, random_ide
     [
         lazy_fixture('catalog_memory'),
         lazy_fixture('catalog_sqlite'),
+        lazy_fixture('catalog_sqlite_without_rowcount'),
     ],
 )
 def test_drop_table_from_self_identifier(catalog: SqlCatalog, table_schema_nested: Schema, random_identifier: Identifier) -> None:
@@ -342,6 +358,7 @@ def test_drop_table_from_self_identifier(catalog: SqlCatalog, table_schema_neste
     [
         lazy_fixture('catalog_memory'),
         lazy_fixture('catalog_sqlite'),
+        lazy_fixture('catalog_sqlite_without_rowcount'),
     ],
 )
 def test_drop_table_that_does_not_exist(catalog: SqlCatalog, random_identifier: Identifier) -> None:
@@ -354,6 +371,7 @@ def test_drop_table_that_does_not_exist(catalog: SqlCatalog, random_identifier: 
     [
         lazy_fixture('catalog_memory'),
         lazy_fixture('catalog_sqlite'),
+        lazy_fixture('catalog_sqlite_without_rowcount'),
     ],
 )
 def test_rename_table(
@@ -378,6 +396,7 @@ def test_rename_table(
     [
         lazy_fixture('catalog_memory'),
         lazy_fixture('catalog_sqlite'),
+        lazy_fixture('catalog_sqlite_without_rowcount'),
     ],
 )
 def test_rename_table_from_self_identifier(
@@ -404,6 +423,7 @@ def test_rename_table_from_self_identifier(
     [
         lazy_fixture('catalog_memory'),
         lazy_fixture('catalog_sqlite'),
+        lazy_fixture('catalog_sqlite_without_rowcount'),
     ],
 )
 def test_rename_table_to_existing_one(
@@ -426,6 +446,7 @@ def test_rename_table_to_existing_one(
     [
         lazy_fixture('catalog_memory'),
         lazy_fixture('catalog_sqlite'),
+        lazy_fixture('catalog_sqlite_without_rowcount'),
     ],
 )
 def test_rename_missing_table(catalog: SqlCatalog, random_identifier: Identifier, another_random_identifier: Identifier) -> None:
@@ -440,6 +461,7 @@ def test_rename_missing_table(catalog: SqlCatalog, random_identifier: Identifier
     [
         lazy_fixture('catalog_memory'),
         lazy_fixture('catalog_sqlite'),
+        lazy_fixture('catalog_sqlite_without_rowcount'),
     ],
 )
 def test_rename_table_to_missing_namespace(
@@ -672,6 +694,7 @@ def test_update_namespace_properties(catalog: SqlCatalog, database_name: str) ->
     [
         lazy_fixture('catalog_memory'),
         lazy_fixture('catalog_sqlite'),
+        lazy_fixture('catalog_sqlite_without_rowcount'),
     ],
 )
 def test_commit_table(catalog: SqlCatalog, table_schema_nested: Schema, random_identifier: Identifier) -> None:


### PR DESCRIPTION
https://github.com/apache/iceberg-python/issues/262

This PR takes much code-spiration from @HonahX 's recent PR for a similar feature enhancement to the Glue Catalog.

The only difference here is that we use the **metadata_location** as the optimistic locking parameter to ensure that the version of the table we used to validate the requirements on is still the same when the SQL update is being made.

EDIT:
for methods that require rowcount on UPDATE and DELETE for optimistic locking, we now fallback to "SELECT ... FOR UPDATE" sqlalchemy expression [with_for_update](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.CompoundSelect.with_for_update) to acquire a row level lock if the sqlalchemy dialect does not support rowcount for UPDATE / DELETE

https://docs.sqlalchemy.org/en/14/core/internals.html - supports_sane_rowcount