### PR TITLE
Allow running the Avro decoder tests without Arrow

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -68,7 +68,7 @@ jobs:
           CIBW_ARCHS: "auto64"
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8,<3.12"
           CIBW_TEST_REQUIRES: "pytest==7.4.2 moto==4.2.2"
-          CIBW_TEST_EXTRAS: "s3fs,glue,pyarrow"
+          CIBW_TEST_EXTRAS: "s3fs,glue"
           CIBW_TEST_COMMAND: "pytest {project}/tests/avro/test_decoder.py"
           # There is an upstream issue with installing on MacOSX
           # https://github.com/pypa/cibuildwheel/issues/1603

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,9 +62,10 @@ from pyiceberg.io import (
     load_file_io,
 )
 from pyiceberg.io.fsspec import FsspecFileIO
+from pyiceberg.manifest import DataFile, FileFormat
 from pyiceberg.schema import Accessor, Schema
 from pyiceberg.serializers import ToOutputFile
-from pyiceberg.table import Table
+from pyiceberg.table import FileScanTask, Table
 from pyiceberg.table.metadata import TableMetadataV1, TableMetadataV2
 from pyiceberg.types import (
     BinaryType,
@@ -1902,6 +1903,28 @@ def clean_up(test_catalog: Catalog) -> None:
             for identifier in test_catalog.list_tables(database_name):
                 test_catalog.purge_table(identifier)
             test_catalog.drop_namespace(database_name)
+
+
+@pytest.fixture
+def data_file(table_schema_simple: Schema, tmp_path: str) -> str:
+    import pyarrow as pa
+    from pyarrow import parquet as pq
+
+    table = pa.table(
+        {"foo": ["a", "b", "c"], "bar": [1, 2, 3], "baz": [True, False, None]},
+        metadata={"iceberg.schema": table_schema_simple.model_dump_json()},
+    )
+
+    file_path = f"{tmp_path}/0000-data.parquet"
+    pq.write_table(table=table, where=file_path)
+    return file_path
+
+
+@pytest.fixture
+def example_task(data_file: str) -> FileScanTask:
+    return FileScanTask(
+        data_file=DataFile(file_path=data_file, file_format=FileFormat.PARQUET, file_size_in_bytes=1925),
+    )
 
 
 @pytest.fixture

--- a/tests/io/test_pyarrow.py
+++ b/tests/io/test_pyarrow.py
@@ -92,28 +92,6 @@ from pyiceberg.types import (
 )
 
 
-@pytest.fixture
-def data_file(table_schema_simple: Schema, tmp_path: str) -> str:
-    import pyarrow as pa
-    from pyarrow import parquet as pq
-
-    table = pa.table(
-        {"foo": ["a", "b", "c"], "bar": [1, 2, 3], "baz": [True, False, None]},
-        metadata={"iceberg.schema": table_schema_simple.model_dump_json()},
-    )
-
-    file_path = f"{tmp_path}/0000-data.parquet"
-    pq.write_table(table=table, where=file_path)
-    return file_path
-
-
-@pytest.fixture
-def example_task(data_file: str) -> FileScanTask:
-    return FileScanTask(
-        data_file=DataFile(file_path=data_file, file_format=FileFormat.PARQUET, file_size_in_bytes=1925),
-    )
-
-
 def test_pyarrow_infer_local_fs_from_path() -> None:
     """Test path with `file` scheme and no scheme both use LocalFileSystem"""
     assert isinstance(PyArrowFileIO().new_output("file://tmp/warehouse")._filesystem, LocalFileSystem)


### PR DESCRIPTION
It looks like PyArrow binaries are not available for all architectures, and therefore it tries to compile it locally when it isn't available.

We want to avoid this since Arrow requires a rather complicated build chain.