### PR TITLE
[Bug Fix] Allow Partition data to be nullable in ManifestEntry

### DIFF
--- a/pyiceberg/manifest.py
+++ b/pyiceberg/manifest.py
@@ -308,6 +308,7 @@ def data_file_with_partition(partition_type: StructType, format_version: Literal
             field_id=field.field_id,
             name=field.name,
             field_type=partition_field_to_data_file_partition_field(field.field_type),
+            required=False,
         )
         for field in partition_type.fields
     ])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -892,7 +892,7 @@ manifest_entry_records = [
         "data_file": {
             "file_path": "/home/iceberg/warehouse/nyc/taxis_partitioned/data/VendorID=1/00000-633-d8a4223e-dc97-45a1-86e1-adaba6e8abd7-00002.parquet",
             "file_format": "PARQUET",
-            "partition": {"VendorID": 1, "tpep_pickup_datetime": 1925},
+            "partition": {"VendorID": 1, "tpep_pickup_datetime": None},
             "record_count": 95050,
             "file_size_in_bytes": 1265950,
             "block_size_in_bytes": 67108864,


### PR DESCRIPTION
Similar to how the [partition fields are already initialized](https://github.com/apache/iceberg-python/blob/pyiceberg-0.6.x/pyiceberg/partitioning.py#L193) with `required=False` in `partition_type`, we should set `required=False` in the manifest_entry schema within the ManifestFile.

This PR introduces this fix first from @jqin61 's WIP PR, so other PRs that add partition values to manifest files can be unblocked.

Without this change, we cannot serialize None partition values into the ManifestEntry in the avro file.

Below WIP PRs require this change
Partitioned Write: https://github.com/apache/iceberg-python/pull/353
Add Files: https://github.com/apache/iceberg-python/pull/506

