### PR TITLE
Tests should explicitly check for `schema_id`

### DIFF
--- a/tests/catalog/test_base.py
+++ b/tests/catalog/test_base.py
@@ -614,9 +614,9 @@ def test_add_column(catalog: InMemoryCatalog) -> None:
         NestedField(field_id=2, name="y", field_type=LongType(), required=True, doc="comment"),
         NestedField(field_id=3, name="z", field_type=LongType(), required=True),
         NestedField(field_id=4, name="new_column1", field_type=IntegerType(), required=False),
-        schema_id=0,
         identifier_field_ids=[],
     )
+    assert given_table.schema().schema_id == 1
 
     transaction = given_table.transaction()
     transaction.update_schema().add_column(path="new_column2", field_type=IntegerType(), doc="doc").commit()
@@ -628,9 +628,9 @@ def test_add_column(catalog: InMemoryCatalog) -> None:
         NestedField(field_id=3, name="z", field_type=LongType(), required=True),
         NestedField(field_id=4, name="new_column1", field_type=IntegerType(), required=False),
         NestedField(field_id=5, name="new_column2", field_type=IntegerType(), required=False, doc="doc"),
-        schema_id=0,
         identifier_field_ids=[],
     )
+    assert given_table.schema().schema_id == 2
 
 
 def test_add_column_with_statement(catalog: InMemoryCatalog) -> None:
@@ -644,9 +644,9 @@ def test_add_column_with_statement(catalog: InMemoryCatalog) -> None:
         NestedField(field_id=2, name="y", field_type=LongType(), required=True, doc="comment"),
         NestedField(field_id=3, name="z", field_type=LongType(), required=True),
         NestedField(field_id=4, name="new_column1", field_type=IntegerType(), required=False),
-        schema_id=0,
         identifier_field_ids=[],
     )
+    assert given_table.schema().schema_id == 1
 
     with given_table.transaction() as tx:
         tx.update_schema().add_column(path="new_column2", field_type=IntegerType(), doc="doc").commit()
@@ -657,9 +657,9 @@ def test_add_column_with_statement(catalog: InMemoryCatalog) -> None:
         NestedField(field_id=3, name="z", field_type=LongType(), required=True),
         NestedField(field_id=4, name="new_column1", field_type=IntegerType(), required=False),
         NestedField(field_id=5, name="new_column2", field_type=IntegerType(), required=False, doc="doc"),
-        schema_id=0,
         identifier_field_ids=[],
     )
+    assert given_table.schema().schema_id == 2
 
 
 def test_catalog_repr(catalog: InMemoryCatalog) -> None:

--- a/tests/integration/test_partition_evolution.py
+++ b/tests/integration/test_partition_evolution.py
@@ -419,9 +419,9 @@ def test_change_specs_and_schema_transaction(catalog: Catalog) -> None:
         NestedField(field_id=2, name='event_ts', field_type=TimestampType(), required=False),
         NestedField(field_id=3, name='str', field_type=StringType(), required=False),
         NestedField(field_id=4, name='col_string', field_type=StringType(), required=False),
-        schema_id=1,
         identifier_field_ids=[],
     )
+    assert table.schema().schema_id == 1
 
 
 @pytest.mark.integration

--- a/tests/integration/test_reads.py
+++ b/tests/integration/test_reads.py
@@ -93,7 +93,6 @@ def create_table(catalog: Catalog) -> Table:
         NestedField(field_id=2, name="int", field_type=IntegerType(), required=True),
         NestedField(field_id=3, name="bool", field_type=BooleanType(), required=False),
         NestedField(field_id=4, name="datetime", field_type=TimestampType(), required=False),
-        schema_id=1,
     )
 
     return catalog.create_table(identifier=TABLE_NAME, schema=schema)

--- a/tests/integration/test_rest_schema.py
+++ b/tests/integration/test_rest_schema.py
@@ -361,7 +361,6 @@ def test_revert_changes(simple_table: Table, table_schema_simple: Schema) -> Non
             NestedField(field_id=1, name='foo', field_type=StringType(), required=False),
             NestedField(field_id=2, name='bar', field_type=IntegerType(), required=True),
             NestedField(field_id=3, name='baz', field_type=BooleanType(), required=False),
-            schema_id=0,
             identifier_field_ids=[2],
         ),
         1: Schema(
@@ -369,11 +368,12 @@ def test_revert_changes(simple_table: Table, table_schema_simple: Schema) -> Non
             NestedField(field_id=2, name='bar', field_type=IntegerType(), required=True),
             NestedField(field_id=3, name='baz', field_type=BooleanType(), required=False),
             NestedField(field_id=4, name='data', field_type=IntegerType(), required=False),
-            schema_id=1,
             identifier_field_ids=[2],
         ),
     }
     assert simple_table.schema().schema_id == 0
+    assert simple_table.schemas()[0].schema_id == 0
+    assert simple_table.schemas()[1].schema_id == 1
 
 
 @pytest.mark.integration

--- a/tests/table/test_metadata.py
+++ b/tests/table/test_metadata.py
@@ -120,7 +120,6 @@ def test_v1_metadata_parsing_directly(example_table_metadata_v1: Dict[str, Any])
             NestedField(field_id=1, name="x", field_type=LongType(), required=True),
             NestedField(field_id=2, name="y", field_type=LongType(), required=True, doc="comment"),
             NestedField(field_id=3, name="z", field_type=LongType(), required=True),
-            schema_id=0,
             identifier_field_ids=[],
         )
     ]


### PR DESCRIPTION
This PR modifies `tests` to explicitly check `schema_id` when comparing `Schema`.
Related to #290

Previously, many tests were written with implicit `schema_id` checks. For example, 
```
    assert table.schema() == Schema(
        NestedField(field_id=1, name='id', field_type=LongType(), required=False),
        NestedField(field_id=2, name='event_ts', field_type=TimestampType(), required=False),
        NestedField(field_id=3, name='str', field_type=StringType(), required=False),
        NestedField(field_id=4, name='col_string', field_type=StringType(), required=False),
        schema_id=1,
        identifier_field_ids=[],
    )
```
Since `Schema.__eq__` does not check for `schema_id`, we never check the `schema_id` of the `Schema`
