### PR TITLE
`create_table` with a PyArrow Schema

### DIFF
--- a/mkdocs/docs/api.md
+++ b/mkdocs/docs/api.md
@@ -146,6 +146,26 @@ catalog.create_table(
 )
 ```
 
+One can also create an Iceberg table using a pyarrow schema:
+
+```python
+import pyarrow as pa
+
+pa.schema(
+    [
+        pa.field("foo", pa.string(), nullable=True),
+        pa.field("bar", pa.int32(), nullable=False),
+        pa.field("baz", pa.bool_(), nullable=True),
+    ]
+)
+
+catalog.create_table(
+    identifier="docs_example.bids",
+    schema=schema,
+    location="s3://pyiceberg",
+)
+```
+
 ## Load a table
 
 ### Catalog table

--- a/mkdocs/docs/api.md
+++ b/mkdocs/docs/api.md
@@ -151,7 +151,7 @@ To create a table using a pyarrow schema:
 ```python
 import pyarrow as pa
 
-pa.schema(
+schema = pa.schema(
     [
         pa.field("foo", pa.string(), nullable=True),
         pa.field("bar", pa.int32(), nullable=False),
@@ -162,7 +162,6 @@ pa.schema(
 catalog.create_table(
     identifier="docs_example.bids",
     schema=schema,
-    location="s3://pyiceberg",
 )
 ```
 

--- a/mkdocs/docs/api.md
+++ b/mkdocs/docs/api.md
@@ -146,7 +146,7 @@ catalog.create_table(
 )
 ```
 
-One can also create an Iceberg table using a pyarrow schema:
+To create a table using a pyarrow schema:
 
 ```python
 import pyarrow as pa

--- a/pyiceberg/catalog/__init__.py
+++ b/pyiceberg/catalog/__init__.py
@@ -518,6 +518,8 @@ class Catalog(ABC):
 
     @staticmethod
     def _convert_schema_if_needed(schema: Union[Schema, "pa.Schema"]) -> Schema:
+        if isinstance(schema, Schema):
+            return schema
         try:
             import pyarrow as pa
 
@@ -525,12 +527,10 @@ class Catalog(ABC):
 
             if isinstance(schema, pa.Schema):
                 schema: Schema = pre_order_visit_pyarrow(schema, _ConvertToIcebergWithFreshIds())  # type: ignore
+                return schema
         except ModuleNotFoundError:
             pass
-
-        if not isinstance(schema, Schema):
-            raise ValueError(f"{type(schema)=} must be pyiceberg.schema.Schema")
-        return schema
+        raise ValueError(f"{type(schema)=}, but it must be pyiceberg.schema.Schema or pyarrow.Schema")
 
     def _resolve_table_location(self, location: Optional[str], database_name: str, table_name: str) -> str:
         if not location:

--- a/pyiceberg/catalog/__init__.py
+++ b/pyiceberg/catalog/__init__.py
@@ -523,10 +523,10 @@ class Catalog(ABC):
         try:
             import pyarrow as pa
 
-            from pyiceberg.io.pyarrow import _ConvertToIcebergWithNoIds, visit_pyarrow
+            from pyiceberg.io.pyarrow import _ConvertToIcebergWithoutIDs, visit_pyarrow
 
             if isinstance(schema, pa.Schema):
-                schema: Schema = visit_pyarrow(schema, _ConvertToIcebergWithNoIds())  # type: ignore
+                schema: Schema = visit_pyarrow(schema, _ConvertToIcebergWithoutIDs())  # type: ignore
                 return schema
         except ModuleNotFoundError:
             pass

--- a/pyiceberg/catalog/__init__.py
+++ b/pyiceberg/catalog/__init__.py
@@ -24,6 +24,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 from typing import (
+    TYPE_CHECKING,
     Callable,
     Dict,
     List,
@@ -55,6 +56,9 @@ from pyiceberg.typedef import (
     RecursiveDict,
 )
 from pyiceberg.utils.config import Config, merge_config
+
+if TYPE_CHECKING:
+    import pyarrow as pa
 
 logger = logging.getLogger(__name__)
 
@@ -288,7 +292,7 @@ class Catalog(ABC):
     def create_table(
         self,
         identifier: Union[str, Identifier],
-        schema: Schema,
+        schema: Union[Schema, "pa.Schema"],
         location: Optional[str] = None,
         partition_spec: PartitionSpec = UNPARTITIONED_PARTITION_SPEC,
         sort_order: SortOrder = UNSORTED_SORT_ORDER,

--- a/pyiceberg/catalog/__init__.py
+++ b/pyiceberg/catalog/__init__.py
@@ -523,10 +523,10 @@ class Catalog(ABC):
         try:
             import pyarrow as pa
 
-            from pyiceberg.io.pyarrow import _ConvertToIcebergWithFreshIds, pre_order_visit_pyarrow
+            from pyiceberg.io.pyarrow import _ConvertToIcebergWithNoIds, visit_pyarrow
 
             if isinstance(schema, pa.Schema):
-                schema: Schema = pre_order_visit_pyarrow(schema, _ConvertToIcebergWithFreshIds())  # type: ignore
+                schema: Schema = visit_pyarrow(schema, _ConvertToIcebergWithNoIds())  # type: ignore
                 return schema
         except ModuleNotFoundError:
             pass

--- a/pyiceberg/catalog/dynamodb.py
+++ b/pyiceberg/catalog/dynamodb.py
@@ -17,6 +17,7 @@
 import uuid
 from time import time
 from typing import (
+    TYPE_CHECKING,
     Any,
     Dict,
     List,
@@ -56,6 +57,9 @@ from pyiceberg.table import CommitTableRequest, CommitTableResponse, Table
 from pyiceberg.table.metadata import new_table_metadata
 from pyiceberg.table.sorting import UNSORTED_SORT_ORDER, SortOrder
 from pyiceberg.typedef import EMPTY_DICT
+
+if TYPE_CHECKING:
+    import pyarrow as pa
 
 DYNAMODB_CLIENT = "dynamodb"
 
@@ -127,7 +131,7 @@ class DynamoDbCatalog(Catalog):
     def create_table(
         self,
         identifier: Union[str, Identifier],
-        schema: Schema,
+        schema: Union[Schema, "pa.Schema"],
         location: Optional[str] = None,
         partition_spec: PartitionSpec = UNPARTITIONED_PARTITION_SPEC,
         sort_order: SortOrder = UNSORTED_SORT_ORDER,
@@ -152,6 +156,14 @@ class DynamoDbCatalog(Catalog):
             ValueError: If the identifier is invalid, or no path is given to store metadata.
 
         """
+        if not isinstance(schema, Schema):
+            import pyarrow as pa
+
+            from pyiceberg.io.pyarrow import _ConvertToIcebergWithFreshIds, pre_order_visit_pyarrow
+
+            if isinstance(schema, pa.Schema):
+                schema: Schema = pre_order_visit_pyarrow(schema, _ConvertToIcebergWithFreshIds())  # type: ignore
+
         database_name, table_name = self.identifier_to_database_and_table(identifier)
 
         location = self._resolve_table_location(location, database_name, table_name)

--- a/pyiceberg/catalog/dynamodb.py
+++ b/pyiceberg/catalog/dynamodb.py
@@ -156,13 +156,7 @@ class DynamoDbCatalog(Catalog):
             ValueError: If the identifier is invalid, or no path is given to store metadata.
 
         """
-        if not isinstance(schema, Schema):
-            import pyarrow as pa
-
-            from pyiceberg.io.pyarrow import _ConvertToIcebergWithFreshIds, pre_order_visit_pyarrow
-
-            if isinstance(schema, pa.Schema):
-                schema: Schema = pre_order_visit_pyarrow(schema, _ConvertToIcebergWithFreshIds())  # type: ignore
+        schema: Schema = self._convert_schema_if_needed(schema)  # type: ignore
 
         database_name, table_name = self.identifier_to_database_and_table(identifier)
 

--- a/pyiceberg/catalog/glue.py
+++ b/pyiceberg/catalog/glue.py
@@ -358,13 +358,7 @@ class GlueCatalog(Catalog):
             ValueError: If the identifier is invalid, or no path is given to store metadata.
 
         """
-        if not isinstance(schema, Schema):
-            import pyarrow as pa
-
-            from pyiceberg.io.pyarrow import _ConvertToIcebergWithFreshIds, pre_order_visit_pyarrow
-
-            if isinstance(schema, pa.Schema):
-                schema: Schema = pre_order_visit_pyarrow(schema, _ConvertToIcebergWithFreshIds())  # type: ignore
+        schema: Schema = self._convert_schema_if_needed(schema)  # type: ignore
 
         database_name, table_name = self.identifier_to_database_and_table(identifier)
 

--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -278,13 +278,7 @@ class HiveCatalog(Catalog):
             AlreadyExistsError: If a table with the name already exists.
             ValueError: If the identifier is invalid.
         """
-        if not isinstance(schema, Schema):
-            import pyarrow as pa
-
-            from pyiceberg.io.pyarrow import _ConvertToIcebergWithFreshIds, pre_order_visit_pyarrow
-
-            if isinstance(schema, pa.Schema):
-                schema: Schema = pre_order_visit_pyarrow(schema, _ConvertToIcebergWithFreshIds())  # type: ignore
+        schema: Schema = self._convert_schema_if_needed(schema)  # type: ignore
 
         properties = {**DEFAULT_PROPERTIES, **properties}
         database_name, table_name = self.identifier_to_database_and_table(identifier)

--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -18,6 +18,7 @@ import getpass
 import time
 from types import TracebackType
 from typing import (
+    TYPE_CHECKING,
     Any,
     Dict,
     List,
@@ -90,6 +91,10 @@ from pyiceberg.types import (
     TimeType,
     UUIDType,
 )
+
+if TYPE_CHECKING:
+    import pyarrow as pa
+
 
 # Replace by visitor
 hive_types = {
@@ -250,7 +255,7 @@ class HiveCatalog(Catalog):
     def create_table(
         self,
         identifier: Union[str, Identifier],
-        schema: Schema,
+        schema: Union[Schema, "pa.Schema"],
         location: Optional[str] = None,
         partition_spec: PartitionSpec = UNPARTITIONED_PARTITION_SPEC,
         sort_order: SortOrder = UNSORTED_SORT_ORDER,
@@ -273,6 +278,14 @@ class HiveCatalog(Catalog):
             AlreadyExistsError: If a table with the name already exists.
             ValueError: If the identifier is invalid.
         """
+        if not isinstance(schema, Schema):
+            import pyarrow as pa
+
+            from pyiceberg.io.pyarrow import _ConvertToIcebergWithFreshIds, pre_order_visit_pyarrow
+
+            if isinstance(schema, pa.Schema):
+                schema: Schema = pre_order_visit_pyarrow(schema, _ConvertToIcebergWithFreshIds())  # type: ignore
+
         properties = {**DEFAULT_PROPERTIES, **properties}
         database_name, table_name = self.identifier_to_database_and_table(identifier)
         current_time_millis = int(time.time() * 1000)

--- a/pyiceberg/catalog/noop.py
+++ b/pyiceberg/catalog/noop.py
@@ -15,6 +15,7 @@
 #  specific language governing permissions and limitations
 #  under the License.
 from typing import (
+    TYPE_CHECKING,
     List,
     Optional,
     Set,
@@ -33,12 +34,15 @@ from pyiceberg.table import (
 from pyiceberg.table.sorting import UNSORTED_SORT_ORDER
 from pyiceberg.typedef import EMPTY_DICT, Identifier, Properties
 
+if TYPE_CHECKING:
+    import pyarrow as pa
+
 
 class NoopCatalog(Catalog):
     def create_table(
         self,
         identifier: Union[str, Identifier],
-        schema: Schema,
+        schema: Union[Schema, "pa.Schema"],
         location: Optional[str] = None,
         partition_spec: PartitionSpec = UNPARTITIONED_PARTITION_SPEC,
         sort_order: SortOrder = UNSORTED_SORT_ORDER,

--- a/pyiceberg/catalog/rest.py
+++ b/pyiceberg/catalog/rest.py
@@ -447,13 +447,7 @@ class RestCatalog(Catalog):
         sort_order: SortOrder = UNSORTED_SORT_ORDER,
         properties: Properties = EMPTY_DICT,
     ) -> Table:
-        if not isinstance(schema, Schema):
-            import pyarrow as pa
-
-            from pyiceberg.io.pyarrow import _ConvertToIcebergWithFreshIds, pre_order_visit_pyarrow
-
-            if isinstance(schema, pa.Schema):
-                schema: Schema = pre_order_visit_pyarrow(schema, _ConvertToIcebergWithFreshIds())  # type: ignore
+        schema: Schema = self._convert_schema_if_needed(schema)  # type: ignore
 
         namespace_and_table = self._split_identifier_for_path(identifier)
         request = CreateTableRequest(

--- a/pyiceberg/catalog/sql.py
+++ b/pyiceberg/catalog/sql.py
@@ -169,13 +169,7 @@ class SqlCatalog(Catalog):
             ValueError: If the identifier is invalid, or no path is given to store metadata.
 
         """
-        if not isinstance(schema, Schema):
-            import pyarrow as pa
-
-            from pyiceberg.io.pyarrow import _ConvertToIcebergWithFreshIds, pre_order_visit_pyarrow
-
-            if isinstance(schema, pa.Schema):
-                schema: Schema = pre_order_visit_pyarrow(schema, _ConvertToIcebergWithFreshIds())  # type: ignore
+        schema: Schema = self._convert_schema_if_needed(schema)  # type: ignore
 
         database_name, table_name = self.identifier_to_database_and_table(identifier)
         if not self._namespace_exists(database_name):

--- a/pyiceberg/catalog/sql.py
+++ b/pyiceberg/catalog/sql.py
@@ -16,6 +16,7 @@
 # under the License.
 
 from typing import (
+    TYPE_CHECKING,
     List,
     Optional,
     Set,
@@ -64,6 +65,9 @@ from pyiceberg.table import CommitTableRequest, CommitTableResponse, Table, upda
 from pyiceberg.table.metadata import new_table_metadata
 from pyiceberg.table.sorting import UNSORTED_SORT_ORDER, SortOrder
 from pyiceberg.typedef import EMPTY_DICT
+
+if TYPE_CHECKING:
+    import pyarrow as pa
 
 
 class SqlCatalogBaseTable(MappedAsDataclass, DeclarativeBase):
@@ -140,7 +144,7 @@ class SqlCatalog(Catalog):
     def create_table(
         self,
         identifier: Union[str, Identifier],
-        schema: Schema,
+        schema: Union[Schema, "pa.Schema"],
         location: Optional[str] = None,
         partition_spec: PartitionSpec = UNPARTITIONED_PARTITION_SPEC,
         sort_order: SortOrder = UNSORTED_SORT_ORDER,
@@ -165,6 +169,14 @@ class SqlCatalog(Catalog):
             ValueError: If the identifier is invalid, or no path is given to store metadata.
 
         """
+        if not isinstance(schema, Schema):
+            import pyarrow as pa
+
+            from pyiceberg.io.pyarrow import _ConvertToIcebergWithFreshIds, pre_order_visit_pyarrow
+
+            if isinstance(schema, pa.Schema):
+                schema: Schema = pre_order_visit_pyarrow(schema, _ConvertToIcebergWithFreshIds())  # type: ignore
+
         database_name, table_name = self.identifier_to_database_and_table(identifier)
         if not self._namespace_exists(database_name):
             raise NoSuchNamespaceError(f"Namespace does not exist: {database_name}")

--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -26,6 +26,7 @@ with the pyarrow library.
 from __future__ import annotations
 
 import concurrent.futures
+import itertools
 import logging
 import os
 import re
@@ -33,8 +34,7 @@ from abc import ABC, abstractmethod
 from concurrent.futures import Future
 from dataclasses import dataclass
 from enum import Enum
-from functools import lru_cache, singledispatch
-from itertools import chain
+from functools import lru_cache, partial, singledispatch
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -631,7 +631,7 @@ def _combine_positional_deletes(positional_deletes: List[pa.ChunkedArray], rows:
     if len(positional_deletes) == 1:
         all_chunks = positional_deletes[0]
     else:
-        all_chunks = pa.chunked_array(chain(*[arr.chunks for arr in positional_deletes]))
+        all_chunks = pa.chunked_array(itertools.chain(*[arr.chunks for arr in positional_deletes]))
     return np.setdiff1d(np.arange(rows), all_chunks, assume_unique=False)
 
 
@@ -711,6 +711,60 @@ def _(obj: pa.DataType, visitor: PyArrowSchemaVisitor[T]) -> T:
     return visitor.primitive(obj)
 
 
+@singledispatch
+def pre_order_visit_pyarrow(obj: Union[pa.DataType, pa.Schema], visitor: PreOrderPyArrowSchemaVisitor[T]) -> T:
+    """Apply a pyarrow schema visitor to any point within a schema.
+
+    The function traverses the schema in pre-order fashion.
+
+    Args:
+        obj (Union[pa.DataType, pa.Schema]): An instance of a Schema or an IcebergType.
+        visitor (PyArrowSchemaVisitor[T]): An instance of an implementation of the generic PyarrowSchemaVisitor base class.
+
+    Raises:
+        NotImplementedError: If attempting to visit an unrecognized object type.
+    """
+    raise NotImplementedError(f"Cannot visit non-type: {obj}")
+
+
+@pre_order_visit_pyarrow.register(pa.Schema)
+def _(obj: pa.Schema, visitor: PreOrderPyArrowSchemaVisitor[T]) -> T:
+    return visitor.schema(obj, lambda: pre_order_visit_pyarrow(pa.struct(obj), visitor))
+
+
+@pre_order_visit_pyarrow.register(pa.StructType)
+def _(obj: pa.StructType, visitor: PreOrderPyArrowSchemaVisitor[T]) -> T:
+    return visitor.struct(
+        obj,
+        [
+            partial(
+                lambda field: visitor.field(field, partial(lambda field: pre_order_visit_pyarrow(field.type, visitor), field)),
+                field,
+            )
+            for field in obj
+        ],
+    )
+
+
+@pre_order_visit_pyarrow.register(pa.ListType)
+def _(obj: pa.ListType, visitor: PreOrderPyArrowSchemaVisitor[T]) -> T:
+    return visitor.list(obj, lambda: pre_order_visit_pyarrow(obj.value_type, visitor))
+
+
+@pre_order_visit_pyarrow.register(pa.MapType)
+def _(obj: pa.MapType, visitor: PreOrderPyArrowSchemaVisitor[T]) -> T:
+    return visitor.map(
+        obj, lambda: pre_order_visit_pyarrow(obj.key_type, visitor), lambda: pre_order_visit_pyarrow(obj.item_type, visitor)
+    )
+
+
+@pre_order_visit_pyarrow.register(pa.DataType)
+def _(obj: pa.DataType, visitor: PreOrderPyArrowSchemaVisitor[T]) -> T:
+    if pa.types.is_nested(obj):
+        raise TypeError(f"Expected primitive type, got: {type(obj)}")
+    return visitor.primitive(obj)
+
+
 class PyArrowSchemaVisitor(Generic[T], ABC):
     def before_field(self, field: pa.Field) -> None:
         """Override this method to perform an action immediately before visiting a field."""
@@ -754,6 +808,32 @@ class PyArrowSchemaVisitor(Generic[T], ABC):
 
     @abstractmethod
     def map(self, map_type: pa.MapType, key_result: T, value_result: T) -> T:
+        """Visit a map."""
+
+    @abstractmethod
+    def primitive(self, primitive: pa.DataType) -> T:
+        """Visit a primitive type."""
+
+
+class PreOrderPyArrowSchemaVisitor(Generic[T], ABC):
+    @abstractmethod
+    def schema(self, schema: pa.Schema, struct_result: Callable[[], T]) -> T:
+        """Visit a schema."""
+
+    @abstractmethod
+    def struct(self, struct: pa.StructType, field_results: List[Callable[[], T]]) -> T:
+        """Visit a struct."""
+
+    @abstractmethod
+    def field(self, field: pa.Field, field_result: Callable[[], T]) -> T:
+        """Visit a field."""
+
+    @abstractmethod
+    def list(self, list_type: pa.ListType, element_result: Callable[[], T]) -> T:
+        """Visit a list."""
+
+    @abstractmethod
+    def map(self, map_type: pa.MapType, key_result: Callable[[], T], value_result: Callable[[], T]) -> T:
         """Visit a map."""
 
     @abstractmethod
@@ -906,6 +986,76 @@ class _ConvertToIceberg(PyArrowSchemaVisitor[Union[IcebergType, Schema]]):
         self._field_names.pop()
 
 
+class _ConvertToIcebergWithFreshIds(PreOrderPyArrowSchemaVisitor[Union[IcebergType, Schema]]):
+    """Converts PyArrowSchema to Iceberg Schema with fresh ids."""
+
+    def __init__(self) -> None:
+        self.counter = itertools.count(1)
+
+    def _field_id(self) -> int:
+        return next(self.counter)
+
+    def schema(self, schema: pa.Schema, struct_result: Callable[[], StructType]) -> Schema:
+        return Schema(*struct_result().fields)
+
+    def struct(self, struct: pa.StructType, field_results: List[Callable[[], NestedField]]) -> StructType:
+        return StructType(*[field() for field in field_results])
+
+    def field(self, field: pa.Field, field_result: Callable[[], IcebergType]) -> NestedField:
+        field_id = self._field_id()
+        field_doc = doc_str.decode() if (field.metadata and (doc_str := field.metadata.get(PYARROW_FIELD_DOC_KEY))) else None
+        field_type = field_result()
+        return NestedField(field_id, field.name, field_type, required=not field.nullable, doc=field_doc)
+
+    def list(self, list_type: pa.ListType, element_result: Callable[[], IcebergType]) -> ListType:
+        element_field = list_type.value_field
+        element_id = self._field_id()
+        return ListType(element_id, element_result(), element_required=not element_field.nullable)
+
+    def map(
+        self, map_type: pa.MapType, key_result: Callable[[], IcebergType], value_result: Callable[[], IcebergType]
+    ) -> MapType:
+        key_id = self._field_id()
+        value_field = map_type.item_field
+        value_id = self._field_id()
+        return MapType(key_id, key_result(), value_id, value_result(), value_required=not value_field.nullable)
+
+    def primitive(self, primitive: pa.DataType) -> PrimitiveType:
+        if pa.types.is_boolean(primitive):
+            return BooleanType()
+        elif pa.types.is_int32(primitive):
+            return IntegerType()
+        elif pa.types.is_int64(primitive):
+            return LongType()
+        elif pa.types.is_float32(primitive):
+            return FloatType()
+        elif pa.types.is_float64(primitive):
+            return DoubleType()
+        elif isinstance(primitive, pa.Decimal128Type):
+            primitive = cast(pa.Decimal128Type, primitive)
+            return DecimalType(primitive.precision, primitive.scale)
+        elif pa.types.is_string(primitive):
+            return StringType()
+        elif pa.types.is_date32(primitive):
+            return DateType()
+        elif isinstance(primitive, pa.Time64Type) and primitive.unit == "us":
+            return TimeType()
+        elif pa.types.is_timestamp(primitive):
+            primitive = cast(pa.TimestampType, primitive)
+            if primitive.unit == "us":
+                if primitive.tz == "UTC" or primitive.tz == "+00:00":
+                    return TimestamptzType()
+                elif primitive.tz is None:
+                    return TimestampType()
+        elif pa.types.is_binary(primitive):
+            return BinaryType()
+        elif pa.types.is_fixed_size_binary(primitive):
+            primitive = cast(pa.FixedSizeBinaryType, primitive)
+            return FixedType(primitive.byte_width)
+
+        raise TypeError(f"Unsupported type: {primitive}")
+
+
 def _task_to_table(
     fs: FileSystem,
     task: FileScanTask,
@@ -993,7 +1143,7 @@ def _task_to_table(
 
 def _read_all_delete_files(fs: FileSystem, tasks: Iterable[FileScanTask]) -> Dict[str, List[ChunkedArray]]:
     deletes_per_file: Dict[str, List[ChunkedArray]] = {}
-    unique_deletes = set(chain.from_iterable([task.delete_files for task in tasks]))
+    unique_deletes = set(itertools.chain.from_iterable([task.delete_files for task in tasks]))
     if len(unique_deletes) > 0:
         executor = ExecutorFactory.get_or_create()
         deletes_per_files: Iterator[Dict[str, ChunkedArray]] = executor.map(
@@ -1399,7 +1549,7 @@ class PyArrowStatisticsCollector(PreOrderSchemaVisitor[List[StatisticsCollector]
     def struct(
         self, struct: StructType, field_results: List[Callable[[], List[StatisticsCollector]]]
     ) -> List[StatisticsCollector]:
-        return list(chain(*[result() for result in field_results]))
+        return list(itertools.chain(*[result() for result in field_results]))
 
     def field(self, field: NestedField, field_result: Callable[[], List[StatisticsCollector]]) -> List[StatisticsCollector]:
         self._field_id = field.field_id
@@ -1491,7 +1641,7 @@ class ID2ParquetPathVisitor(PreOrderSchemaVisitor[List[ID2ParquetPath]]):
         return struct_result()
 
     def struct(self, struct: StructType, field_results: List[Callable[[], List[ID2ParquetPath]]]) -> List[ID2ParquetPath]:
-        return list(chain(*[result() for result in field_results]))
+        return list(itertools.chain(*[result() for result in field_results]))
 
     def field(self, field: NestedField, field_result: Callable[[], List[ID2ParquetPath]]) -> List[ID2ParquetPath]:
         self._field_id = field.field_id

--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -761,32 +761,6 @@ class PyArrowSchemaVisitor(Generic[T], ABC):
         """Visit a primitive type."""
 
 
-class PreOrderPyArrowSchemaVisitor(Generic[T], ABC):
-    @abstractmethod
-    def schema(self, schema: pa.Schema, struct_result: Callable[[], T]) -> T:
-        """Visit a schema."""
-
-    @abstractmethod
-    def struct(self, struct: pa.StructType, field_results: List[Callable[[], T]]) -> T:
-        """Visit a struct."""
-
-    @abstractmethod
-    def field(self, field: pa.Field, field_result: Callable[[], T]) -> T:
-        """Visit a field."""
-
-    @abstractmethod
-    def list(self, list_type: pa.ListType, element_result: Callable[[], T]) -> T:
-        """Visit a list."""
-
-    @abstractmethod
-    def map(self, map_type: pa.MapType, key_result: Callable[[], T], value_result: Callable[[], T]) -> T:
-        """Visit a map."""
-
-    @abstractmethod
-    def primitive(self, primitive: pa.DataType) -> T:
-        """Visit a primitive type."""
-
-
 def _get_field_id(field: pa.Field) -> Optional[int]:
     return (
         int(field_id_str.decode())
@@ -932,7 +906,7 @@ class _ConvertToIceberg(PyArrowSchemaVisitor[Union[IcebergType, Schema]]):
         self._field_names.pop()
 
 
-class _ConvertToIcebergWithNoIds(_ConvertToIceberg):
+class _ConvertToIcebergWithoutIDs(_ConvertToIceberg):
     """
     Converts PyArrowSchema to Iceberg Schema with all -1 ids.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -311,7 +311,7 @@ select = [
     "I", # isort
     "UP", # pyupgrade
 ]
-ignore = ["E501","E203","B024","B028"]
+ignore = ["E501","E203","B024","B028","UP037"]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]

--- a/tests/catalog/test_base.py
+++ b/tests/catalog/test_base.py
@@ -26,6 +26,7 @@ from typing import (
 
 import pyarrow as pa
 import pytest
+from pytest_lazyfixture import lazy_fixture
 
 from pyiceberg.catalog import (
     Catalog,
@@ -334,19 +335,19 @@ def test_create_table(catalog: InMemoryCatalog) -> None:
 
 
 @pytest.mark.parametrize(
-    "schema_fixture,expected_fixture",
+    "schema,expected",
     [
-        ("pyarrow_schema_simple_without_ids", "iceberg_schema_simple"),
-        ("iceberg_schema_simple", "iceberg_schema_simple"),
-        ("iceberg_schema_nested", "iceberg_schema_nested"),
-        ("pyarrow_schema_nested_without_ids", "iceberg_schema_nested"),
+        (lazy_fixture("pyarrow_schema_simple_without_ids"), lazy_fixture("iceberg_schema_simple_no_ids")),
+        (lazy_fixture("iceberg_schema_simple"), lazy_fixture("iceberg_schema_simple")),
+        (lazy_fixture("iceberg_schema_nested"), lazy_fixture("iceberg_schema_nested")),
+        (lazy_fixture("pyarrow_schema_nested_without_ids"), lazy_fixture("iceberg_schema_nested_no_ids")),
     ],
 )
 def test_convert_schema_if_needed(
-    schema_fixture: str, expected_fixture: str, catalog: InMemoryCatalog, request: pytest.FixtureRequest
+    schema: Union[Schema, pa.Schema],
+    expected: Schema,
+    catalog: InMemoryCatalog,
 ) -> None:
-    schema = request.getfixturevalue(schema_fixture)
-    expected = request.getfixturevalue(expected_fixture)
     assert expected == catalog._convert_schema_if_needed(schema)
 
 

--- a/tests/catalog/test_base.py
+++ b/tests/catalog/test_base.py
@@ -258,10 +258,6 @@ def catalog() -> InMemoryCatalog:
     return InMemoryCatalog("test.in.memory.catalog", **{"test.key": "test.value"})
 
 
-TEST_PYARROW_SCHEMA = pa.schema([
-    pa.field('some_int', pa.int32(), nullable=True),
-    pa.field('some_string', pa.string(), nullable=False),
-])
 TEST_TABLE_IDENTIFIER = ("com", "organization", "department", "my_table")
 TEST_TABLE_NAMESPACE = ("com", "organization", "department")
 TEST_TABLE_NAME = "my_table"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,7 @@ from typing import (
 from urllib.parse import urlparse
 
 import boto3
+import pyarrow as pa
 import pytest
 from moto import mock_dynamodb, mock_glue
 from moto.server import ThreadedMotoServer  # type: ignore
@@ -264,6 +265,120 @@ def table_schema_nested_with_struct_key_map() -> Schema:
         NestedField(field_id=29, name="double", field_type=DoubleType(), required=True),
         schema_id=1,
         identifier_field_ids=[1],
+    )
+
+
+@pytest.fixture(scope="session")
+def pyarrow_schema_simple_without_ids() -> pa.Schema:
+    return pa.schema([
+        pa.field('foo', pa.string(), nullable=True),
+        pa.field('bar', pa.int32(), nullable=False),
+        pa.field('baz', pa.bool_(), nullable=True),
+    ])
+
+
+@pytest.fixture(scope="session")
+def pyarrow_schema_nested_without_ids() -> pa.Schema:
+    return pa.schema([
+        pa.field('foo', pa.string(), nullable=False),
+        pa.field('bar', pa.int32(), nullable=False),
+        pa.field('baz', pa.bool_(), nullable=True),
+        pa.field('qux', pa.list_(pa.string()), nullable=False),
+        pa.field(
+            'quux',
+            pa.map_(
+                pa.string(),
+                pa.map_(pa.string(), pa.int32()),
+            ),
+            nullable=False,
+        ),
+        pa.field(
+            'location',
+            pa.list_(
+                pa.struct([
+                    pa.field('latitude', pa.float32(), nullable=False),
+                    pa.field('longitude', pa.float32(), nullable=False),
+                ]),
+            ),
+            nullable=False,
+        ),
+        pa.field(
+            'person',
+            pa.struct([
+                pa.field('name', pa.string(), nullable=True),
+                pa.field('age', pa.int32(), nullable=False),
+            ]),
+            nullable=True,
+        ),
+    ])
+
+
+@pytest.fixture(scope="session")
+def iceberg_schema_simple() -> Schema:
+    return Schema(
+        NestedField(field_id=1, name="foo", field_type=StringType(), required=False),
+        NestedField(field_id=2, name="bar", field_type=IntegerType(), required=True),
+        NestedField(field_id=3, name="baz", field_type=BooleanType(), required=False),
+    )
+
+
+@pytest.fixture(scope="session")
+def iceberg_table_schema_simple() -> Schema:
+    return Schema(
+        NestedField(field_id=1, name="foo", field_type=StringType(), required=False),
+        NestedField(field_id=2, name="bar", field_type=IntegerType(), required=True),
+        NestedField(field_id=3, name="baz", field_type=BooleanType(), required=False),
+        schema_id=0,
+        identifier_field_ids=[],
+    )
+
+
+@pytest.fixture(scope="session")
+def iceberg_schema_nested() -> Schema:
+    return Schema(
+        NestedField(field_id=1, name="foo", field_type=StringType(), required=True),
+        NestedField(field_id=2, name="bar", field_type=IntegerType(), required=True),
+        NestedField(field_id=3, name="baz", field_type=BooleanType(), required=False),
+        NestedField(
+            field_id=4,
+            name="qux",
+            field_type=ListType(element_id=5, element_type=StringType(), element_required=False),
+            required=True,
+        ),
+        NestedField(
+            field_id=6,
+            name="quux",
+            field_type=MapType(
+                key_id=7,
+                key_type=StringType(),
+                value_id=8,
+                value_type=MapType(key_id=9, key_type=StringType(), value_id=10, value_type=IntegerType(), value_required=False),
+                value_required=False,
+            ),
+            required=True,
+        ),
+        NestedField(
+            field_id=11,
+            name="location",
+            field_type=ListType(
+                element_id=12,
+                element_type=StructType(
+                    NestedField(field_id=13, name="latitude", field_type=FloatType(), required=True),
+                    NestedField(field_id=14, name="longitude", field_type=FloatType(), required=True),
+                ),
+                element_required=False,
+            ),
+            required=True,
+        ),
+        NestedField(
+            field_id=15,
+            name="person",
+            field_type=StructType(
+                NestedField(field_id=16, name="name", field_type=StringType(), required=False),
+                NestedField(field_id=17, name="age", field_type=IntegerType(), required=True),
+            ),
+            required=False,
+        ),
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -323,6 +323,15 @@ def iceberg_schema_simple() -> Schema:
 
 
 @pytest.fixture(scope="session")
+def iceberg_schema_simple_no_ids() -> Schema:
+    return Schema(
+        NestedField(field_id=-1, name="foo", field_type=StringType(), required=False),
+        NestedField(field_id=-1, name="bar", field_type=IntegerType(), required=True),
+        NestedField(field_id=-1, name="baz", field_type=BooleanType(), required=False),
+    )
+
+
+@pytest.fixture(scope="session")
 def iceberg_table_schema_simple() -> Schema:
     return Schema(
         NestedField(field_id=1, name="foo", field_type=StringType(), required=False),
@@ -376,6 +385,55 @@ def iceberg_schema_nested() -> Schema:
             field_type=StructType(
                 NestedField(field_id=16, name="name", field_type=StringType(), required=False),
                 NestedField(field_id=17, name="age", field_type=IntegerType(), required=True),
+            ),
+            required=False,
+        ),
+    )
+
+
+@pytest.fixture(scope="session")
+def iceberg_schema_nested_no_ids() -> Schema:
+    return Schema(
+        NestedField(field_id=-1, name="foo", field_type=StringType(), required=True),
+        NestedField(field_id=-1, name="bar", field_type=IntegerType(), required=True),
+        NestedField(field_id=-1, name="baz", field_type=BooleanType(), required=False),
+        NestedField(
+            field_id=-1,
+            name="qux",
+            field_type=ListType(element_id=-1, element_type=StringType(), element_required=False),
+            required=True,
+        ),
+        NestedField(
+            field_id=-1,
+            name="quux",
+            field_type=MapType(
+                key_id=-1,
+                key_type=StringType(),
+                value_id=-1,
+                value_type=MapType(key_id=-1, key_type=StringType(), value_id=-1, value_type=IntegerType(), value_required=False),
+                value_required=False,
+            ),
+            required=True,
+        ),
+        NestedField(
+            field_id=-1,
+            name="location",
+            field_type=ListType(
+                element_id=-1,
+                element_type=StructType(
+                    NestedField(field_id=-1, name="latitude", field_type=FloatType(), required=True),
+                    NestedField(field_id=-1, name="longitude", field_type=FloatType(), required=True),
+                ),
+                element_required=False,
+            ),
+            required=True,
+        ),
+        NestedField(
+            field_id=-1,
+            name="person",
+            field_type=StructType(
+                NestedField(field_id=-1, name="name", field_type=StringType(), required=False),
+                NestedField(field_id=-1, name="age", field_type=IntegerType(), required=True),
             ),
             required=False,
         ),

--- a/tests/io/test_pyarrow_visitor.py
+++ b/tests/io/test_pyarrow_visitor.py
@@ -23,7 +23,7 @@ import pytest
 from pyiceberg.io.pyarrow import (
     _ConvertToArrowSchema,
     _ConvertToIceberg,
-    _ConvertToIcebergWithNoIds,
+    _ConvertToIcebergWithoutIDs,
     _HasIds,
     pyarrow_to_schema,
     schema_to_pyarrow,
@@ -481,10 +481,10 @@ def test_pyarrow_schema_to_schema_missing_ids_using_name_mapping_nested_missing_
 def test_pyarrow_schema_to_schema_fresh_ids_simple_schema(
     pyarrow_schema_simple_without_ids: pa.Schema, iceberg_schema_simple_no_ids: Schema
 ) -> None:
-    assert visit_pyarrow(pyarrow_schema_simple_without_ids, _ConvertToIcebergWithNoIds()) == iceberg_schema_simple_no_ids
+    assert visit_pyarrow(pyarrow_schema_simple_without_ids, _ConvertToIcebergWithoutIDs()) == iceberg_schema_simple_no_ids
 
 
 def test_pyarrow_schema_to_schema_fresh_ids_nested_schema(
     pyarrow_schema_nested_without_ids: pa.Schema, iceberg_schema_nested_no_ids: Schema
 ) -> None:
-    assert visit_pyarrow(pyarrow_schema_nested_without_ids, _ConvertToIcebergWithNoIds()) == iceberg_schema_nested_no_ids
+    assert visit_pyarrow(pyarrow_schema_nested_without_ids, _ConvertToIcebergWithoutIDs()) == iceberg_schema_nested_no_ids

--- a/tests/io/test_pyarrow_visitor.py
+++ b/tests/io/test_pyarrow_visitor.py
@@ -23,7 +23,9 @@ import pytest
 from pyiceberg.io.pyarrow import (
     _ConvertToArrowSchema,
     _ConvertToIceberg,
+    _ConvertToIcebergWithFreshIds,
     _HasIds,
+    pre_order_visit_pyarrow,
     pyarrow_to_schema,
     schema_to_pyarrow,
     visit_pyarrow,
@@ -49,104 +51,6 @@ from pyiceberg.types import (
     TimestamptzType,
     TimeType,
 )
-
-
-@pytest.fixture(scope="module")
-def pyarrow_schema_simple_without_ids() -> pa.Schema:
-    return pa.schema([pa.field('some_int', pa.int32(), nullable=True), pa.field('some_string', pa.string(), nullable=False)])
-
-
-@pytest.fixture(scope="module")
-def pyarrow_schema_nested_without_ids() -> pa.Schema:
-    return pa.schema([
-        pa.field('foo', pa.string(), nullable=False),
-        pa.field('bar', pa.int32(), nullable=False),
-        pa.field('baz', pa.bool_(), nullable=True),
-        pa.field('qux', pa.list_(pa.string()), nullable=False),
-        pa.field(
-            'quux',
-            pa.map_(
-                pa.string(),
-                pa.map_(pa.string(), pa.int32()),
-            ),
-            nullable=False,
-        ),
-        pa.field(
-            'location',
-            pa.list_(
-                pa.struct([
-                    pa.field('latitude', pa.float32(), nullable=False),
-                    pa.field('longitude', pa.float32(), nullable=False),
-                ]),
-            ),
-            nullable=False,
-        ),
-        pa.field(
-            'person',
-            pa.struct([
-                pa.field('name', pa.string(), nullable=True),
-                pa.field('age', pa.int32(), nullable=False),
-            ]),
-            nullable=True,
-        ),
-    ])
-
-
-@pytest.fixture(scope="module")
-def iceberg_schema_simple() -> Schema:
-    return Schema(
-        NestedField(field_id=1, name="some_int", field_type=IntegerType(), required=False),
-        NestedField(field_id=2, name="some_string", field_type=StringType(), required=True),
-    )
-
-
-@pytest.fixture(scope="module")
-def iceberg_schema_nested() -> Schema:
-    return Schema(
-        NestedField(field_id=1, name="foo", field_type=StringType(), required=True),
-        NestedField(field_id=2, name="bar", field_type=IntegerType(), required=True),
-        NestedField(field_id=3, name="baz", field_type=BooleanType(), required=False),
-        NestedField(
-            field_id=4,
-            name="qux",
-            field_type=ListType(element_id=5, element_type=StringType(), element_required=False),
-            required=True,
-        ),
-        NestedField(
-            field_id=6,
-            name="quux",
-            field_type=MapType(
-                key_id=7,
-                key_type=StringType(),
-                value_id=8,
-                value_type=MapType(key_id=9, key_type=StringType(), value_id=10, value_type=IntegerType(), value_required=False),
-                value_required=False,
-            ),
-            required=True,
-        ),
-        NestedField(
-            field_id=11,
-            name="location",
-            field_type=ListType(
-                element_id=12,
-                element_type=StructType(
-                    NestedField(field_id=13, name="latitude", field_type=FloatType(), required=True),
-                    NestedField(field_id=14, name="longitude", field_type=FloatType(), required=True),
-                ),
-                element_required=False,
-            ),
-            required=True,
-        ),
-        NestedField(
-            field_id=15,
-            name="person",
-            field_type=StructType(
-                NestedField(field_id=16, name="name", field_type=StringType(), required=False),
-                NestedField(field_id=17, name="age", field_type=IntegerType(), required=True),
-            ),
-            required=False,
-        ),
-    )
 
 
 def test_pyarrow_binary_to_iceberg() -> None:
@@ -468,8 +372,9 @@ def test_simple_pyarrow_schema_to_schema_missing_ids_using_name_mapping(
 ) -> None:
     schema = pyarrow_schema_simple_without_ids
     name_mapping = NameMapping([
-        MappedField(field_id=1, names=['some_int']),
-        MappedField(field_id=2, names=['some_string']),
+        MappedField(field_id=1, names=['foo']),
+        MappedField(field_id=2, names=['bar']),
+        MappedField(field_id=3, names=['baz']),
     ])
 
     assert pyarrow_to_schema(schema, name_mapping) == iceberg_schema_simple
@@ -480,11 +385,11 @@ def test_simple_pyarrow_schema_to_schema_missing_ids_using_name_mapping_partial_
 ) -> None:
     schema = pyarrow_schema_simple_without_ids
     name_mapping = NameMapping([
-        MappedField(field_id=1, names=['some_string']),
+        MappedField(field_id=1, names=['foo']),
     ])
     with pytest.raises(ValueError) as exc_info:
         _ = pyarrow_to_schema(schema, name_mapping)
-    assert "Could not find field with name: some_int" in str(exc_info.value)
+    assert "Could not find field with name: bar" in str(exc_info.value)
 
 
 def test_nested_pyarrow_schema_to_schema_missing_ids_using_name_mapping(
@@ -572,3 +477,15 @@ def test_pyarrow_schema_to_schema_missing_ids_using_name_mapping_nested_missing_
     with pytest.raises(ValueError) as exc_info:
         _ = pyarrow_to_schema(schema, name_mapping)
     assert "Could not find field with name: quux.value.key" in str(exc_info.value)
+
+
+def test_pyarrow_schema_to_schema_fresh_ids_simple_schema(
+    pyarrow_schema_simple_without_ids: pa.Schema, iceberg_schema_simple: Schema
+) -> None:
+    assert pre_order_visit_pyarrow(pyarrow_schema_simple_without_ids, _ConvertToIcebergWithFreshIds()) == iceberg_schema_simple
+
+
+def test_pyarrow_schema_to_schema_fresh_ids_nested_schema(
+    pyarrow_schema_nested_without_ids: pa.Schema, iceberg_schema_nested: Schema
+) -> None:
+    assert pre_order_visit_pyarrow(pyarrow_schema_nested_without_ids, _ConvertToIcebergWithFreshIds()) == iceberg_schema_nested

--- a/tests/io/test_pyarrow_visitor.py
+++ b/tests/io/test_pyarrow_visitor.py
@@ -23,9 +23,8 @@ import pytest
 from pyiceberg.io.pyarrow import (
     _ConvertToArrowSchema,
     _ConvertToIceberg,
-    _ConvertToIcebergWithFreshIds,
+    _ConvertToIcebergWithNoIds,
     _HasIds,
-    pre_order_visit_pyarrow,
     pyarrow_to_schema,
     schema_to_pyarrow,
     visit_pyarrow,
@@ -480,12 +479,12 @@ def test_pyarrow_schema_to_schema_missing_ids_using_name_mapping_nested_missing_
 
 
 def test_pyarrow_schema_to_schema_fresh_ids_simple_schema(
-    pyarrow_schema_simple_without_ids: pa.Schema, iceberg_schema_simple: Schema
+    pyarrow_schema_simple_without_ids: pa.Schema, iceberg_schema_simple_no_ids: Schema
 ) -> None:
-    assert pre_order_visit_pyarrow(pyarrow_schema_simple_without_ids, _ConvertToIcebergWithFreshIds()) == iceberg_schema_simple
+    assert visit_pyarrow(pyarrow_schema_simple_without_ids, _ConvertToIcebergWithNoIds()) == iceberg_schema_simple_no_ids
 
 
 def test_pyarrow_schema_to_schema_fresh_ids_nested_schema(
-    pyarrow_schema_nested_without_ids: pa.Schema, iceberg_schema_nested: Schema
+    pyarrow_schema_nested_without_ids: pa.Schema, iceberg_schema_nested_no_ids: Schema
 ) -> None:
-    assert pre_order_visit_pyarrow(pyarrow_schema_nested_without_ids, _ConvertToIcebergWithFreshIds()) == iceberg_schema_nested
+    assert visit_pyarrow(pyarrow_schema_nested_without_ids, _ConvertToIcebergWithNoIds()) == iceberg_schema_nested_no_ids


### PR DESCRIPTION
This addresses: https://github.com/apache/iceberg-python/issues/278

Added `UP037 [*] Remove quotes from type annotation` to ruff in order to support [Forward References: PEP-484](https://peps.python.org/pep-0484/#forward-references)

As discussed in the issue, we are proposing to update the create_table API to:
```
    def create_table(
        self,
        identifier: Union[str, Identifier],
        schema: Union[Schema, "pa.Schema"],
        location: Optional[str] = None,
        partition_spec: PartitionSpec = UNPARTITIONED_PARTITION_SPEC,
        sort_order: SortOrder = UNSORTED_SORT_ORDER,
        properties: Properties = EMPTY_DICT,
    ) -> Table:
    ...
    if isinstance(schema, pa.Schema):
        schema = pre_order_visit_pyarrow(schema, _ConvertToIcebergWithFreshIds())
    ...
    # existing code
```

We will call the function like:
```
table: pa.Table
catalog = load_catalog()
catalog.create_table('some.table', schema=table.schema)
```

And use the previously proposed Visitor: https://github.com/syun64/iceberg-python/blob/preorder-fresh-schema/pyiceberg/io/pyarrow.py#L994 since [new_table_metadata](https://github.com/apache/iceberg-python/blob/46b25be424d1ef0f28778b0873c4d91bf117a2a7/pyiceberg/table/metadata.py#L399) has to take `field_id`ed Iceberg Schema as the input.