### PR TITLE
Bug fix for writing empty df or null only columns

### DIFF
--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -1339,7 +1339,10 @@ class StatsAggregator:
     def update_max(self, val: Any) -> None:
         self.current_max = val if self.current_max is None else max(val, self.current_max)
 
-    def min_as_bytes(self) -> bytes:
+    def min_as_bytes(self) -> Optional[bytes]:
+        if self.current_min is None:
+            return None
+
         return self.serialize(
             self.current_min
             if self.trunc_length is None

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -982,14 +982,14 @@ class Table:
         if len(self.sort_order().fields) > 0:
             raise ValueError("Cannot write to tables with a sort-order")
 
-        data_files = _dataframe_to_data_files(self, df=df)
         merge = _MergingSnapshotProducer(
             operation=Operation.OVERWRITE if self.current_snapshot() is not None else Operation.APPEND,
             table=self,
         )
-
-        for data_file in data_files:
-            merge.append_data_file(data_file)
+        if df.shape[0] > 0:
+            data_files = _dataframe_to_data_files(self, df=df)
+            for data_file in data_files:
+                merge.append_data_file(data_file)
 
         merge.commit()
 

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -946,10 +946,13 @@ class Table:
         if len(self.sort_order().fields) > 0:
             raise ValueError("Cannot write to tables with a sort-order")
 
-        data_files = _dataframe_to_data_files(self, df=df)
         merge = _MergingSnapshotProducer(operation=Operation.APPEND, table=self)
-        for data_file in data_files:
-            merge.append_data_file(data_file)
+
+        # skip writing data files if the dataframe is empty
+        if df.shape[0] > 0:
+            data_files = _dataframe_to_data_files(self, df=df)
+            for data_file in data_files:
+                merge.append_data_file(data_file)
 
         merge.commit()
 


### PR DESCRIPTION
There's two different flavors to this edge case:
1. Handling of Null only columns on write
2. Support for writing empty tables / dataframes that behaves consistently with Spark

Resolves https://github.com/apache/iceberg-python/issues/337
Resolves https://github.com/apache/iceberg-python/issues/348