### PR TITLE
Remove sort-order constraint

### DIFF
--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -1735,7 +1735,10 @@ def write_file(table: Table, tasks: Iterator[WriteTask]) -> Iterator[DataFile]:
         file_format=FileFormat.PARQUET,
         partition=Record(),
         file_size_in_bytes=len(fo),
-        sort_order_id=task.sort_order_id,
+        # After this has been fixed:
+        # https://github.com/apache/iceberg-python/issues/271
+        # sort_order_id=task.sort_order_id,
+        sort_order_id=None,
         # Just copy these from the table for now
         spec_id=table.spec().spec_id,
         equality_ids=None,

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -943,9 +943,6 @@ class Table:
         if len(self.spec().fields) > 0:
             raise ValueError("Cannot write to partitioned tables")
 
-        if len(self.sort_order().fields) > 0:
-            raise ValueError("Cannot write to tables with a sort-order")
-
         data_files = _dataframe_to_data_files(self, df=df)
         merge = _MergingSnapshotProducer(operation=Operation.APPEND, table=self)
         for data_file in data_files:
@@ -975,9 +972,6 @@ class Table:
 
         if len(self.spec().fields) > 0:
             raise ValueError("Cannot write to partitioned tables")
-
-        if len(self.sort_order().fields) > 0:
-            raise ValueError("Cannot write to tables with a sort-order")
 
         data_files = _dataframe_to_data_files(self, df=df)
         merge = _MergingSnapshotProducer(
@@ -2278,9 +2272,6 @@ def _dataframe_to_data_files(table: Table, df: pa.Table) -> Iterable[DataFile]:
 
     if len(table.spec().fields) > 0:
         raise ValueError("Cannot write to partitioned tables")
-
-    if len(table.sort_order().fields) > 0:
-        raise ValueError("Cannot write to tables with a sort-order")
 
     write_uuid = uuid.uuid4()
     counter = itertools.count(0)


### PR DESCRIPTION
We currently don't set the sort-order id, which means unsorted:

> If sort order ID is missing or unknown, then the order is assumed to be unsorted.

From the spec. We don't set the sort-order, since it is optional.

If you have a process that compacts the data, that will take care of the sorting.