### PR TITLE
[doc] Support multilingual doc by google-translator plugin

### DIFF
--- a/mkdocs/mkdocs.yml
+++ b/mkdocs/mkdocs.yml
@@ -20,6 +20,19 @@ site_url: https://py.iceberg.apache.org/
 repo_url: "https://github.com/apache/iceberg-python"
 repo_name: "apache/iceberg-python"
 
+extra:
+  alternate:
+      # Original Language
+    - name: English
+      lang: 'en'
+      link: '%GT_RELATIVE_URL%'  # For relative urls back to original language
+      # Extra languages
+    - name: Chinese
+      lang: 'zh'
+      link: 'https://translate.goog/?_x_tr_sl=en&_x_tr_tl=zh'
+      # _x_tr_sl = source language
+      # _x_tr_tl = translation language
+
 plugins:
   - gen-files:
       scripts:
@@ -32,6 +45,8 @@ plugins:
       handlers:
         python:
           paths: [..]
+  - google-translate:
+      url: https://py.iceberg.apache.org/  # optional (but necessary for local tests)
 
 theme:
   name: material

--- a/mkdocs/requirements.txt
+++ b/mkdocs/requirements.txt
@@ -26,3 +26,4 @@ mkdocs-gen-files==0.5.0
 mkdocs-material==9.5.4
 mkdocs-material-extensions==1.3.1
 mkdocs-section-index==0.3.8
+mkdocs-google-translate==1.2.0


### PR DESCRIPTION
# Purpose

Support for Chinese Documentation for PyIceberg better spreading in Chinese developer community.

# What I've Done

1. Add google-translator-plugin in mkdocs.yml and requirements.txt

# Preview

![image](https://github.com/apache/iceberg-python/assets/41324537/c6456495-a334-4bb4-9cf6-b9b91814a43a)
