### PR TITLE
Fix environment variable parsing

### DIFF
--- a/pyiceberg/utils/config.py
+++ b/pyiceberg/utils/config.py
@@ -125,8 +125,8 @@ class Config:
             env_var_lower = env_var.lower()
             if env_var_lower.startswith(PYICEBERG.lower()):
                 key = env_var_lower[len(PYICEBERG) :]
-                parts = key.split("__")
-                parts_normalized = [part.replace("_", "-") for part in parts]
+                parts = key.split("__", maxsplit=2)
+                parts_normalized = [part.replace('__', '.').replace("_", "-") for part in parts]
                 set_property(config, parts_normalized, config_value)
 
         return config

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -41,9 +41,15 @@ def test_from_environment_variables_uppercase() -> None:
     assert Config().get_catalog_config("PRODUCTION") == {"uri": "https://service.io/api"}
 
 
-@mock.patch.dict(os.environ, {"PYICEBERG_CATALOG__PRODUCTION__S3__REGION": "eu-north-1"})
+@mock.patch.dict(os.environ, {
+    "PYICEBERG_CATALOG__PRODUCTION__S3__REGION": "eu-north-1",
+    "PYICEBERG_CATALOG__PRODUCTION__S3__ACCESS_KEY_ID": "username",
+})
 def test_fix_nested_objects_from_environment_variables() -> None:
-    assert Config().get_catalog_config("PRODUCTION") == {'s3.region': 'eu-north-1'}
+    assert Config().get_catalog_config("PRODUCTION") == {
+        's3.region': 'eu-north-1',
+        's3.access-key-id': 'username',
+    }
 
 
 def test_from_configuration_files(tmp_path_factory: pytest.TempPathFactory) -> None:

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -41,10 +41,13 @@ def test_from_environment_variables_uppercase() -> None:
     assert Config().get_catalog_config("PRODUCTION") == {"uri": "https://service.io/api"}
 
 
-@mock.patch.dict(os.environ, {
-    "PYICEBERG_CATALOG__PRODUCTION__S3__REGION": "eu-north-1",
-    "PYICEBERG_CATALOG__PRODUCTION__S3__ACCESS_KEY_ID": "username",
-})
+@mock.patch.dict(
+    os.environ,
+    {
+        "PYICEBERG_CATALOG__PRODUCTION__S3__REGION": "eu-north-1",
+        "PYICEBERG_CATALOG__PRODUCTION__S3__ACCESS_KEY_ID": "username",
+    },
+)
 def test_fix_nested_objects_from_environment_variables() -> None:
     assert Config().get_catalog_config("PRODUCTION") == {
         's3.region': 'eu-north-1',

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -41,6 +41,11 @@ def test_from_environment_variables_uppercase() -> None:
     assert Config().get_catalog_config("PRODUCTION") == {"uri": "https://service.io/api"}
 
 
+@mock.patch.dict(os.environ, {"PYICEBERG_CATALOG__PRODUCTION__S3__REGION": "eu-north-1"})
+def test_fix_nested_objects_from_environment_variables() -> None:
+    assert Config().get_catalog_config("PRODUCTION") == {'s3.region': 'eu-north-1'}
+
+
 def test_from_configuration_files(tmp_path_factory: pytest.TempPathFactory) -> None:
     config_path = str(tmp_path_factory.mktemp("config"))
     with open(f"{config_path}/.pyiceberg.yaml", "w", encoding=UTF8) as file:


### PR DESCRIPTION
Reported on Slack: https://apache-iceberg.slack.com/archives/C029EE6HQ5D/p1707633685716559

```bash
export PYICEBERG_CATALOG__SOMETHING__S3__REGION=eu-north-1
```

Before:

```python
>>> from pyiceberg.catalog import load_catalog
>>> load_catalog('something').properties
{'s3': {'region': 'eu-north-1'}, ...}
```

After:

```python
>>> from pyiceberg.catalog import load_catalog
>>> load_catalog('something').properties
{'s3.region': 'eu-north-1', ...}
```

Which correspondents with the key `s3.region` that we use. Now the example makes sense:

<img width="980" alt="image" src="https://github.com/apache/iceberg-python/assets/1134248/de1c0502-2ac0-4561-bdb0-8f8bb64dbefc">
