### PR TITLE
Use the correct name of extra that adds GCS support

### DIFF
--- a/mkdocs/docs/index.md
+++ b/mkdocs/docs/index.md
@@ -55,7 +55,7 @@ You can mix and match optional dependencies depending on your needs:
 | s3fs         | S3FS as a FileIO implementation to interact with the object store    |
 | adlfs        | ADLFS as a FileIO implementation to interact with the object store   |
 | snappy       | Support for snappy Avro compression                                  |
-| gcsfs        | GCS as the FileIO implementation to interact with the object store   |
+| gcsfs        | GCSFS as a FileIO implementation to interact with the object store   |
 
 You either need to install `s3fs`, `adlfs`, `gcsfs`, or `pyarrow` to be able to fetch files from an object store.
 

--- a/mkdocs/docs/index.md
+++ b/mkdocs/docs/index.md
@@ -55,9 +55,9 @@ You can mix and match optional dependencies depending on your needs:
 | s3fs         | S3FS as a FileIO implementation to interact with the object store    |
 | adlfs        | ADLFS as a FileIO implementation to interact with the object store   |
 | snappy       | Support for snappy Avro compression                                  |
-| gcs          | GCS as the FileIO implementation to interact with the object store   |
+| gcsfs        | GCS as the FileIO implementation to interact with the object store   |
 
-You either need to install `s3fs`, `adlfs`, `gcs`, or `pyarrow` to be able to fetch files from an object store.
+You either need to install `s3fs`, `adlfs`, `gcsfs`, or `pyarrow` to be able to fetch files from an object store.
 
 ## Connecting to a catalog
 


### PR DESCRIPTION
The correct name is `gcsfs`. https://github.com/apache/iceberg-python/blob/main/pyproject.toml#L119