### PR TITLE
Fix dead links in docs

### DIFF
--- a/.github/workflows/check-md-link.yml
+++ b/.github/workflows/check-md-link.yml
@@ -4,6 +4,9 @@ on:
   push:
     paths:
       - mkdocs/**
+    branches:
+    - 'main'
+  pull_request:
 
 jobs:
   markdown-link-check:

--- a/mkdocs/docs/SUMMARY.md
+++ b/mkdocs/docs/SUMMARY.md
@@ -17,6 +17,8 @@
 
 <!-- prettier-ignore-start -->
 
+<!-- markdown-link-check-disable -->
+
 - [Getting started](index.md)
 - [Configuration](configuration.md)
 - [CLI](cli.md)
@@ -26,6 +28,8 @@
 - Releases
     - [Verify a release](verify-release.md)
     - [How to release](how-to-release.md)
-- [Code Reference](reference/) <!-- markdown-link-check-disable-line -->
+- [Code Reference](reference/)
+
+<!-- markdown-link-check-enable-->
 
 <!-- prettier-ignore-end -->

--- a/mkdocs/docs/SUMMARY.md
+++ b/mkdocs/docs/SUMMARY.md
@@ -26,6 +26,6 @@
 - Releases
     - [Verify a release](verify-release.md)
     - [How to release](how-to-release.md)
-- [Code Reference](reference/)
+- [Code Reference](reference/) <!-- markdown-link-check-disable-line -->
 
 <!-- prettier-ignore-end -->

--- a/mkdocs/docs/configuration.md
+++ b/mkdocs/docs/configuration.md
@@ -81,6 +81,8 @@ For the FileIO there are several configuration options available:
 
 ### S3
 
+<!-- markdown-link-check-disable -->
+
 | Key                  | Example                  | Description                                                                                                                                                                                                                                               |
 | -------------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | s3.endpoint          | https://10.0.19.25/      | Configure an alternative endpoint of the S3 service for the FileIO to access. This could be used to use S3FileIO with any s3-compatible object storage service that has a different endpoint, or access a private S3 endpoint in a virtual private cloud. |
@@ -91,7 +93,11 @@ For the FileIO there are several configuration options available:
 | s3.proxy-uri         | http://my.proxy.com:8080 | Configure the proxy server to be used by the FileIO.                                                                                                                                                                                                      |
 | s3.connect-timeout   | 60.0                     | Configure socket connection timeout, in seconds.                                                                                                                                                                                                          |
 
+<!-- markdown-link-check-enable-->
+
 ### HDFS
+
+<!-- markdown-link-check-disable -->
 
 | Key                  | Example             | Description                                      |
 | -------------------- | ------------------- | ------------------------------------------------ |
@@ -100,7 +106,11 @@ For the FileIO there are several configuration options available:
 | hdfs.user            | user                | Configure the HDFS username used for connection. |
 | hdfs.kerberos_ticket | kerberos_ticket     | Configure the path to the Kerberos ticket cache. |
 
+<!-- markdown-link-check-enable-->
+
 ### Azure Data lake
+
+<!-- markdown-link-check-disable -->
 
 | Key                     | Example                                                                                   | Description                                                                                                                                                                                                                                                                            |
 | ----------------------- | ----------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -112,7 +122,11 @@ For the FileIO there are several configuration options available:
 | adlfs.client-id         | ad667be4-b811-11ed-afa1-0242ac120002                                                      | The client-id                                                                                                                                                                                                                                                                          |
 | adlfs.client-secret     | oCA3R6P\*ka#oa1Sms2J74z...                                                                | The client-secret                                                                                                                                                                                                                                                                      |
 
+<!-- markdown-link-check-enable-->
+
 ### Google Cloud Storage
+
+<!-- markdown-link-check-disable -->
 
 | Key                        | Example             | Description                                                                                                                                                                                                                                                                                    |
 | -------------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -127,6 +141,8 @@ For the FileIO there are several configuration options available:
 | gcs.endpoint               | http://0.0.0.0:4443 | Configure an alternative endpoint for the GCS FileIO to access (format protocol://host:port) If not given, defaults to the value of environment variable "STORAGE_EMULATOR_HOST"; if that is not set either, will use the standard Google endpoint.                                            |
 | gcs.default-location       | US                  | Configure the default location where buckets are created, like 'US' or 'EUROPE-WEST3'.                                                                                                                                                                                                         |
 | gcs.version-aware          | False               | Configure whether to support object versioning on the GCS bucket.                                                                                                                                                                                                                              |
+
+<!-- markdown-link-check-enable-->
 
 ## REST Catalog
 
@@ -145,6 +161,8 @@ catalog:
       cabundle: /absolute/path/to/cabundle.pem
 ```
 
+<!-- markdown-link-check-disable -->
+
 | Key                    | Example                 | Description                                                                                        |
 | ---------------------- | ----------------------- | -------------------------------------------------------------------------------------------------- |
 | uri                    | https://rest-catalog/ws | URI identifying the REST Server                                                                    |
@@ -155,6 +173,8 @@ catalog:
 | rest.signing-region    | us-east-1               | The region to use when SigV4 signing a request                                                     |
 | rest.signing-name      | execute-api             | The service signing name to use when SigV4 signing a request                                       |
 | rest.authorization-url | https://auth-service/cc | Authentication URL to use for client credentials authentication (default: uri + 'v1/oauth/tokens') |
+
+<!-- markdown-link-check-enable-->
 
 ### Headers in RESTCatalog
 

--- a/mkdocs/docs/index.md
+++ b/mkdocs/docs/index.md
@@ -61,7 +61,7 @@ You either need to install `s3fs`, `adlfs`, `gcsfs`, or `pyarrow` to be able to 
 
 ## Connecting to a catalog
 
-Iceberg leverages the [catalog to have one centralized place to organize the tables](https://iceberg.apache.org/catalog/). This can be a traditional Hive catalog to store your Iceberg tables next to the rest, a vendor solution like the AWS Glue catalog, or an implementation of Icebergs' own [REST protocol](https://github.com/apache/iceberg/tree/main/open-api). Checkout the [configuration](configuration.md) page to find all the configuration details.
+Iceberg leverages the [catalog to have one centralized place to organize the tables](https://iceberg.apache.org/concepts/catalog/). This can be a traditional Hive catalog to store your Iceberg tables next to the rest, a vendor solution like the AWS Glue catalog, or an implementation of Icebergs' own [REST protocol](https://github.com/apache/iceberg/tree/main/open-api). Checkout the [configuration](configuration.md) page to find all the configuration details.
 
 For the sake of demonstration, we'll configure the catalog to use the `SqlCatalog` implementation, which will store information in a local `sqlite` database. We'll also configure the catalog to store data files in the local filesystem instead of an object store. This should not be used in production due to the limited scalability.
 


### PR DESCRIPTION
#324 added Github action to check link html links in docs. There are a few dead links in the most recent run. 
https://github.com/kevinjqliu/iceberg-python/actions/runs/8124843259/job/22207404913

This PR corrects the dead links or disables checking for those particular cases. 

```
ERROR: 1 dead links found!
[✖] https://iceberg.apache.org/catalog/ → Status: 404

ERROR: 6 dead links found!
[✖] https://10.0.19.25/ → Status: 0
[✖] http://my.proxy.com:8080 → Status: 0
[✖] http://localhost/ → Status: 0
[✖] http://0.0.0.0:4443 → Status: 0
[✖] https://rest-catalog/ws → Status: 0
[✖] https://auth-service/cc → Status: 0

ERROR: 1 dead links found!
[✖] reference/ → Status: 400
```

Following instructions in 
https://github.com/gaurav-nelson/github-action-markdown-link-check
