### PR TITLE
fix postgres catalog initialization when tables do not exist

### DIFF
--- a/pyiceberg/catalog/sql.py
+++ b/pyiceberg/catalog/sql.py
@@ -32,7 +32,7 @@ from sqlalchemy import (
     union,
     update,
 )
-from sqlalchemy.exc import IntegrityError, NoResultFound, OperationalError
+from sqlalchemy.exc import IntegrityError, NoResultFound, OperationalError, ProgrammingError
 from sqlalchemy.orm import (
     DeclarativeBase,
     Mapped,
@@ -111,7 +111,7 @@ class SqlCatalog(Catalog):
                 stmt = select(1).select_from(table)
                 try:
                     session.scalar(stmt)
-                except OperationalError:
+                except (OperationalError, ProgrammingError): # sqlalchemy returns OperationalError in case of sqlite and ProgrammingError with postgres.
                     self.create_tables()
                     return
 

--- a/pyiceberg/catalog/sql.py
+++ b/pyiceberg/catalog/sql.py
@@ -111,7 +111,10 @@ class SqlCatalog(Catalog):
                 stmt = select(1).select_from(table)
                 try:
                     session.scalar(stmt)
-                except (OperationalError, ProgrammingError): # sqlalchemy returns OperationalError in case of sqlite and ProgrammingError with postgres.
+                except (
+                    OperationalError,
+                    ProgrammingError,
+                ):  # sqlalchemy returns OperationalError in case of sqlite and ProgrammingError with postgres.
                     self.create_tables()
                     return
 


### PR DESCRIPTION
When sqlalchemy encounters an error if the table does not exist, it raises a different exception from sqlite. Hence, when using postgres, it is not possible to even create the catalog, as the exception is not handled (and therefore, we will not be able to do `catalog.create_tables()` either). I am able to reproduce this in tests with a postgres docker container, so I can incorporate that into these tests as another parameterized fixture if that is desired.