### PR TITLE
Set table properties with dictionary

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -294,17 +294,21 @@ class Transaction:
 
         return self
 
-    def set_properties(self, **updates: str) -> Transaction:
+    def set_properties(self, properties: Properties = EMPTY_DICT, **kwargs: str) -> Transaction:
         """Set properties.
 
         When a property is already set, it will be overwritten.
 
         Args:
-            updates: The properties set on the table.
+            properties: The properties set on the table.
+            kwargs: properties can also be pass as kwargs.
 
         Returns:
             The alter table builder.
         """
+        if properties and kwargs:
+            raise ValueError("Cannot pass both properties and kwargs")
+        updates = properties or kwargs
         return self._apply((SetPropertiesUpdate(updates=updates),))
 
     def update_schema(self, allow_incompatible_changes: bool = False, case_sensitive: bool = True) -> UpdateSchema:

--- a/tests/integration/test_reads.py
+++ b/tests/integration/test_reads.py
@@ -107,20 +107,16 @@ def test_table_properties(catalog: Catalog) -> None:
 
     with table.transaction() as transaction:
         transaction.set_properties(abc="🤪")
-
     assert table.properties == dict(abc="🤪", **DEFAULT_PROPERTIES)
 
     with table.transaction() as transaction:
         transaction.remove_properties("abc")
-
     assert table.properties == DEFAULT_PROPERTIES
 
     table = table.transaction().set_properties(abc="def").commit_transaction()
-
     assert table.properties == dict(abc="def", **DEFAULT_PROPERTIES)
 
     table = table.transaction().remove_properties("abc").commit_transaction()
-
     assert table.properties == DEFAULT_PROPERTIES
 
 
@@ -133,20 +129,16 @@ def test_table_properties_dict(catalog: Catalog) -> None:
 
     with table.transaction() as transaction:
         transaction.set_properties({"abc": "🤪"})
-
     assert table.properties == dict({"abc": "🤪"}, **DEFAULT_PROPERTIES)
 
     with table.transaction() as transaction:
         transaction.remove_properties("abc")
-
     assert table.properties == DEFAULT_PROPERTIES
 
     table = table.transaction().set_properties({"abc": "def"}).commit_transaction()
-
     assert table.properties == dict({"abc": "def"}, **DEFAULT_PROPERTIES)
 
     table = table.transaction().remove_properties("abc").commit_transaction()
-
     assert table.properties == DEFAULT_PROPERTIES
 
 


### PR DESCRIPTION
Resolves #502

This PR modifies the `Transaction`s `set_properties` API to allow passing table properties either as dictionary or as kwargs
For example, 
```
with table.transaction() as transaction: 
    transaction.set_properties(abc="def")
    transaction.set_properties({"abc": "def"}) 
```

`set_properties` only allows table properties to be passed in either via dictionary or kwarg, not both. This removes complexity when both are set. 
