### PR TITLE
Refactor to write APIs to default to `main` branch 

### DIFF
--- a/pyiceberg/cli/console.py
+++ b/pyiceberg/cli/console.py
@@ -32,7 +32,7 @@ from pyiceberg import __version__
 from pyiceberg.catalog import Catalog, load_catalog
 from pyiceberg.cli.output import ConsoleOutput, JsonOutput, Output
 from pyiceberg.exceptions import NoSuchNamespaceError, NoSuchPropertyException, NoSuchTableError
-from pyiceberg.table.refs import SnapshotRef
+from pyiceberg.table.refs import SnapshotRef, SnapshotRefType
 
 DEFAULT_MIN_SNAPSHOTS_TO_KEEP = 1
 DEFAULT_MAX_SNAPSHOT_AGE_MS = 432000000
@@ -388,7 +388,7 @@ def list_refs(ctx: Context, identifier: str, type: str, verbose: bool) -> None:
     refs = table.refs()
     if type:
         type = type.lower()
-        if type not in {"branch", "tag"}:
+        if type not in {SnapshotRefType.BRANCH, SnapshotRefType.TAG}:
             raise ValueError(f"Type must be either branch or tag, got: {type}")
 
     relevant_refs = [
@@ -402,7 +402,7 @@ def list_refs(ctx: Context, identifier: str, type: str, verbose: bool) -> None:
 
 def _retention_properties(ref: SnapshotRef, table_properties: Dict[str, str]) -> Dict[str, str]:
     retention_properties = {}
-    if ref.snapshot_ref_type == "branch":
+    if ref.snapshot_ref_type == SnapshotRefType.BRANCH:
         default_min_snapshots_to_keep = table_properties.get(
             "history.expire.min-snapshots-to-keep", DEFAULT_MIN_SNAPSHOTS_TO_KEEP
         )

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -90,7 +90,7 @@ from pyiceberg.table.name_mapping import (
     create_mapping_from_schema,
     parse_mapping_from_json,
 )
-from pyiceberg.table.refs import MAIN_BRANCH, SnapshotRef
+from pyiceberg.table.refs import MAIN_BRANCH, SnapshotRef, SnapshotRefType
 from pyiceberg.table.snapshots import (
     Operation,
     Snapshot,
@@ -391,7 +391,7 @@ class AddSnapshotUpdate(TableUpdate):
 class SetSnapshotRefUpdate(TableUpdate):
     action: TableUpdateAction = TableUpdateAction.set_snapshot_ref
     ref_name: str = Field(alias="ref-name")
-    type: Literal["tag", "branch"]
+    type: Literal[SnapshotRefType.TAG, SnapshotRefType.BRANCH]
     snapshot_id: int = Field(alias="snapshot-id")
     max_ref_age_ms: Annotated[Optional[int], Field(alias="max-ref-age-ms", default=None)]
     max_snapshot_age_ms: Annotated[Optional[int], Field(alias="max-snapshot-age-ms", default=None)]
@@ -2445,7 +2445,10 @@ class _MergingSnapshotProducer:
         with self._table.transaction() as tx:
             tx.add_snapshot(snapshot=snapshot)
             tx.set_ref_snapshot(
-                snapshot_id=self._snapshot_id, parent_snapshot_id=self._parent_snapshot_id, ref_name=MAIN_BRANCH, type="branch"
+                snapshot_id=self._snapshot_id,
+                parent_snapshot_id=self._parent_snapshot_id,
+                ref_name=MAIN_BRANCH,
+                type=SnapshotRefType.BRANCH,
             )
 
         return snapshot

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -269,7 +269,7 @@ class Transaction:
             )
         )
 
-        self._append_requirements(AssertRefSnapshotId(snapshot_id=parent_snapshot_id, ref="main"))
+        self._append_requirements(AssertRefSnapshotId(snapshot_id=parent_snapshot_id, ref=MAIN_BRANCH))
         return self
 
     def update_schema(self) -> UpdateSchema:
@@ -2445,7 +2445,7 @@ class _MergingSnapshotProducer:
         with self._table.transaction() as tx:
             tx.add_snapshot(snapshot=snapshot)
             tx.set_ref_snapshot(
-                snapshot_id=self._snapshot_id, parent_snapshot_id=self._parent_snapshot_id, ref_name="main", type="branch"
+                snapshot_id=self._snapshot_id, parent_snapshot_id=self._parent_snapshot_id, ref_name=MAIN_BRANCH, type="branch"
             )
 
         return snapshot


### PR DESCRIPTION
Issue #306 (Support writing to a branch)

First pass. 
This PR
* Update string literals (`"main"`/`"branch"`/`"tag"`) to its corresponding constant. String literals in tests are left alone.
* Default `append` and `overwrite` API to the `"main"` branch and pass the variable all the way down