### PR TITLE
Fix setting V1 format version for Non-REST catalogs

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -166,6 +166,8 @@ class TableProperties:
     METRICS_MODE_COLUMN_CONF_PREFIX = "write.metadata.metrics.column"
 
     DEFAULT_NAME_MAPPING = "schema.name-mapping.default"
+    FORMAT_VERSION = "format-version"
+    DEFAULT_FORMAT_VERSION = 2
 
 
 class PropertyUtil:


### PR DESCRIPTION
Currently we always set V2 format for create table for non-rest Catalogs regardless of the specified version. This change addresses that.