### PR TITLE
Raise exception if namespace does not exist in load_namespace_properties for Sql Catalog

### DIFF
--- a/pyiceberg/catalog/sql.py
+++ b/pyiceberg/catalog/sql.py
@@ -567,7 +567,9 @@ class SqlCatalog(Catalog):
         Raises:
             NoSuchNamespaceError: If a namespace with the given name does not exist.
         """
-        database_name = self.identifier_to_database(namespace, NoSuchNamespaceError)
+        database_name = self.identifier_to_database(namespace)
+        if not self._namespace_exists(database_name):
+            raise NoSuchNamespaceError(f"Database {database_name} does not exists")
 
         stmt = select(IcebergNamespaceProperties).where(
             IcebergNamespaceProperties.catalog_name == self.name, IcebergNamespaceProperties.namespace == database_name

--- a/tests/catalog/test_sql.py
+++ b/tests/catalog/test_sql.py
@@ -733,6 +733,18 @@ def test_load_empty_namespace_properties(catalog: SqlCatalog, database_name: str
         lazy_fixture('catalog_sqlite'),
     ],
 )
+def test_load_namespace_properties_non_existing_namespace(catalog: SqlCatalog) -> None:
+    with pytest.raises(NoSuchNamespaceError):
+        catalog.load_namespace_properties("does_not_exist")
+
+
+@pytest.mark.parametrize(
+    'catalog',
+    [
+        lazy_fixture('catalog_memory'),
+        lazy_fixture('catalog_sqlite'),
+    ],
+)
 def test_update_namespace_properties(catalog: SqlCatalog, database_name: str) -> None:
     warehouse_location = "/test/location"
     test_properties = {


### PR DESCRIPTION
There is a bug where `load_namespace_properties` for the SqlCatalog does not raise an exception if the namespace does not exist. This PR fixes it in the same convention as other functions (ref.  update_namespace_properties ) and adds a test case for it as well.