### PR TITLE
Allow mmhash3 v4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,11 +47,11 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-mmhash3 = ">=3.0.0,<4.0.0"
+mmhash3 = ">=3.0.0,<5.0.0"
 requests = ">=2.20.0,<3.0.0"
 click = ">=7.1.1,<9.0.0"
 rich = ">=10.11.0,<14.0.0"
-strictyaml = ">=1.7.0,<2.0.0" # CVE-2020-14343 was fixed in 5.4.
+strictyaml = ">=1.7.0,<2.0.0" # CVE-2020-14343 was fixed in PyYAML 5.4.
 pydantic = ">=2.0,<3.0,!=2.4.0,!=2.4.1" # 2.4.0, 2.4.1 has a critical bug
 sortedcontainers = "2.4.0"
 fsspec = ">=2023.1.0,<2024.1.0"


### PR DESCRIPTION
Let's give this a try.

Unblocks Python 3.12 support on conda-forge