### PR TITLE
Add PyArrow for the Cython decoder tests

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -68,7 +68,7 @@ jobs:
           CIBW_ARCHS: "auto64"
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8,<3.12"
           CIBW_TEST_REQUIRES: "pytest==7.4.2 moto==4.2.2"
-          CIBW_TEST_EXTRAS: "s3fs,glue"
+          CIBW_TEST_EXTRAS: "s3fs,glue,pyarrow"
           CIBW_TEST_COMMAND: "pytest {project}/tests/avro/test_decoder.py"
           # There is an upstream issue with installing on MacOSX
           # https://github.com/pypa/cibuildwheel/issues/1603


### PR DESCRIPTION
We now include PyArrow in the `conftest.py`: https://github.com/apache/iceberg-python/actions/runs/7716469604