### PR TITLE
Add Support for Custom Header Configurations in RESTCatalog

### DIFF
--- a/mkdocs/docs/configuration.md
+++ b/mkdocs/docs/configuration.md
@@ -155,6 +155,19 @@ catalog:
 | rest.signing-name      | execute-api             | The service signing name to use when SigV4 signing a request                                       |
 | rest.authorization-url | https://auth-service/cc | Authentication URL to use for client credentials authentication (default: uri + 'v1/oauth/tokens') |
 
+### Headers in RESTCatalog
+
+To configure custom headers in RESTCatalog, include them in the catalog properties with the prefix `header.`. This
+ensures that all HTTP requests to the REST service include the specified headers.
+
+```yaml
+catalog:
+  default:
+    uri: http://rest-catalog/ws/
+    credential: t-1234:secret
+    header.content-type: application/vnd.api+json
+```
+
 ## SQL Catalog
 
 The SQL catalog requires a database for its backend. PyIceberg supports PostgreSQL and SQLite through psycopg2. The database connection has to be configured using the `uri` property. See SQLAlchemy's [documentation for URL format](https://docs.sqlalchemy.org/en/20/core/engines.html#backend-specific-urls):

--- a/pyiceberg/catalog/rest.py
+++ b/pyiceberg/catalog/rest.py
@@ -465,7 +465,7 @@ class RestCatalog(Catalog):
         session.headers.update(header_properties)
 
     def _extract_headers_from_properties(self) -> Dict[str, str]:
-        return {key[len(HEADER_PREFIX):]: value for key, value in self.properties.items() if key.startswith(HEADER_PREFIX)}
+        return {key[len(HEADER_PREFIX) :]: value for key, value in self.properties.items() if key.startswith(HEADER_PREFIX)}
 
     @retry(**_RETRY_ARGS)
     def create_table(

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -166,6 +166,42 @@ def test_config_200(requests_mock: Mocker) -> None:
     assert history[1].method == "GET"
     assert history[1].url == "https://iceberg-test-catalog/v1/config?warehouse=s3%3A%2F%2Fsome-bucket"
 
+def test_properties_sets_headers(requests_mock: Mocker) -> None:
+    requests_mock.get(
+        f"{TEST_URI}v1/config",
+        json={"defaults": {}, "overrides": {}},
+        status_code=200,
+    )
+
+    catalog = RestCatalog("rest", uri=TEST_URI, warehouse="s3://some-bucket",
+                          **{"header.Content-Type": "application/vnd.api+json"})
+
+    assert catalog._session.headers.get("Content-type") == "application/vnd.api+json", \
+        "Expected 'Content-Type' header to be 'application/vnd.api+json'"
+
+    assert requests_mock.last_request.headers["Content-type"] == "application/vnd.api+json", \
+        "Config request did not include expected 'Content-Type' header"
+
+def test_config_sets_headers(requests_mock: Mocker) -> None:
+    namespace = "leden"
+    requests_mock.get(
+        f"{TEST_URI}v1/config",
+        json={"defaults": {"header.Content-Type": "application/vnd.api+json"}, "overrides": {}},
+        status_code=200,
+    )
+    requests_mock.post(
+        f"{TEST_URI}v1/namespaces",
+        json={"namespace": [namespace], "properties": {}},
+        status_code=200
+    )
+    catalog = RestCatalog("rest", uri=TEST_URI, warehouse="s3://some-bucket")
+    catalog.create_namespace(namespace)
+
+    assert catalog._session.headers.get("Content-type") == "application/vnd.api+json", \
+        "Expected 'Content-Type' header to be 'application/vnd.api+json'"
+    assert requests_mock.last_request.headers["Content-type"] == "application/vnd.api+json", \
+        "Create namespace request did not include expected 'Content-Type' header"
+
 
 def test_token_400(rest_mock: Mocker) -> None:
     rest_mock.post(

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -166,6 +166,7 @@ def test_config_200(requests_mock: Mocker) -> None:
     assert history[1].method == "GET"
     assert history[1].url == "https://iceberg-test-catalog/v1/config?warehouse=s3%3A%2F%2Fsome-bucket"
 
+
 def test_properties_sets_headers(requests_mock: Mocker) -> None:
     requests_mock.get(
         f"{TEST_URI}v1/config",
@@ -173,14 +174,18 @@ def test_properties_sets_headers(requests_mock: Mocker) -> None:
         status_code=200,
     )
 
-    catalog = RestCatalog("rest", uri=TEST_URI, warehouse="s3://some-bucket",
-                          **{"header.Content-Type": "application/vnd.api+json"})
+    catalog = RestCatalog(
+        "rest", uri=TEST_URI, warehouse="s3://some-bucket", **{"header.Content-Type": "application/vnd.api+json"}
+    )
 
-    assert catalog._session.headers.get("Content-type") == "application/vnd.api+json", \
-        "Expected 'Content-Type' header to be 'application/vnd.api+json'"
+    assert (
+        catalog._session.headers.get("Content-type") == "application/vnd.api+json"
+    ), "Expected 'Content-Type' header to be 'application/vnd.api+json'"
 
-    assert requests_mock.last_request.headers["Content-type"] == "application/vnd.api+json", \
-        "Config request did not include expected 'Content-Type' header"
+    assert (
+        requests_mock.last_request.headers["Content-type"] == "application/vnd.api+json"
+    ), "Config request did not include expected 'Content-Type' header"
+
 
 def test_config_sets_headers(requests_mock: Mocker) -> None:
     namespace = "leden"
@@ -189,18 +194,16 @@ def test_config_sets_headers(requests_mock: Mocker) -> None:
         json={"defaults": {"header.Content-Type": "application/vnd.api+json"}, "overrides": {}},
         status_code=200,
     )
-    requests_mock.post(
-        f"{TEST_URI}v1/namespaces",
-        json={"namespace": [namespace], "properties": {}},
-        status_code=200
-    )
+    requests_mock.post(f"{TEST_URI}v1/namespaces", json={"namespace": [namespace], "properties": {}}, status_code=200)
     catalog = RestCatalog("rest", uri=TEST_URI, warehouse="s3://some-bucket")
     catalog.create_namespace(namespace)
 
-    assert catalog._session.headers.get("Content-type") == "application/vnd.api+json", \
-        "Expected 'Content-Type' header to be 'application/vnd.api+json'"
-    assert requests_mock.last_request.headers["Content-type"] == "application/vnd.api+json", \
-        "Create namespace request did not include expected 'Content-Type' header"
+    assert (
+        catalog._session.headers.get("Content-type") == "application/vnd.api+json"
+    ), "Expected 'Content-Type' header to be 'application/vnd.api+json'"
+    assert (
+        requests_mock.last_request.headers["Content-type"] == "application/vnd.api+json"
+    ), "Create namespace request did not include expected 'Content-Type' header"
 
 
 def test_token_400(rest_mock: Mocker) -> None:


### PR DESCRIPTION
This PR Fixes #455 by adding ability to use custom headers in PyIceberg's RESTCatalog, making it consistent with the Java implementation of the RESTCatalog. In the Java implementation, configs have the flexibility to be specified at two points: initially, through catalog properties provided at creation, and dynamically, based on the properties included in the server's response to the getConfig endpoint call. Which ensures that all the subsequent requests are made with these headers. One thing to call out is headers are also case insensitive, and this change respects that.

**Catalog Properties**
```
catalog = RestCatalog("rest", uri=TEST_URI, warehouse="s3://some-bucket", **{"header.Content-Type": "application/vnd.api+json"})
```

**getConfig Response**
```
{
  "defaults": {
    "header.cache-control": "no-cache"
  },
  "overrides": {}
}
```

Header logic in Java RESTCatalog: https://github.com/apache/iceberg/blob/4090a8860061f58748e3faa6804094f90d3575f3/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java#L165

@Fokko @HonahX 