### PR TITLE
The name needs to be unique per run

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -82,5 +82,5 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: "release-${{ github.event.inputs.version }}"
+          name: "release-${{ matrix.os }}-${{ github.event.inputs.version }}"
           path: ./wheelhouse/*


### PR DESCRIPTION
The build failed: https://github.com/apache/iceberg-python/actions/runs/7717856635/job/21037867863
```
Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```