### PR TITLE
[Bug fix] update name mapping in Transaction.update_schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ test-integration:
 	docker-compose -f dev/docker-compose-integration.yml up -d
 	sleep 10
 	docker-compose -f dev/docker-compose-integration.yml exec -T spark-iceberg ipython ./provision.py
-	poetry run pytest tests/ -v -m integration ${PYTEST_ARGS}
+	poetry run pytest tests/integration/test_rest_schema.py -v -m integration ${PYTEST_ARGS}
 
 test-integration-rebuild:
 	docker-compose -f dev/docker-compose-integration.yml kill

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ test-integration:
 	docker-compose -f dev/docker-compose-integration.yml up -d
 	sleep 10
 	docker-compose -f dev/docker-compose-integration.yml exec -T spark-iceberg ipython ./provision.py
-	poetry run pytest tests/integration/test_rest_schema.py -v -m integration ${PYTEST_ARGS}
+	poetry run pytest tests/ -v -m integration ${PYTEST_ARGS}
 
 test-integration-rebuild:
 	docker-compose -f dev/docker-compose-integration.yml kill

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -321,7 +321,12 @@ class Transaction:
         Returns:
             A new UpdateSchema.
         """
-        return UpdateSchema(self, allow_incompatible_changes=allow_incompatible_changes, case_sensitive=case_sensitive)
+        return UpdateSchema(
+            self,
+            allow_incompatible_changes=allow_incompatible_changes,
+            case_sensitive=case_sensitive,
+            name_mapping=self._table.name_mapping(),
+        )
 
     def update_snapshot(self) -> UpdateSnapshot:
         """Create a new UpdateSnapshot to produce a new snapshot for the table.

--- a/tests/integration/test_rest_schema.py
+++ b/tests/integration/test_rest_schema.py
@@ -672,9 +672,13 @@ def test_rename_simple(simple_table: Table) -> None:
     with simple_table.update_schema() as schema_update:
         schema_update.rename_column("foo", "vo")
 
+    with simple_table.transaction() as txn:
+        with txn.update_schema() as schema_update:
+            schema_update.rename_column("bar", "var")
+
     assert simple_table.schema() == Schema(
         NestedField(field_id=1, name="vo", field_type=StringType(), required=False),
-        NestedField(field_id=2, name="bar", field_type=IntegerType(), required=True),
+        NestedField(field_id=2, name="var", field_type=IntegerType(), required=True),
         NestedField(field_id=3, name="baz", field_type=BooleanType(), required=False),
         identifier_field_ids=[2],
     )
@@ -682,7 +686,7 @@ def test_rename_simple(simple_table: Table) -> None:
     # Check that the name mapping gets updated
     assert simple_table.name_mapping() == NameMapping([
         MappedField(field_id=1, names=['foo', 'vo']),
-        MappedField(field_id=2, names=['bar']),
+        MappedField(field_id=2, names=['bar', 'var']),
         MappedField(field_id=3, names=['baz']),
     ])
 


### PR DESCRIPTION
Also update name mapping if schema is updated through a Transaction.

[Related PR](https://github.com/apache/iceberg-python/pull/441)

This PR fixes the current behavior, which only updates the name mapping if UpdateSchema is created from the Table.update_schema function. Transaction.update_schema should also pass the name_mapping of the table.

```
    with simple_table.transaction() as txn:
        with txn.update_schema() as schema_update:
            schema_update.rename_column("bar", "var")
```