### PR TITLE
Make issued_token_type optional to support OAuth2 Client Credential Flow

### DIFF
--- a/pyiceberg/catalog/rest.py
+++ b/pyiceberg/catalog/rest.py
@@ -156,10 +156,10 @@ class RegisterTableRequest(IcebergBaseModel):
 class TokenResponse(IcebergBaseModel):
     access_token: str = Field()
     token_type: str = Field()
-    expires_in: Optional[int] = None
-    issued_token_type: Optional[str] = None
-    refresh_token: Optional[str] = None
-    scope: Optional[str] = None
+    expires_in: Optional[int] = Field(default=None)
+    issued_token_type: Optional[str] = Field(default=None)
+    refresh_token: Optional[str] = Field(default=None)
+    scope: Optional[str] = Field(default=None)
 
 
 class ConfigResponse(IcebergBaseModel):

--- a/pyiceberg/catalog/rest.py
+++ b/pyiceberg/catalog/rest.py
@@ -156,8 +156,10 @@ class RegisterTableRequest(IcebergBaseModel):
 class TokenResponse(IcebergBaseModel):
     access_token: str = Field()
     token_type: str = Field()
-    expires_in: int = Field()
+    expires_in: Optional[int] = None
     issued_token_type: Optional[str] = None
+    refresh_token: Optional[str] = None
+    scope: Optional[str] = None
 
 
 class ConfigResponse(IcebergBaseModel):

--- a/pyiceberg/catalog/rest.py
+++ b/pyiceberg/catalog/rest.py
@@ -157,7 +157,7 @@ class TokenResponse(IcebergBaseModel):
     access_token: str = Field()
     token_type: str = Field()
     expires_in: int = Field()
-    issued_token_type: str = Field()
+    issued_token_type: Optional[str] = None
 
 
 class ConfigResponse(IcebergBaseModel):

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -117,6 +117,21 @@ def test_token_200(rest_mock: Mocker) -> None:
         == f"Bearer {TEST_TOKEN}"
     )
 
+def test_token_200_without_issued_token_type(rest_mock: Mocker) -> None:
+    rest_mock.post(
+        f"{TEST_URI}v1/oauth/tokens",
+        json={
+            "access_token": TEST_TOKEN,
+            "token_type": "Bearer",
+            "expires_in": 86400,
+        },
+        status_code=200,
+        request_headers=OAUTH_TEST_HEADERS,
+    )
+    assert (
+        RestCatalog("rest", uri=TEST_URI, credential=TEST_CREDENTIALS)._session.headers["Authorization"]  # pylint: disable=W0212
+        == f"Bearer {TEST_TOKEN}"
+    )
 
 def test_token_200_w_auth_url(rest_mock: Mocker) -> None:
     rest_mock.post(

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -108,6 +108,8 @@ def test_token_200(rest_mock: Mocker) -> None:
             "token_type": "Bearer",
             "expires_in": 86400,
             "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+            "scope": "openid offline",
+            "refresh_token": "refresh_token",
         },
         status_code=200,
         request_headers=OAUTH_TEST_HEADERS,
@@ -118,13 +120,12 @@ def test_token_200(rest_mock: Mocker) -> None:
     )
 
 
-def test_token_200_without_issued_token_type(rest_mock: Mocker) -> None:
+def test_token_200_without_optional_fields(rest_mock: Mocker) -> None:
     rest_mock.post(
         f"{TEST_URI}v1/oauth/tokens",
         json={
             "access_token": TEST_TOKEN,
             "token_type": "Bearer",
-            "expires_in": 86400,
         },
         status_code=200,
         request_headers=OAUTH_TEST_HEADERS,

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -117,6 +117,7 @@ def test_token_200(rest_mock: Mocker) -> None:
         == f"Bearer {TEST_TOKEN}"
     )
 
+
 def test_token_200_without_issued_token_type(rest_mock: Mocker) -> None:
     rest_mock.post(
         f"{TEST_URI}v1/oauth/tokens",
@@ -132,6 +133,7 @@ def test_token_200_without_issued_token_type(rest_mock: Mocker) -> None:
         RestCatalog("rest", uri=TEST_URI, credential=TEST_CREDENTIALS)._session.headers["Authorization"]  # pylint: disable=W0212
         == f"Bearer {TEST_TOKEN}"
     )
+
 
 def test_token_200_w_auth_url(rest_mock: Mocker) -> None:
     rest_mock.post(


### PR DESCRIPTION
To fix issue(https://github.com/apache/iceberg-python/issues/463). In short, Client Credential Flow's http response doesn't have the field `issued_token_type`. Make it optional to avoid validation error like this:
```
ValidationError: 1 validation error for TokenResponse
issued_token_type
  Field required [type=missing, input_value={'access_token': 'eyJhbGc... 'token_type': 'bearer'},
input_type=dict]
```
cc @danielcweeks @Fokko @syun64 @RussellSpitzer 