### PR TITLE
Allow setting non-string typed values in `set_properties`

### DIFF
--- a/pyiceberg/catalog/rest.py
+++ b/pyiceberg/catalog/rest.py
@@ -149,9 +149,12 @@ class CreateTableRequest(IcebergBaseModel):
     partition_spec: Optional[PartitionSpec] = Field(alias="partition-spec")
     write_order: Optional[SortOrder] = Field(alias="write-order")
     stage_create: bool = Field(alias="stage-create", default=False)
-    properties: Properties = Field(default_factory=dict)
+    properties: Dict[str, str] = Field(default_factory=dict)
+
     # validators
-    transform_properties_dict_value_to_str = field_validator('properties', mode='before')(transform_dict_value_to_str)
+    @field_validator('properties', mode='before')
+    def transform_properties_dict_value_to_str(cls, properties: Properties) -> Dict[str, str]:
+        return transform_dict_value_to_str(properties)
 
 
 class RegisterTableRequest(IcebergBaseModel):

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -42,7 +42,7 @@ from typing import (
     Union,
 )
 
-from pydantic import Field, SerializeAsAny
+from pydantic import Field, SerializeAsAny, field_validator
 from sortedcontainers import SortedList
 from typing_extensions import Annotated
 
@@ -124,6 +124,7 @@ from pyiceberg.types import (
     NestedField,
     PrimitiveType,
     StructType,
+    transform_dict_value_to_str,
 )
 from pyiceberg.utils.concurrent import ExecutorFactory
 from pyiceberg.utils.datetime import datetime_to_millis
@@ -293,7 +294,7 @@ class Transaction:
 
         return self
 
-    def set_properties(self, properties: Properties = EMPTY_DICT, **kwargs: str) -> Transaction:
+    def set_properties(self, properties: Properties = EMPTY_DICT, **kwargs: Any) -> Transaction:
         """Set properties.
 
         When a property is already set, it will be overwritten.
@@ -472,7 +473,9 @@ class SetLocationUpdate(TableUpdate):
 
 class SetPropertiesUpdate(TableUpdate):
     action: TableUpdateAction = TableUpdateAction.set_properties
-    updates: Dict[str, str]
+    updates: Properties
+    # validators
+    transform_properties_dict_value_to_str = field_validator('updates', mode='before')(transform_dict_value_to_str)
 
 
 class RemovePropertiesUpdate(TableUpdate):

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -473,7 +473,7 @@ class SetLocationUpdate(TableUpdate):
 
 class SetPropertiesUpdate(TableUpdate):
     action: TableUpdateAction = TableUpdateAction.set_properties
-    updates: Properties
+    updates: Dict[str, str]
 
     @field_validator('updates', mode='before')
     def transform_properties_dict_value_to_str(cls, properties: Properties) -> Dict[str, str]:

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -474,8 +474,10 @@ class SetLocationUpdate(TableUpdate):
 class SetPropertiesUpdate(TableUpdate):
     action: TableUpdateAction = TableUpdateAction.set_properties
     updates: Properties
-    # validators
-    transform_properties_dict_value_to_str = field_validator('updates', mode='before')(transform_dict_value_to_str)
+
+    @field_validator('updates', mode='before')
+    def transform_properties_dict_value_to_str(cls, properties: Properties) -> Dict[str, str]:
+        return transform_dict_value_to_str(properties)
 
 
 class RemovePropertiesUpdate(TableUpdate):

--- a/pyiceberg/table/metadata.py
+++ b/pyiceberg/table/metadata.py
@@ -221,7 +221,9 @@ class TableMetadataCommonFields(IcebergBaseModel):
     current-snapshot-id even if the refs map is null."""
 
     # validators
-    transform_properties_dict_value_to_str = field_validator('properties', mode='before')(transform_dict_value_to_str)
+    @field_validator('properties', mode='before')
+    def transform_properties_dict_value_to_str(cls, properties: Properties) -> Dict[str, str]:
+        return transform_dict_value_to_str(properties)
 
     def snapshot_by_id(self, snapshot_id: int) -> Optional[Snapshot]:
         """Get the snapshot by snapshot_id."""

--- a/tests/integration/test_reads.py
+++ b/tests/integration/test_reads.py
@@ -121,6 +121,7 @@ def test_table_properties(catalog: Catalog) -> None:
     assert table.properties == DEFAULT_PROPERTIES
 
     table = table.transaction().set_properties(abc=123).commit_transaction()
+    # properties are stored as strings in the iceberg spec
     assert table.properties == dict(abc="123", **DEFAULT_PROPERTIES)
 
     with pytest.raises(ValidationError) as exc_info:
@@ -150,6 +151,7 @@ def test_table_properties_dict(catalog: Catalog) -> None:
     assert table.properties == DEFAULT_PROPERTIES
 
     table = table.transaction().set_properties({"abc": 123}).commit_transaction()
+    # properties are stored as strings in the iceberg spec
     assert table.properties == dict({"abc": "123"}, **DEFAULT_PROPERTIES)
 
     with pytest.raises(ValidationError) as exc_info:

--- a/tests/integration/test_reads.py
+++ b/tests/integration/test_reads.py
@@ -154,6 +154,42 @@ def test_table_properties_error(catalog: Catalog) -> None:
 
 @pytest.mark.integration
 @pytest.mark.parametrize('catalog', [pytest.lazy_fixture('catalog_hive'), pytest.lazy_fixture('catalog_rest')])
+def test_table_properties_dict(catalog: Catalog) -> None:
+    table = create_table(catalog)
+
+    assert table.properties == DEFAULT_PROPERTIES
+
+    with table.transaction() as transaction:
+        transaction.set_properties({"abc": "🤪"})
+
+    assert table.properties == dict({"abc": "🤪"}, **DEFAULT_PROPERTIES)
+
+    with table.transaction() as transaction:
+        transaction.remove_properties("abc")
+
+    assert table.properties == DEFAULT_PROPERTIES
+
+    table = table.transaction().set_properties({"abc": "def"}).commit_transaction()
+
+    assert table.properties == dict({"abc": "def"}, **DEFAULT_PROPERTIES)
+
+    table = table.transaction().remove_properties("abc").commit_transaction()
+
+    assert table.properties == DEFAULT_PROPERTIES
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize('catalog', [pytest.lazy_fixture('catalog_hive'), pytest.lazy_fixture('catalog_rest')])
+def test_table_properties_error(catalog: Catalog) -> None:
+    table = create_table(catalog)
+    properties = {"abc": "def"}
+    with pytest.raises(ValueError) as e:
+        table.transaction().set_properties(properties, abc="def").commit_transaction()
+    assert "Cannot pass both properties and kwargs" in str(e.value)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize('catalog', [pytest.lazy_fixture('catalog_hive'), pytest.lazy_fixture('catalog_rest')])
 def test_pyarrow_nan(catalog: Catalog) -> None:
     table_test_null_nan = catalog.load_table("default.test_null_nan")
     arrow_table = table_test_null_nan.scan(row_filter=IsNaN("col_numeric"), selected_fields=("idx", "col_numeric")).to_arrow()

--- a/tests/integration/test_reads.py
+++ b/tests/integration/test_reads.py
@@ -171,38 +171,6 @@ def test_table_properties_error(catalog: Catalog) -> None:
 
 @pytest.mark.integration
 @pytest.mark.parametrize('catalog', [pytest.lazy_fixture('catalog_hive'), pytest.lazy_fixture('catalog_rest')])
-def test_table_properties_dict(catalog: Catalog) -> None:
-    table = create_table(catalog)
-
-    assert table.properties == DEFAULT_PROPERTIES
-
-    with table.transaction() as transaction:
-        transaction.set_properties({"abc": "🤪"})
-    assert table.properties == dict({"abc": "🤪"}, **DEFAULT_PROPERTIES)
-
-    with table.transaction() as transaction:
-        transaction.remove_properties("abc")
-    assert table.properties == DEFAULT_PROPERTIES
-
-    table = table.transaction().set_properties({"abc": "def"}).commit_transaction()
-    assert table.properties == dict({"abc": "def"}, **DEFAULT_PROPERTIES)
-
-    table = table.transaction().remove_properties("abc").commit_transaction()
-    assert table.properties == DEFAULT_PROPERTIES
-
-
-@pytest.mark.integration
-@pytest.mark.parametrize('catalog', [pytest.lazy_fixture('catalog_hive'), pytest.lazy_fixture('catalog_rest')])
-def test_table_properties_error(catalog: Catalog) -> None:
-    table = create_table(catalog)
-    properties = {"abc": "def"}
-    with pytest.raises(ValueError) as e:
-        table.transaction().set_properties(properties, abc="def").commit_transaction()
-    assert "Cannot pass both properties and kwargs" in str(e.value)
-
-
-@pytest.mark.integration
-@pytest.mark.parametrize('catalog', [pytest.lazy_fixture('catalog_hive'), pytest.lazy_fixture('catalog_rest')])
 def test_pyarrow_nan(catalog: Catalog) -> None:
     table_test_null_nan = catalog.load_table("default.test_null_nan")
     arrow_table = table_test_null_nan.scan(row_filter=IsNaN("col_numeric"), selected_fields=("idx", "col_numeric")).to_arrow()

--- a/tests/integration/test_reads.py
+++ b/tests/integration/test_reads.py
@@ -161,20 +161,16 @@ def test_table_properties_dict(catalog: Catalog) -> None:
 
     with table.transaction() as transaction:
         transaction.set_properties({"abc": "🤪"})
-
     assert table.properties == dict({"abc": "🤪"}, **DEFAULT_PROPERTIES)
 
     with table.transaction() as transaction:
         transaction.remove_properties("abc")
-
     assert table.properties == DEFAULT_PROPERTIES
 
     table = table.transaction().set_properties({"abc": "def"}).commit_transaction()
-
     assert table.properties == dict({"abc": "def"}, **DEFAULT_PROPERTIES)
 
     table = table.transaction().remove_properties("abc").commit_transaction()
-
     assert table.properties == DEFAULT_PROPERTIES
 
 

--- a/tests/integration/test_reads.py
+++ b/tests/integration/test_reads.py
@@ -119,6 +119,9 @@ def test_table_properties(catalog: Catalog) -> None:
     table = table.transaction().remove_properties("abc").commit_transaction()
     assert table.properties == DEFAULT_PROPERTIES
 
+    table = table.transaction().set_properties(abc=123).commit_transaction()
+    assert table.properties == dict(abc="123", **DEFAULT_PROPERTIES)
+
 
 @pytest.mark.integration
 @pytest.mark.parametrize('catalog', [pytest.lazy_fixture('catalog_hive'), pytest.lazy_fixture('catalog_rest')])
@@ -140,6 +143,9 @@ def test_table_properties_dict(catalog: Catalog) -> None:
 
     table = table.transaction().remove_properties("abc").commit_transaction()
     assert table.properties == DEFAULT_PROPERTIES
+
+    table = table.transaction().set_properties({"abc": 123}).commit_transaction()
+    assert table.properties == dict({"abc": "123"}, **DEFAULT_PROPERTIES)
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Requires #503 to be merged first, extension of #502. 

This PR modifies `Transaction`'s `set_properties` API to accept table properties as type `Dict[str, Any]`, either as dictionary or kwargs. 

For example, 
```
with table.transaction() as transaction:
    transaction.set_properties(abc=123)
    transaction.set_properties({"abc": 123})
```

This is done by reusing the field validator defined in #469. Setting `None` property value is disallowed since the transformation will change None to str "None" which is unintuitive.

#### Note
The Iceberg spec stores table properties as strings. That is why when setting a property value as int, reading it back produces a string.
```
table = table.transaction().set_properties({"abc": 123}).commit_transaction()
assert table.properties.get("abc") == "123"
```
Use `PropertyUtil.property_as_int` to return property value as int
```
table = table.transaction().set_properties({"abc": 123}).commit_transaction()
assert PropertyUtil.property_as_int("abc") == 123
```