### PR TITLE
Update `LICENSE` and `NOTICE`

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -200,3 +200,36 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+--------------------------------------------------------------------------------
+
+This product includes code from Apache Avro.
+
+* Code for initializing the Avro (de)compression codecs
+* The Binary decoder for reading in an Avro byte stream
+
+Copyright: 2014-2022 The Apache Software Foundation.
+Home page: https://avro.apache.org/
+License: https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product includes code from Apache Thrift.
+
+* Uses the fb303.thrift file that's part of Hive's thrift service in vendor/fb303/
+
+Copyright: 2006-2022 The Apache Software Foundation.
+Home page: https://thrift.apache.org/
+License: https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product includes code from Apache Hive.
+
+* Uses hive_metastore.thrift to generate the Hive Metastore client in vendor/hive_metastore/
+
+Copyright: 2008-2022 The Apache Software Foundation.
+Home page: https://hive.apache.org/
+License: https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------

--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,6 @@
 
 Apache Iceberg
-Copyright 2017-2022 The Apache Software Foundation
+Copyright 2017-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/NOTICE
+++ b/NOTICE
@@ -1,37 +1,8 @@
 
 Apache Iceberg
-Copyright 2017-2024 The Apache Software Foundation
+Copyright 2017-2022 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-
-This product includes code from Apache Avro.
-
-* Code for initializing the Avro (de)compression codecs
-* The Binary decoder for reading in an Avro byte stream
-
-Copyright: 2014-2022 The Apache Software Foundation.
-Home page: https://avro.apache.org/
-License: https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-This product includes code from Apache Thrift.
-
-* Uses the fb303.thrift file that's part of Hive's thrift service in vendor/fb303/
-
-Copyright: 2006-2022 The Apache Software Foundation.
-Home page: https://thrift.apache.org/
-License: https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-This product includes code from Apache Hive.
-
-* Uses hive_metastore.thrift to generate the Hive Metastore client in vendor/hive_metastore/
-
-Copyright: 2008-2022 The Apache Software Foundation.
-Home page: https://hive.apache.org/
-License: https://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
This reverts commit e9e265a1878a55a4385580bf800382fd75c912c9.

If I'm reading [the page right](https://infra.apache.org/licensing-howto.html) I don't think we should add this to the notice:

- Avro: Since we don't bundle the code, but just took some part of it, and want to attribute the author.
- Thrift/Hive: We don't bundle any code, but just take the Python-compiled Thrift definitions.