### PR TITLE
 Deprecate DynamoDB Catalog to Reduce Catalog Scope

### DIFF
--- a/mkdocs/docs/configuration.md
+++ b/mkdocs/docs/configuration.md
@@ -221,6 +221,7 @@ catalog:
 ```
 
 ## DynamoDB Catalog
+**Deprecated:** As of version 0.6.0, the DynamoDB Catalog is planned for deprecation in version 1.0.0.
 
 If you want to use AWS DynamoDB as the catalog, you can use the last two ways to configure the pyiceberg and refer
 [How to configure AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)

--- a/pyiceberg/catalog/dynamodb.py
+++ b/pyiceberg/catalog/dynamodb.py
@@ -57,6 +57,7 @@ from pyiceberg.table import CommitTableRequest, CommitTableResponse, Table
 from pyiceberg.table.metadata import new_table_metadata
 from pyiceberg.table.sorting import UNSORTED_SORT_ORDER, SortOrder
 from pyiceberg.typedef import EMPTY_DICT
+from pyiceberg.utils.deprecated import deprecated
 
 if TYPE_CHECKING:
     import pyarrow as pa
@@ -81,6 +82,10 @@ ACTIVE = "ACTIVE"
 ITEM = "Item"
 
 
+@deprecated(
+    deprecated_in="0.6.0",
+    removed_in="1.0.0",
+)
 class DynamoDbCatalog(Catalog):
     def __init__(self, name: str, **properties: str):
         super().__init__(name, **properties)


### PR DESCRIPTION
The deprecation of the dynamo catalog in python is stemming from the discussion in the [community sync](https://youtu.be/uAQVGd5zV4I?si=cj0xpfprgvJIGYIm&t=1323), we want to reduce the scope of supported catalogs in Iceberg. The Dynamo catalog in the Java library as a part of this [pr: #9783](https://github.com/apache/iceberg/pull/9783).

This PR marks the DynamoDB catalog as deprecated. Also I'm starting the deprecation version at 0.6.0 and extending the deprecated window to 1.0.0 so we can account for potential RC's. Similar to what we did in the iceberg deprecation: [link](https://github.com/apache/iceberg/pull/9783#issuecomment-1961679888)

Please comment If you have any concerns or a hard dependency on this catalog.