### PR TITLE
Downgrade to the previous artifact upload action

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -80,7 +80,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         run: ls -lah dist/* && cp dist/* wheelhouse/
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
-          name: "release-${{ matrix.os }}-${{ github.event.inputs.version }}"
+          name: "release-${{ matrix.os }}"
           path: ./wheelhouse/*


### PR DESCRIPTION
With the new version, you cannot merge the different runs anymore into a single zip: https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes

Which is quite annoying since you have to merge them by hand.