### PR TITLE
Set version in path instead of OS

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -82,5 +82,5 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: "release-${{ matrix.os }}"
+          name: "release-${{ github.event.inputs.version }}"
           path: ./wheelhouse/*


### PR DESCRIPTION
Bundling this by version makes it easier for the release