### PR TITLE
Disable Spark Catalog caching for integration tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1965,6 +1965,7 @@ def spark() -> SparkSession:
         .config("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions")
         .config("spark.sql.catalog.integration", "org.apache.iceberg.spark.SparkCatalog")
         .config("spark.sql.catalog.integration.catalog-impl", "org.apache.iceberg.rest.RESTCatalog")
+        .config("spark.sql.catalog.integration.cache-enabled", "false")
         .config("spark.sql.catalog.integration.uri", "http://localhost:8181")
         .config("spark.sql.catalog.integration.io-impl", "org.apache.iceberg.aws.s3.S3FileIO")
         .config("spark.sql.catalog.integration.warehouse", "s3://warehouse/wh/")

--- a/tests/integration/test_writes.py
+++ b/tests/integration/test_writes.py
@@ -356,8 +356,8 @@ def test_data_files(spark: SparkSession, session_catalog: Catalog, arrow_table_w
 
 
 @pytest.mark.integration
-def test_multiple_spark_sql_queries(spark: SparkSession, session_catalog: Catalog, arrow_table_with_null: pa.Table) -> None:
-    identifier = "default.multiple_spark_sql_queries"
+def test_python_writes_with_spark_snapshot_reads(spark: SparkSession, session_catalog: Catalog, arrow_table_with_null: pa.Table) -> None:
+    identifier = "default.python_writes_with_spark_snapshot_reads"
     tbl = _create_table(session_catalog, identifier, {"format-version": "1"}, [])
 
     def get_current_snapshot_id(identifier: str) -> int:

--- a/tests/integration/test_writes.py
+++ b/tests/integration/test_writes.py
@@ -356,7 +356,9 @@ def test_data_files(spark: SparkSession, session_catalog: Catalog, arrow_table_w
 
 
 @pytest.mark.integration
-def test_python_writes_with_spark_snapshot_reads(spark: SparkSession, session_catalog: Catalog, arrow_table_with_null: pa.Table) -> None:
+def test_python_writes_with_spark_snapshot_reads(
+    spark: SparkSession, session_catalog: Catalog, arrow_table_with_null: pa.Table
+) -> None:
     identifier = "default.python_writes_with_spark_snapshot_reads"
     tbl = _create_table(session_catalog, identifier, {"format-version": "1"}, [])
 

--- a/tests/integration/test_writes.py
+++ b/tests/integration/test_writes.py
@@ -356,6 +356,26 @@ def test_data_files(spark: SparkSession, session_catalog: Catalog, arrow_table_w
 
 
 @pytest.mark.integration
+def test_multiple_spark_sql_queries(spark: SparkSession, session_catalog: Catalog, arrow_table_with_null: pa.Table) -> None:
+    identifier = "default.multiple_spark_sql_queries"
+    tbl = _create_table(session_catalog, identifier, {"format-version": "1"}, [])
+
+    def get_current_snapshot_id(identifier: str) -> int:
+        return (
+            spark.sql(f"SELECT snapshot_id FROM {identifier}.snapshots order by committed_at desc limit 1")
+            .collect()[0]
+            .snapshot_id
+        )
+
+    tbl.overwrite(arrow_table_with_null)
+    assert tbl.current_snapshot().snapshot_id == get_current_snapshot_id(identifier)  # type: ignore
+    tbl.overwrite(arrow_table_with_null)
+    assert tbl.current_snapshot().snapshot_id == get_current_snapshot_id(identifier)  # type: ignore
+    tbl.append(arrow_table_with_null)
+    assert tbl.current_snapshot().snapshot_id == get_current_snapshot_id(identifier)  # type: ignore
+
+
+@pytest.mark.integration
 @pytest.mark.parametrize("format_version", [1, 2])
 @pytest.mark.parametrize(
     "properties, expected_compression_name",


### PR DESCRIPTION
Fix #482

While working on #444, I couldn't get integration tests working since using `spark.sql` to count the number of data files returns the wrong result. This becomes more bizarre when Python's iceberg table state is not the same as Spark's iceberg table state. 

This PR adds a simple test to verify that "python's iceberg table snapshot id" is the same as "spark's iceberg table's snapshot id".

The culprit is the `spark.sql.catalog.catalog-name.cache-enabled` setting, which defaults to `True` and caches table metadata. 
Spark sql calls will use the cached iceberg metadata instead of the updated one. 
```
spark.sql.catalog.catalog-name.cache-enabled	true or false	Whether to enable catalog cache, default value is true
```
https://iceberg.apache.org/docs/latest/spark-configuration/#catalog-configuration