### PR TITLE
Use `.read_bytes()` instead

### DIFF
--- a/pyiceberg/avro/file.py
+++ b/pyiceberg/avro/file.py
@@ -194,8 +194,7 @@ class AvroFile(Generic[D]):
                 raise ValueError(f"Expected sync bytes {self.header.sync!r}, but got {sync_marker!r}")
         block_records = self.decoder.read_int()
 
-        block_bytes_len = self.decoder.read_int()
-        block_bytes = self.decoder.read(block_bytes_len)
+        block_bytes = self.decoder.read_bytes()
         if codec := self.header.compression_codec():
             block_bytes = codec.decompress(block_bytes)
 


### PR DESCRIPTION
Noticed this while profiling. This simplifies the code a bit.