### PR TITLE
Fix resolving table name from db location

### DIFF
--- a/pyiceberg/catalog/__init__.py
+++ b/pyiceberg/catalog/__init__.py
@@ -568,14 +568,18 @@ class Catalog(ABC):
         return location
 
     def _get_default_warehouse_location(self, database_name: str, table_name: str) -> str:
+        def remove_protocol(uri: str) -> str:
+            parsed_uri = uri.split("://")
+            return parsed_uri[1] if len(parsed_uri) > 1 else parsed_uri[0]
+
         database_properties = self.load_namespace_properties(database_name)
         if database_location := database_properties.get(LOCATION):
             database_location = database_location.rstrip("/")
-            return f"{database_location}/{table_name}"
+            return remove_protocol(f"{database_location}/{table_name}")
 
         if warehouse_path := self.properties.get(WAREHOUSE_LOCATION):
             warehouse_path = warehouse_path.rstrip("/")
-            return f"{warehouse_path}/{database_name}.db/{table_name}"
+            return remove_protocol(f"{warehouse_path}/{database_name}.db/{table_name}")
 
         raise ValueError("No default path is set, please specify a location when creating a table")
 

--- a/tests/catalog/test_hive.py
+++ b/tests/catalog/test_hive.py
@@ -913,3 +913,15 @@ def test_resolve_table_location_warehouse(hive_database: HiveDatabase) -> None:
 
     location = catalog._resolve_table_location(None, "database", "table")
     assert location == "/tmp/warehouse/database.db/table"
+
+
+def test_resolve_table_location_using_db_location(hive_database: HiveDatabase) -> None:
+    catalog = HiveCatalog(HIVE_CATALOG_NAME, warehouse="/tmp/warehouse/", uri=HIVE_METASTORE_FAKE_URL)
+
+    hive_database.locationUri = "hdfs://tmp/warehouse/database.db"
+
+    catalog._client = MagicMock()
+    catalog._client.__enter__().get_database.return_value = hive_database
+
+    location = catalog._resolve_table_location(None, "database", "table")
+    assert location == "tmp/warehouse/database.db/table"


### PR DESCRIPTION
closes: #459

According to https://github.com/apache/arrow/pull/9192, GetFileInfo should only receive the file path, and after investigating why create_table provides the full URI, it looks like `_get_default_warehouse_location` returns the db location as it is.

I'm not sure if there is a configuration problem in the raised issue, if that's the case, then we need to add a check somewhere to block creating the database/namespace with a wrong location, otherwise, we need to remove the protocol from the table location.