### PR TITLE
SqlCatalog, default create_engine echo to False

### DIFF
--- a/pyiceberg/catalog/sql.py
+++ b/pyiceberg/catalog/sql.py
@@ -101,7 +101,7 @@ class SqlCatalog(Catalog):
 
         if not (uri_prop := self.properties.get("uri")):
             raise NoSuchPropertyException("SQL connection URI is required")
-        echo = self.properties.get("echo") or False
+        echo = bool(self.properties.get("echo", False))
         self.engine = create_engine(uri_prop, echo=echo)
 
         self._ensure_tables_exist()

--- a/pyiceberg/catalog/sql.py
+++ b/pyiceberg/catalog/sql.py
@@ -101,7 +101,8 @@ class SqlCatalog(Catalog):
 
         if not (uri_prop := self.properties.get("uri")):
             raise NoSuchPropertyException("SQL connection URI is required")
-        self.engine = create_engine(uri_prop, echo=True)
+        echo = self.properties.get("echo") or False
+        self.engine = create_engine(uri_prop, echo=echo)
 
         self._ensure_tables_exist()
 


### PR DESCRIPTION
`create_engine`'s `echo` is useful for debugging purposes.

Otherwise, it exposes a lot of internal SQLite information when it's not needed.


![Screenshot 2024-02-03 at 11 01 53 AM](https://github.com/apache/iceberg-python/assets/9057843/b538436c-8f18-4f53-a718-21f9bc374f4e)
