### PR TITLE
Add `syun64` as collaborator

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -44,6 +44,7 @@ github:
     projects: true
   collaborators:  # Note: the number of collaborators is limited to 10
     - ajantha-bhat
+    - syun64
   ghp_branch: gh-pages
   ghp_path: /
 


### PR DESCRIPTION
Sung as a release manager, I think it would help if he can update issues himself. For example in https://github.com/apache/iceberg-python/issues/226#issuecomment-1900604096