### PR TITLE
Hive locking

### DIFF
--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -164,7 +164,7 @@ PROP_EXTERNAL = "EXTERNAL"
 PROP_TABLE_TYPE = "table_type"
 PROP_METADATA_LOCATION = "metadata_location"
 PROP_PREVIOUS_METADATA_LOCATION = "previous_metadata_location"
-DEFAULT_PROPERTIES = {'write.parquet.compression-codec': 'zstd'}
+DEFAULT_PROPERTIES = {TableProperties.PARQUET_COMPRESSION: TableProperties.PARQUET_COMPRESSION_DEFAULT}
 
 
 def _construct_parameters(metadata_location: str, previous_metadata_location: Optional[str] = None) -> Dict[str, Any]:

--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -76,7 +76,7 @@ from pyiceberg.io import FileIO, load_file_io
 from pyiceberg.partitioning import UNPARTITIONED_PARTITION_SPEC, PartitionSpec
 from pyiceberg.schema import Schema, SchemaVisitor, visit
 from pyiceberg.serializers import FromInputFile
-from pyiceberg.table import CommitTableRequest, CommitTableResponse, Table, update_table_metadata
+from pyiceberg.table import CommitTableRequest, CommitTableResponse, Table, TableProperties, update_table_metadata
 from pyiceberg.table.metadata import new_table_metadata
 from pyiceberg.table.sorting import UNSORTED_SORT_ORDER, SortOrder
 from pyiceberg.typedef import EMPTY_DICT

--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -15,6 +15,7 @@
 #  specific language governing permissions and limitations
 #  under the License.
 import getpass
+import socket
 import time
 from types import TracebackType
 from typing import (
@@ -34,10 +35,17 @@ from hive_metastore.ttypes import (
     AlreadyExistsException,
     FieldSchema,
     InvalidOperationException,
+    LockComponent,
+    LockLevel,
+    LockRequest,
+    LockResponse,
+    LockState,
+    LockType,
     MetaException,
     NoSuchObjectException,
     SerDeInfo,
     StorageDescriptor,
+    UnlockRequest,
 )
 from hive_metastore.ttypes import Database as HiveDatabase
 from hive_metastore.ttypes import Table as HiveTable
@@ -56,6 +64,7 @@ from pyiceberg.catalog import (
     PropertiesUpdateSummary,
 )
 from pyiceberg.exceptions import (
+    CommitFailedException,
     NamespaceAlreadyExistsError,
     NamespaceNotEmptyError,
     NoSuchIcebergTableError,
@@ -67,7 +76,7 @@ from pyiceberg.io import FileIO, load_file_io
 from pyiceberg.partitioning import UNPARTITIONED_PARTITION_SPEC, PartitionSpec
 from pyiceberg.schema import Schema, SchemaVisitor, visit
 from pyiceberg.serializers import FromInputFile
-from pyiceberg.table import CommitTableRequest, CommitTableResponse, Table, TableProperties, update_table_metadata
+from pyiceberg.table import CommitTableRequest, CommitTableResponse, Table, update_table_metadata
 from pyiceberg.table.metadata import new_table_metadata
 from pyiceberg.table.sorting import UNSORTED_SORT_ORDER, SortOrder
 from pyiceberg.typedef import EMPTY_DICT
@@ -155,7 +164,7 @@ PROP_EXTERNAL = "EXTERNAL"
 PROP_TABLE_TYPE = "table_type"
 PROP_METADATA_LOCATION = "metadata_location"
 PROP_PREVIOUS_METADATA_LOCATION = "previous_metadata_location"
-DEFAULT_PROPERTIES = {TableProperties.PARQUET_COMPRESSION: TableProperties.PARQUET_COMPRESSION_DEFAULT}
+DEFAULT_PROPERTIES = {'write.parquet.compression-codec': 'zstd'}
 
 
 def _construct_parameters(metadata_location: str, previous_metadata_location: Optional[str] = None) -> Dict[str, Any]:
@@ -331,6 +340,15 @@ class HiveCatalog(Catalog):
         """
         raise NotImplementedError
 
+    def _create_lock_request(self, database_name: str, table_name: str) -> LockRequest:
+        lock_component: LockComponent = LockComponent(
+            level=LockLevel.TABLE, type=LockType.EXCLUSIVE, dbname=database_name, tablename=table_name, isTransactional=True
+        )
+
+        lock_request: LockRequest = LockRequest(component=[lock_component], user=getpass.getuser(), hostname=socket.gethostname())
+
+        return lock_request
+
     def _commit_table(self, table_request: CommitTableRequest) -> CommitTableResponse:
         """Update the table.
 
@@ -363,15 +381,23 @@ class HiveCatalog(Catalog):
         self._write_metadata(updated_metadata, current_table.io, new_metadata_location)
 
         # commit to hive
-        try:
-            with self._client as open_client:
+        # https://github.com/apache/hive/blob/master/standalone-metastore/metastore-common/src/main/thrift/hive_metastore.thrift#L1232
+        with self._client as open_client:
+            lock: LockResponse = open_client.lock(self._create_lock_request(database_name, table_name))
+
+            try:
+                if lock.state != LockState.ACQUIRED:
+                    raise CommitFailedException(f"Failed to acquire lock for {table_request.identifier}, state: {lock.state}")
+
                 tbl = open_client.get_table(dbname=database_name, tbl_name=table_name)
                 tbl.parameters = _construct_parameters(
                     metadata_location=new_metadata_location, previous_metadata_location=current_table.metadata_location
                 )
                 open_client.alter_table(dbname=database_name, tbl_name=table_name, new_tbl=tbl)
-        except NoSuchObjectException as e:
-            raise NoSuchTableError(f"Table does not exist: {table_name}") from e
+            except NoSuchObjectException as e:
+                raise NoSuchTableError(f"Table does not exist: {table_name}") from e
+            finally:
+                open_client.unlock(UnlockRequest(lockid=lock.lockid))
 
         return CommitTableResponse(metadata=updated_metadata, metadata_location=new_metadata_location)
 

--- a/tests/integration/test_reads.py
+++ b/tests/integration/test_reads.py
@@ -22,10 +22,12 @@ from urllib.parse import urlparse
 
 import pyarrow.parquet as pq
 import pytest
+from hive_metastore.ttypes import LockRequest, LockResponse, LockState, UnlockRequest
 from pyarrow.fs import S3FileSystem
 
 from pyiceberg.catalog import Catalog, load_catalog
-from pyiceberg.exceptions import NoSuchTableError
+from pyiceberg.catalog.hive import HiveCatalog, _HiveClient
+from pyiceberg.exceptions import CommitFailedException, NoSuchTableError
 from pyiceberg.expressions import (
     And,
     EqualTo,
@@ -467,3 +469,27 @@ def test_null_list_and_map(catalog: Catalog) -> None:
     # assert arrow_table["col_list_with_struct"].to_pylist() == [None, [{'test': 1}]]
     # Once https://github.com/apache/arrow/issues/38809 has been fixed
     assert arrow_table["col_list_with_struct"].to_pylist() == [[], [{'test': 1}]]
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize('catalog', [pytest.lazy_fixture('catalog_hive')])
+def test_hive_locking(catalog: HiveCatalog) -> None:
+    table = create_table(catalog)
+
+    database_name: str
+    table_name: str
+    database_name, table_name = table.identifier
+
+    hive_client: _HiveClient = catalog._client
+    blocking_lock_request: LockRequest = catalog._create_lock_request(database_name, table_name)
+
+    with hive_client as open_client:
+        # Force a lock on the test table
+        lock: LockResponse = open_client.lock(blocking_lock_request)
+        assert lock.state == LockState.ACQUIRED
+
+        try:
+            with pytest.raises(CommitFailedException, match="Cannot acquire lock"):
+                table.transaction().set_properties(lock="fail").commit_transaction()
+        finally:
+            open_client.unlock(UnlockRequest(lock.lockid))

--- a/tests/integration/test_reads.py
+++ b/tests/integration/test_reads.py
@@ -478,7 +478,7 @@ def test_hive_locking(catalog: HiveCatalog) -> None:
 
     database_name: str
     table_name: str
-    database_name, table_name = catalog.identifier_to_database_and_table(table.identifier)
+    _ignored, database_name, table_name = table.identifier
 
     hive_client: _HiveClient = catalog._client
     blocking_lock_request: LockRequest = catalog._create_lock_request(database_name, table_name)

--- a/tests/integration/test_reads.py
+++ b/tests/integration/test_reads.py
@@ -478,7 +478,7 @@ def test_hive_locking(catalog: HiveCatalog) -> None:
 
     database_name: str
     table_name: str
-    database_name, table_name = table.identifier
+    database_name, table_name = catalog.identifier_to_database_and_table(table.identifier)
 
     hive_client: _HiveClient = catalog._client
     blocking_lock_request: LockRequest = catalog._create_lock_request(database_name, table_name)

--- a/tests/integration/test_reads.py
+++ b/tests/integration/test_reads.py
@@ -472,13 +472,12 @@ def test_null_list_and_map(catalog: Catalog) -> None:
 
 
 @pytest.mark.integration
-@pytest.mark.parametrize('catalog', [pytest.lazy_fixture('catalog_hive')])
-def test_hive_locking(catalog: HiveCatalog) -> None:
-    table = create_table(catalog)
+def test_hive_locking(catalog_hive: HiveCatalog) -> None:
+    table = create_table(catalog_hive)
 
     database_name: str
     table_name: str
-    _ignored, database_name, table_name = table.identifier
+    _, database_name, table_name = table.identifier
 
     hive_client: _HiveClient = catalog._client
     blocking_lock_request: LockRequest = catalog._create_lock_request(database_name, table_name)

--- a/tests/integration/test_reads.py
+++ b/tests/integration/test_reads.py
@@ -479,8 +479,8 @@ def test_hive_locking(catalog_hive: HiveCatalog) -> None:
     table_name: str
     _, database_name, table_name = table.identifier
 
-    hive_client: _HiveClient = catalog._client
-    blocking_lock_request: LockRequest = catalog._create_lock_request(database_name, table_name)
+    hive_client: _HiveClient = catalog_hive._client
+    blocking_lock_request: LockRequest = catalog_hive._create_lock_request(database_name, table_name)
 
     with hive_client as open_client:
         # Force a lock on the test table

--- a/tests/integration/test_reads.py
+++ b/tests/integration/test_reads.py
@@ -487,8 +487,8 @@ def test_hive_locking(catalog_hive: HiveCatalog) -> None:
         lock: LockResponse = open_client.lock(blocking_lock_request)
         assert lock.state == LockState.ACQUIRED
 
-        try:
-            with pytest.raises(CommitFailedException, match="Cannot acquire lock"):
-                table.transaction().set_properties(lock="fail").commit_transaction()
-        finally:
-            open_client.unlock(UnlockRequest(lock.lockid))
+    with pytest.raises(CommitFailedException, match="Cannot acquire lock"):
+        table.transaction().set_properties(lock="fail").commit_transaction()
+
+    with hive_client as open_client:
+        open_client.unlock(UnlockRequest(lock.lockid))

--- a/tests/integration/test_reads.py
+++ b/tests/integration/test_reads.py
@@ -487,7 +487,7 @@ def test_hive_locking(catalog_hive: HiveCatalog) -> None:
         lock: LockResponse = open_client.lock(blocking_lock_request)
         assert lock.state == LockState.ACQUIRED
 
-    with pytest.raises(CommitFailedException, match="Cannot acquire lock"):
+    with pytest.raises(CommitFailedException, match="(Failed to acquire lock for).*"):
         table.transaction().set_properties(lock="fail").commit_transaction()
 
     with hive_client as open_client:

--- a/tests/integration/test_reads.py
+++ b/tests/integration/test_reads.py
@@ -487,7 +487,7 @@ def test_hive_locking(catalog_hive: HiveCatalog) -> None:
         lock: LockResponse = open_client.lock(blocking_lock_request)
         assert lock.state == LockState.ACQUIRED
         try:
-            with pytest.raises(CommitFailedException, match="(Failed to acquire lock for).*",):
+            with pytest.raises(CommitFailedException, match="(Failed to acquire lock for).*"):
                 table.transaction().set_properties(lock="fail").commit_transaction()
         finally:
             open_client.unlock(UnlockRequest(lock.lockid))


### PR DESCRIPTION
This PR adds locking to the hive commit path for tables.  The current commit path is unsafe as competing updates may overwrite other clients that are using locking.

This implementation is the most restrictive in that it will fail a commit if it cannot immediately acquire a lock.  