### PR TITLE
Accept pyarrow LargeListType and FixedSizeListType

### DIFF
--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -689,26 +689,15 @@ def _(obj: pa.StructType, visitor: PyArrowSchemaVisitor[T]) -> T:
     return visitor.struct(obj, results)
 
 
-def process_list_type(obj: Union[pa.ListType, pa.LargeListType, pa.FixedSizeListType], visitor: PyArrowSchemaVisitor[T]) -> T:
+@visit_pyarrow.register(pa.ListType)
+@visit_pyarrow.register(pa.FixedSizeListType)
+@visit_pyarrow.register(pa.LargeListType)
+def _(obj: Union[pa.ListType, pa.LargeListType, pa.FixedSizeListType], visitor: PyArrowSchemaVisitor[T]) -> T:
     visitor.before_list_element(obj.value_field)
     result = visit_pyarrow(obj.value_type, visitor)
     visitor.after_list_element(obj.value_field)
+
     return visitor.list(obj, result)
-
-
-@visit_pyarrow.register(pa.ListType)
-def _(obj: pa.ListType, visitor: PyArrowSchemaVisitor[T]) -> T:
-    return process_list_type(obj, visitor)
-
-
-@visit_pyarrow.register(pa.LargeListType)
-def _(obj: pa.LargeListType, visitor: PyArrowSchemaVisitor[T]) -> T:
-    return process_list_type(obj, visitor)
-
-
-@visit_pyarrow.register(pa.FixedSizeListType)
-def _(obj: pa.FixedSizeListType, visitor: PyArrowSchemaVisitor[T]) -> T:
-    return process_list_type(obj, visitor)
 
 
 @visit_pyarrow.register(pa.MapType)

--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -689,13 +689,26 @@ def _(obj: pa.StructType, visitor: PyArrowSchemaVisitor[T]) -> T:
     return visitor.struct(obj, results)
 
 
-@visit_pyarrow.register(pa.ListType)
-def _(obj: pa.ListType, visitor: PyArrowSchemaVisitor[T]) -> T:
+def process_list_type(obj: Union[pa.ListType, pa.LargeListType, pa.FixedSizeListType], visitor: PyArrowSchemaVisitor[T]) -> T:
     visitor.before_list_element(obj.value_field)
     result = visit_pyarrow(obj.value_type, visitor)
     visitor.after_list_element(obj.value_field)
-
     return visitor.list(obj, result)
+
+
+@visit_pyarrow.register(pa.ListType)
+def _(obj: pa.ListType, visitor: PyArrowSchemaVisitor[T]) -> T:
+    return process_list_type(obj, visitor)
+
+
+@visit_pyarrow.register(pa.LargeListType)
+def _(obj: pa.LargeListType, visitor: PyArrowSchemaVisitor[T]) -> T:
+    return process_list_type(obj, visitor)
+
+
+@visit_pyarrow.register(pa.FixedSizeListType)
+def _(obj: pa.FixedSizeListType, visitor: PyArrowSchemaVisitor[T]) -> T:
+    return process_list_type(obj, visitor)
 
 
 @visit_pyarrow.register(pa.MapType)

--- a/tests/io/test_pyarrow_visitor.py
+++ b/tests/io/test_pyarrow_visitor.py
@@ -245,6 +245,26 @@ def test_pyarrow_list_to_iceberg() -> None:
     assert visit_pyarrow(pyarrow_list, _ConvertToIceberg()) == expected
 
 
+def test_pyarrow_large_list_to_iceberg() -> None:
+    pyarrow_list = pa.large_list(pa.field("element", pa.int32(), nullable=False, metadata={"PARQUET:field_id": "1"}))
+    expected = ListType(
+        element_id=1,
+        element_type=IntegerType(),
+        element_required=True,
+    )
+    assert visit_pyarrow(pyarrow_list, _ConvertToIceberg()) == expected
+
+
+def test_pyarrow_fixed_size_list_to_iceberg() -> None:
+    pyarrow_list = pa.list_(pa.field("element", pa.int32(), nullable=False, metadata={"PARQUET:field_id": "1"}), 1)
+    expected = ListType(
+        element_id=1,
+        element_type=IntegerType(),
+        element_required=True,
+    )
+    assert visit_pyarrow(pyarrow_list, _ConvertToIceberg()) == expected
+
+
 def test_pyarrow_map_to_iceberg() -> None:
     pyarrow_map = pa.map_(
         pa.field("key", pa.int32(), nullable=False, metadata={"PARQUET:field_id": "1"}),


### PR DESCRIPTION
closes: #451

The C++ implementation of Arrow has different types of lists (https://arrow.apache.org/docs/cpp/api/datatype.html#_CPPv4N5arrow12BaseListTypeE), but these types are not correctly implemented in Python, where there is no common superclass for them, they extend the DataType class directly.

`LargeListType` and `FixedSizeListType` are also lists but with some extra characteristics, so they should be accepted by PyIceberg, and transformed to ListType as the PyArrow `ListType`.

In the mentioned issue, PyArrow map the Polars list to a `LargeListType` instead of `ListType` and that's why it fails.