### PR TITLE
Remove redundant API call to Glue

### DIFF
--- a/pyiceberg/catalog/glue.py
+++ b/pyiceberg/catalog/glue.py
@@ -490,7 +490,6 @@ class GlueCatalog(Catalog):
         table_list: List[TableTypeDef] = []
         next_token: Optional[str] = None
         try:
-            table_list_response = self.glue.get_tables(DatabaseName=database_name)
             while True:
                 table_list_response = (
                     self.glue.get_tables(DatabaseName=database_name)
@@ -517,7 +516,6 @@ class GlueCatalog(Catalog):
             return []
 
         database_list: List[DatabaseTypeDef] = []
-        databases_response = self.glue.get_databases()
         next_token: Optional[str] = None
 
         while True:


### PR DESCRIPTION
While reviewing the GlueCatalog implementation in Python, I noticed the listing methods for tables and namespaces are making redundant calls to AWS Glue. This PR removes the extra call and ensures that all data retrieval and pagination handling remains consistent. 

## Manual Testing

Before:
```
print(glue_catalog.list_namespaces())
> [('default',), ('spark',)]

print(glue_catalog.list_tables("default"))
> [('default', 'amazon'), ('default', 'cmd'), ('default', 'history'), ('default', 'snapshots'), ('default', 'table3'), ('default', 'table3_copy'), ('default', 'table4')]
```

After:
```
print(glue_catalog.list_namespaces())
> [('default',), ('spark',)]

print(glue_catalog.list_tables("default"))
> [('default', 'amazon'), ('default', 'cmd'), ('default', 'history'), ('default', 'snapshots'), ('default', 'table3'), ('default', 'table3_copy'), ('default', 'table4')]
```