### PR TITLE
Update NameMapping on update_schema()

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -1933,7 +1933,6 @@ class UpdateSchema:
                 updates += (  # type: ignore
                     SetPropertiesUpdate(updates={TableProperties.DEFAULT_NAME_MAPPING: updated_name_mapping.model_dump_json()}),
                 )
-                print(f"DEBUG: {updates=}")
 
             if self._transaction is not None:
                 self._transaction._append_updates(*updates)  # pylint: disable=W0212

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -990,7 +990,7 @@ class Table:
         """
         return UpdateSnapshot(self)
 
-    def name_mapping(self) -> NameMapping:
+    def name_mapping(self) -> Optional[NameMapping]:
         """Return the table's field-id NameMapping."""
         if name_mapping_json := self.properties.get(TableProperties.DEFAULT_NAME_MAPPING):
             return parse_mapping_from_json(name_mapping_json)

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -84,11 +84,7 @@ from pyiceberg.table.metadata import (
     TableMetadata,
     TableMetadataUtil,
 )
-from pyiceberg.table.name_mapping import (
-    NameMapping,
-    create_mapping_from_schema,
-    parse_mapping_from_json,
-)
+from pyiceberg.table.name_mapping import NameMapping, parse_mapping_from_json, update_mapping
 from pyiceberg.table.refs import MAIN_BRANCH, SnapshotRef
 from pyiceberg.table.snapshots import (
     Operation,
@@ -967,12 +963,12 @@ class Table:
     def update_schema(self, allow_incompatible_changes: bool = False, case_sensitive: bool = True) -> UpdateSchema:
         return UpdateSchema(self, allow_incompatible_changes=allow_incompatible_changes, case_sensitive=case_sensitive)
 
-    def name_mapping(self) -> NameMapping:
+    def name_mapping(self) -> Optional[NameMapping]:
         """Return the table's field-id NameMapping."""
         if name_mapping_json := self.properties.get(TableProperties.DEFAULT_NAME_MAPPING):
             return parse_mapping_from_json(name_mapping_json)
         else:
-            return create_mapping_from_schema(self.schema())
+            return None
 
     def append(self, df: pa.Table) -> None:
         """
@@ -1931,6 +1927,13 @@ class UpdateSchema:
                 )
             else:
                 updates = (SetCurrentSchemaUpdate(schema_id=existing_schema_id),)  # type: ignore
+
+            if name_mapping := self._table.name_mapping():
+                updated_name_mapping = update_mapping(name_mapping, self._updates, self._adds)
+                updates += (  # type: ignore
+                    SetPropertiesUpdate(updates={TableProperties.DEFAULT_NAME_MAPPING: updated_name_mapping.model_dump_json()}),
+                )
+                print(f"DEBUG: {updates=}")
 
             if self._transaction is not None:
                 self._transaction._append_updates(*updates)  # pylint: disable=W0212

--- a/pyiceberg/table/name_mapping.py
+++ b/pyiceberg/table/name_mapping.py
@@ -224,8 +224,7 @@ class _UpdateMapping(NameMappingVisitor[List[MappedField], MappedField]):
                 updated_field
                 for field in mapped_fields
                 if (updated_field := self._remove_reassigned_names(field, reassignments)) is not None
-            ]
-            fields.extend(new_fields)
+            ] + new_fields
             return fields
         else:
             return mapped_fields

--- a/pyiceberg/table/name_mapping.py
+++ b/pyiceberg/table/name_mapping.py
@@ -45,7 +45,7 @@ class MappedField(IcebergBaseModel):
     def convert_null_to_empty_List(cls, v: Any) -> Any:
         return v or []
 
-    @field_validator('names', mode='before')
+    @field_validator('names', mode='after')
     @classmethod
     def check_at_least_one(cls, v: List[str]) -> Any:
         """

--- a/pyiceberg/table/name_mapping.py
+++ b/pyiceberg/table/name_mapping.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections import ChainMap
 from functools import cached_property, singledispatch
-from typing import Any, Dict, Generic, List, TypeVar, Union
+from typing import Any, Dict, Generic, List, Optional, TypeVar, Union
 
 from pydantic import Field, conlist, field_validator, model_serializer
 
@@ -44,6 +44,18 @@ class MappedField(IcebergBaseModel):
     @classmethod
     def convert_null_to_empty_List(cls, v: Any) -> Any:
         return v or []
+
+    @field_validator('names', mode='before')
+    @classmethod
+    def check_at_least_one(cls, v: List[str]) -> Any:
+        """
+        Conlist constraint does not seem to be validating the class on instantiation.
+
+        Adding a custom validator to enforce min_length=1 constraint.
+        """
+        if len(v) < 1:
+            raise ValueError("At least one mapped name must be provided for the field")
+        return v
 
     @model_serializer
     def ser_model(self) -> Dict[str, Any]:
@@ -93,24 +105,25 @@ class NameMapping(IcebergRootModel[List[MappedField]]):
             return "[\n  " + "\n  ".join([str(e) for e in self.root]) + "\n]"
 
 
+S = TypeVar('S')
 T = TypeVar("T")
 
 
-class NameMappingVisitor(Generic[T], ABC):
+class NameMappingVisitor(Generic[S, T], ABC):
     @abstractmethod
-    def mapping(self, nm: NameMapping, field_results: T) -> T:
+    def mapping(self, nm: NameMapping, field_results: S) -> S:
         """Visit a NameMapping."""
 
     @abstractmethod
-    def fields(self, struct: List[MappedField], field_results: List[T]) -> T:
+    def fields(self, struct: List[MappedField], field_results: List[T]) -> S:
         """Visit a List[MappedField]."""
 
     @abstractmethod
-    def field(self, field: MappedField, field_result: T) -> T:
+    def field(self, field: MappedField, field_result: S) -> T:
         """Visit a MappedField."""
 
 
-class _IndexByName(NameMappingVisitor[Dict[str, MappedField]]):
+class _IndexByName(NameMappingVisitor[Dict[str, MappedField], Dict[str, MappedField]]):
     def mapping(self, nm: NameMapping, field_results: Dict[str, MappedField]) -> Dict[str, MappedField]:
         return field_results
 
@@ -129,18 +142,18 @@ class _IndexByName(NameMappingVisitor[Dict[str, MappedField]]):
 
 
 @singledispatch
-def visit_name_mapping(obj: Union[NameMapping, List[MappedField], MappedField], visitor: NameMappingVisitor[T]) -> T:
+def visit_name_mapping(obj: Union[NameMapping, List[MappedField], MappedField], visitor: NameMappingVisitor[S, T]) -> S:
     """Traverse the name mapping in post-order traversal."""
     raise NotImplementedError(f"Cannot visit non-type: {obj}")
 
 
 @visit_name_mapping.register(NameMapping)
-def _(obj: NameMapping, visitor: NameMappingVisitor[T]) -> T:
+def _(obj: NameMapping, visitor: NameMappingVisitor[S, T]) -> S:
     return visitor.mapping(obj, visit_name_mapping(obj.root, visitor))
 
 
 @visit_name_mapping.register(list)
-def _(fields: List[MappedField], visitor: NameMappingVisitor[T]) -> T:
+def _(fields: List[MappedField], visitor: NameMappingVisitor[S, T]) -> S:
     results = [visitor.field(field, visit_name_mapping(field.fields, visitor)) for field in fields]
     return visitor.fields(fields, results)
 
@@ -175,5 +188,72 @@ class _CreateMapping(SchemaVisitor[List[MappedField]]):
         return []
 
 
+class _UpdateMapping(NameMappingVisitor[List[MappedField], MappedField]):
+    _updates: Dict[int, NestedField]
+    _adds: Dict[int, List[NestedField]]
+
+    def __init__(self, updates: Dict[int, NestedField], adds: Dict[int, List[NestedField]]):
+        self._updates = updates
+        self._adds = adds
+
+    @staticmethod
+    def _remove_reassigned_names(field: MappedField, assignments: Dict[str, int]) -> Optional[MappedField]:
+        removed_names = set()
+        for name in field.names:
+            if (assigned_id := assignments.get(name)) and assigned_id != field.field_id:
+                removed_names.add(name)
+
+        remaining_names = [f for f in field.names if f not in removed_names]
+        if remaining_names:
+            return MappedField(field_id=field.field_id, names=remaining_names, fields=field.fields)
+        else:
+            return None
+
+    def _add_new_fields(self, mapped_fields: List[MappedField], parent_id: int) -> List[MappedField]:
+        if fields_to_add := self._adds.get(parent_id):
+            fields: List[MappedField] = []
+            new_fields: List[MappedField] = []
+
+            for add in fields_to_add:
+                new_fields.append(
+                    MappedField(field_id=add.field_id, names=[add.name], fields=visit(add.field_type, _CreateMapping()))
+                )
+
+            reassignments = {f.name: f.field_id for f in fields_to_add}
+            fields = [
+                updated_field
+                for field in mapped_fields
+                if (updated_field := self._remove_reassigned_names(field, reassignments)) is not None
+            ]
+            fields.extend(new_fields)
+            return fields
+        else:
+            return mapped_fields
+
+    def mapping(self, nm: NameMapping, field_results: List[MappedField]) -> List[MappedField]:
+        return self._add_new_fields(field_results, -1)
+
+    def fields(self, struct: List[MappedField], field_results: List[MappedField]) -> List[MappedField]:
+        reassignments: Dict[str, int] = {
+            update.name: update.field_id for f in field_results if (update := self._updates.get(f.field_id))
+        }
+        return [
+            updated_field
+            for field in field_results
+            if (updated_field := self._remove_reassigned_names(field, reassignments)) is not None
+        ]
+
+    def field(self, field: MappedField, field_result: List[MappedField]) -> MappedField:
+        field_names = field.names
+        if (update := self._updates.get(field.field_id)) is not None and update.name not in field_names:
+            field_names.append(update.name)
+
+        return MappedField(field_id=field.field_id, names=field_names, fields=self._add_new_fields(field_result, field.field_id))
+
+
 def create_mapping_from_schema(schema: Schema) -> NameMapping:
     return NameMapping(visit(schema, _CreateMapping()))
+
+
+def update_mapping(mapping: NameMapping, updates: Dict[int, NestedField], adds: Dict[int, List[NestedField]]) -> NameMapping:
+    return NameMapping(visit_name_mapping(mapping, _UpdateMapping(updates, adds)))


### PR DESCRIPTION
Similar to the [Java implementation](https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/SchemaUpdate.java#L464), we should update the existing name_mapping on update_schema().

Some changes:

- Table.name_mapping no longer defaults to the auto-generated name_mapping based on the current Schema. We should explicitly return None if the property isn't set, so that we can use the function return value to avoid the additional steps in updating the existing name mapping.
- I've introduced some changes compared to the Java version. Specifically:
   - the way it was handling reassigned names had a bug where it wasn't removing all reassigned fields, but only the last one: https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/mapping/MappingUtil.java#L161C11-L161C19
   - remove MappedField from MappedFields if the mapped_field.names parameter is an empty list