### PR TITLE
Fix writing to local filesystem

### DIFF
--- a/pyiceberg/io/__init__.py
+++ b/pyiceberg/io/__init__.py
@@ -275,7 +275,7 @@ SCHEMA_TO_FILE_IO: Dict[str, List[str]] = {
     "s3a": [ARROW_FILE_IO, FSSPEC_FILE_IO],
     "s3n": [ARROW_FILE_IO, FSSPEC_FILE_IO],
     "gs": [ARROW_FILE_IO],
-    "file": [ARROW_FILE_IO],
+    "file": [ARROW_FILE_IO, FSSPEC_FILE_IO],
     "hdfs": [ARROW_FILE_IO],
     "abfs": [FSSPEC_FILE_IO],
     "abfss": [FSSPEC_FILE_IO],

--- a/pyiceberg/io/fsspec.py
+++ b/pyiceberg/io/fsspec.py
@@ -99,7 +99,7 @@ SIGNERS: Dict[str, Callable[[Properties, AWSRequest], AWSRequest]] = {"S3V4RestS
 
 
 def _file(_: Properties) -> LocalFileSystem:
-    return LocalFileSystem()
+    return LocalFileSystem(auto_mkdir=True)
 
 
 def _s3(properties: Properties) -> AbstractFileSystem:
@@ -173,6 +173,7 @@ def _adlfs(properties: Properties) -> AbstractFileSystem:
 
 
 SCHEME_TO_FS = {
+    "": _file,
     "file": _file,
     "s3": _s3,
     "s3a": _s3,

--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -173,7 +173,7 @@ T = TypeVar("T")
 
 
 class PyArrowLocalFileSystem(pyarrow.fs.LocalFileSystem):
-    def open_output_stream(self, path, *args, **kwargs):
+    def open_output_stream(self, path: str, *args: Any, **kwargs: Any) -> pyarrow.NativeFile:
         # In LocalFileSystem, parent directories must be first created before opening an output stream
         self.create_dir(os.path.dirname(path), recursive=True)
         return super().open_output_stream(path, *args, **kwargs)

--- a/tests/catalog/test_sql.py
+++ b/tests/catalog/test_sql.py
@@ -119,7 +119,6 @@ def catalog_sqlite_fsspec(warehouse: Path) -> Generator[SqlCatalog, None, None]:
     catalog.destroy_tables()
 
 
-
 def test_creation_with_no_uri() -> None:
     with pytest.raises(NoSuchPropertyException):
         SqlCatalog("test_ddb_catalog", not_uri="unused")


### PR DESCRIPTION
[Issue #299](https://github.com/apache/iceberg-python/issues/299)

This PR changes the behavior of both `PyArrow` and `FsSpec` file systems. When writing to the local file system, parent directories will be created first before writing to the file. Previously, a `FileNotFoundError` error is thrown when the parent directories are missing. 


### Testing
Added tests to `tests/io/test_fsspec.py` and `tests/io/test_pyarrow.py`
Added `test_append_table` test to write to the local filesystem, to illustrate the issue. It fails without the changes in this PR.
Also added the `catalog_sqlite_fsspec` catalog which tests writing to the local filesystem using `FSSPEC_FILE_IO`