### PR TITLE
Cleanup conftest, remove LocalOutputFile

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1456,40 +1456,6 @@ def simple_map() -> MapType:
     return MapType(key_id=19, key_type=StringType(), value_id=25, value_type=DoubleType(), value_required=False)
 
 
-class LocalOutputFile(OutputFile):
-    """An OutputFile implementation for local files (for test use only)."""
-
-    def __init__(self, location: str) -> None:
-        parsed_location = urlparse(location)  # Create a ParseResult from the uri
-        if (
-            parsed_location.scheme and parsed_location.scheme != "file"
-        ):  # Validate that an uri is provided with a scheme of `file`
-            raise ValueError("LocalOutputFile location must have a scheme of `file`")
-        elif parsed_location.netloc:
-            raise ValueError(f"Network location is not allowed for LocalOutputFile: {parsed_location.netloc}")
-
-        super().__init__(location=location)
-        self._path = parsed_location.path
-
-    def __len__(self) -> int:
-        """Return the length of an instance of the LocalOutputFile class."""
-        return os.path.getsize(self._path)
-
-    def exists(self) -> bool:
-        return os.path.exists(self._path)
-
-    def to_input_file(self) -> "PyArrowFile":
-        from pyiceberg.io.pyarrow import PyArrowFileIO
-
-        return PyArrowFileIO().new_input(location=self.location)
-
-    def create(self, overwrite: bool = False) -> OutputStream:
-        output_file = open(self._path, "wb" if overwrite else "xb")
-        if not issubclass(type(output_file), OutputStream):
-            raise TypeError("Object returned from LocalOutputFile.create(...) does not match the OutputStream protocol.")
-        return output_file
-
-
 @pytest.fixture(scope="session")
 def generated_manifest_entry_file(avro_schema_manifest_entry: Dict[str, Any]) -> Generator[str, None, None]:
     from fastavro import parse_schema, writer

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,6 @@ from typing import (
     List,
     Optional,
 )
-from urllib.parse import urlparse
 
 import boto3
 import pytest
@@ -57,8 +56,6 @@ from pyiceberg.io import (
     GCS_PROJECT_ID,
     GCS_TOKEN,
     GCS_TOKEN_EXPIRES_AT_MS,
-    OutputFile,
-    OutputStream,
     fsspec,
     load_file_io,
 )
@@ -88,7 +85,7 @@ if TYPE_CHECKING:
     import pyarrow as pa
     from moto.server import ThreadedMotoServer  # type: ignore
 
-    from pyiceberg.io.pyarrow import PyArrowFile, PyArrowFileIO
+    from pyiceberg.io.pyarrow import PyArrowFileIO
 
 
 def pytest_collection_modifyitems(items: List[pytest.Item]) -> None:


### PR DESCRIPTION
While browsing `conftest.py`, I noticed `LocalOutputFile` which is [not used anywhere in the repo](https://github.com/search?q=repo%3Aapache%2Ficeberg-python%20LocalOutputFile&type=code). 
It's first introduced in [this commit](https://github.com/apache/iceberg/commit/98dc1e63d240c32ec7d48eb246d4b8bcd421aeff#diff-93c4e2e1e5b9bad7dee0662cdcc293096d159ee95665affad7ea84814d2eb738R807), originally used for `LocalFileIO`. 

Since we added the ability to write to local filesystem in #301, I believe this is no longer needed