### PR TITLE
Add partition stats in snapshot summary

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -2572,13 +2572,11 @@ class _MergingSnapshotProducer(UpdateTableMetadata["_MergingSnapshotProducer"]):
 
     def _summary(self) -> Summary:
         ssc = SnapshotSummaryCollector()
-        partition_summary_limit = self._transaction.table_metadata.properties.get(
-            TableProperties.WRITE_PARTITION_SUMMARY_LIMIT, TableProperties.WRITE_PARTITION_SUMMARY_LIMIT_DEFAULT
-        )
-        if isinstance(partition_summary_limit, str):
-            raise ValueError(
-                f"WRITE_PARTITION_SUMMARY_LIMIT in table properties should be int but get str: {partition_summary_limit}"
+        partition_summary_limit = int(
+            self._transaction.table_metadata.properties.get(
+                TableProperties.WRITE_PARTITION_SUMMARY_LIMIT, TableProperties.WRITE_PARTITION_SUMMARY_LIMIT_DEFAULT
             )
+        )
         ssc.set_partition_summary_limit(partition_summary_limit)
 
         for data_file in self._added_data_files:

--- a/pyiceberg/table/snapshots.py
+++ b/pyiceberg/table/snapshots.py
@@ -92,24 +92,6 @@ class UpdateMetrics:
     added_eq_deletes: int
     removed_eq_deletes: int
 
-    # def clear() {
-    #     self.added_file_size = 0
-    #     self.removed_file_size = 0
-    #     self.added_data_files = 0
-    #     self.removed_data_files = 0
-    #     self.added_eq_delete_files = 0
-    #     self.removed_eq_delete_files = 0
-    #     self.added_pos_delete_files = 0
-    #     self.removed_pos_delete_files = 0
-    #     self.added_delete_files = 0
-    #     self.removed_delete_files = 0
-    #     self.added_records = 0
-    #     self.deleted_records = 0
-    #     self.added_pos_deletes = 0
-    #     self.removed_pos_deletes = 0
-    #     self.added_eq_deletes = 0
-    #     self.removed_eq_deletes = 0
-    # }
     def __init__(self) -> None:
         self.added_file_size = 0
         self.removed_file_size = 0
@@ -303,7 +285,7 @@ class SnapshotSummaryCollector:
         self.metrics.remove_file(data_file)
         if getattr(data_file, "partition", None) is not None and len(data_file.partition.record_fields()) != 0:
             if partition_spec is None or schema is None:
-                raise ValueError("add data file with partition but without specifying the partiton_spec and schema")
+                raise ValueError("remove data file with partition but without specifying the partiton_spec and schema")
             self.update_partition_metrics(partition_spec=partition_spec, file=data_file, is_add_file=False, schema=schema)
 
     def update_partition_metrics(self, partition_spec: PartitionSpec, file: DataFile, is_add_file: bool, schema: Schema) -> None:

--- a/pyiceberg/table/snapshots.py
+++ b/pyiceberg/table/snapshots.py
@@ -15,19 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 import time
+from collections import defaultdict
 from enum import Enum
-from typing import (
-    Any,
-    Dict,
-    List,
-    Mapping,
-    Optional,
-)
+from typing import Any, DefaultDict, Dict, List, Mapping, Optional
 
 from pydantic import Field, PrivateAttr, model_serializer
 
 from pyiceberg.io import FileIO
 from pyiceberg.manifest import DataFile, DataFileContent, ManifestFile, read_manifest_list
+from pyiceberg.partitioning import PartitionSpec
+from pyiceberg.schema import Schema
 from pyiceberg.typedef import IcebergBaseModel
 
 ADDED_DATA_FILES = 'added-data-files'
@@ -52,8 +49,8 @@ TOTAL_DATA_FILES = 'total-data-files'
 TOTAL_DELETE_FILES = 'total-delete-files'
 TOTAL_RECORDS = 'total-records'
 TOTAL_FILE_SIZE = 'total-files-size'
-
-
+CHANGED_PARTITION_COUNT_PROP = 'changed-partition-count'
+CHANGED_PARTITION_PREFIX = "partitions."
 OPERATION = "operation"
 
 
@@ -75,6 +72,147 @@ class Operation(Enum):
     def __repr__(self) -> str:
         """Return the string representation of the Operation class."""
         return f"Operation.{self.name}"
+
+
+class UpdateMetrics:
+    added_file_size: int
+    removed_file_size: int
+    added_data_files: int
+    removed_data_files: int
+    added_eq_delete_files: int
+    removed_eq_delete_files: int
+    added_pos_delete_files: int
+    removed_pos_delete_files: int
+    added_delete_files: int
+    removed_delete_files: int
+    added_records: int
+    deleted_records: int
+    added_pos_deletes: int
+    removed_pos_deletes: int
+    added_eq_deletes: int
+    removed_eq_deletes: int
+
+    # def clear() {
+    #     self.added_file_size = 0
+    #     self.removed_file_size = 0
+    #     self.added_data_files = 0
+    #     self.removed_data_files = 0
+    #     self.added_eq_delete_files = 0
+    #     self.removed_eq_delete_files = 0
+    #     self.added_pos_delete_files = 0
+    #     self.removed_pos_delete_files = 0
+    #     self.added_delete_files = 0
+    #     self.removed_delete_files = 0
+    #     self.added_records = 0
+    #     self.deleted_records = 0
+    #     self.added_pos_deletes = 0
+    #     self.removed_pos_deletes = 0
+    #     self.added_eq_deletes = 0
+    #     self.removed_eq_deletes = 0
+    # }
+    def __init__(self) -> None:
+        self.added_file_size = 0
+        self.removed_file_size = 0
+        self.added_data_files = 0
+        self.removed_data_files = 0
+        self.added_eq_delete_files = 0
+        self.removed_eq_delete_files = 0
+        self.added_pos_delete_files = 0
+        self.removed_pos_delete_files = 0
+        self.added_delete_files = 0
+        self.removed_delete_files = 0
+        self.added_records = 0
+        self.deleted_records = 0
+        self.added_pos_deletes = 0
+        self.removed_pos_deletes = 0
+        self.added_eq_deletes = 0
+        self.removed_eq_deletes = 0
+
+    # def added_file(file: DataFile) -> None:
+    #     self.added_file_size += file.file_size_in_bytes
+    #     if file.content == DataFileContent.DATA:
+    #         self.added_data_files += 1
+    #         self.added_records += file.record_count
+    #     elif file.content == DataFileContent.POSITION_DELETES:
+    #         self.added_delete_files += 1
+    #         self.added_pos_delete_files += 1
+    #         self.added_pos_deletes += file.record_count
+    #     elif file.content == DataFileContent.EQUALITY_DELETES:
+    #         self.added_delete_files += 1
+    #         self.added_eq_delete_files += 1
+    #         self.added_eq_deletes += file.record_count
+    #     else:
+    #         raise ValueError("Unsupported file content type: " + file.content())
+
+    # def removed_file(file: DataFile) -> None:
+    #     self.removed_file_size += file.file_size_in_bytes
+    #     if file.content == DataFileContent.DATA:
+    #         self.removed_data_files += 1
+    #         self.deleted_records += file.record_count
+    #     elif file.content == DataFileContent.POSITION_DELETES:
+    #         self.removed_delete_files += 1
+    #         self.removed_pos_delete_files += 1
+    #         self.removed_pos_deletes += file.record_count
+    #     elif file.content == DataFileContent.EQUALITY_DELETES
+    #         self.removed_delete_files += 1
+    #         self.removed_eq_delete_files += 1
+    #         self.removed_eq_deletes += file.record_count
+    #     else:
+    #         raise ValueError("Unsupported file content type: " + file.content())
+
+    def add_file(self, data_file: DataFile) -> None:
+        self.added_file_size += data_file.file_size_in_bytes
+
+        if data_file.content == DataFileContent.DATA:
+            self.added_data_files += 1
+            self.added_records += data_file.record_count
+        elif data_file.content == DataFileContent.POSITION_DELETES:
+            self.added_delete_files += 1
+            self.added_pos_delete_files += 1
+            self.added_pos_deletes += data_file.record_count
+        elif data_file.content == DataFileContent.EQUALITY_DELETES:
+            self.added_delete_files += 1
+            self.added_eq_delete_files += 1
+            self.added_eq_deletes += data_file.record_count
+        else:
+            raise ValueError(f"Unknown data file content: {data_file.content}")
+
+    def remove_file(self, data_file: DataFile) -> None:
+        self.removed_file_size += data_file.file_size_in_bytes
+
+        if data_file.content == DataFileContent.DATA:
+            self.removed_data_files += 1
+            self.deleted_records += data_file.record_count
+        elif data_file.content == DataFileContent.POSITION_DELETES:
+            self.removed_delete_files += 1
+            self.removed_pos_delete_files += 1
+            self.removed_pos_deletes += data_file.record_count
+        elif data_file.content == DataFileContent.EQUALITY_DELETES:
+            self.removed_delete_files += 1
+            self.removed_eq_delete_files += 1
+            self.removed_eq_deletes += data_file.record_count
+        else:
+            raise ValueError(f"Unknown data file content: {data_file.content}")
+
+    def to_dict(self) -> Dict[str, str]:
+        properties: Dict[str, str] = {}
+        set_when_positive(properties, self.added_file_size, ADDED_FILE_SIZE)
+        set_when_positive(properties, self.removed_file_size, REMOVED_FILE_SIZE)
+        set_when_positive(properties, self.added_data_files, ADDED_DATA_FILES)
+        set_when_positive(properties, self.removed_data_files, DELETED_DATA_FILES)
+        set_when_positive(properties, self.added_eq_delete_files, ADDED_EQUALITY_DELETE_FILES)
+        set_when_positive(properties, self.removed_eq_delete_files, REMOVED_EQUALITY_DELETE_FILES)
+        set_when_positive(properties, self.added_pos_delete_files, ADDED_POSITION_DELETE_FILES)
+        set_when_positive(properties, self.removed_pos_delete_files, REMOVED_POSITION_DELETE_FILES)
+        set_when_positive(properties, self.added_delete_files, ADDED_DELETE_FILES)
+        set_when_positive(properties, self.removed_delete_files, REMOVED_DELETE_FILES)
+        set_when_positive(properties, self.added_records, ADDED_RECORDS)
+        set_when_positive(properties, self.deleted_records, DELETED_RECORDS)
+        set_when_positive(properties, self.added_pos_deletes, ADDED_POSITION_DELETES)
+        set_when_positive(properties, self.removed_pos_deletes, REMOVED_POSITION_DELETES)
+        set_when_positive(properties, self.added_eq_deletes, ADDED_EQUALITY_DELETES)
+        set_when_positive(properties, self.removed_eq_deletes, REMOVED_EQUALITY_DELETES)
+        return properties
 
 
 class Summary(IcebergBaseModel, Mapping[str, str]):
@@ -172,99 +310,56 @@ class SnapshotLogEntry(IcebergBaseModel):
 
 
 class SnapshotSummaryCollector:
-    added_file_size: int
-    removed_file_size: int
-    added_data_files: int
-    removed_data_files: int
-    added_eq_delete_files: int
-    removed_eq_delete_files: int
-    added_pos_delete_files: int
-    removed_pos_delete_files: int
-    added_delete_files: int
-    removed_delete_files: int
-    added_records: int
-    deleted_records: int
-    added_pos_deletes: int
-    removed_pos_deletes: int
-    added_eq_deletes: int
-    removed_eq_deletes: int
+    metrics: UpdateMetrics
+    partition_metrics: DefaultDict[str, UpdateMetrics]
+    max_changed_partitions_for_summaries: int
 
     def __init__(self) -> None:
-        self.added_file_size = 0
-        self.removed_file_size = 0
-        self.added_data_files = 0
-        self.removed_data_files = 0
-        self.added_eq_delete_files = 0
-        self.removed_eq_delete_files = 0
-        self.added_pos_delete_files = 0
-        self.removed_pos_delete_files = 0
-        self.added_delete_files = 0
-        self.removed_delete_files = 0
-        self.added_records = 0
-        self.deleted_records = 0
-        self.added_pos_deletes = 0
-        self.removed_pos_deletes = 0
-        self.added_eq_deletes = 0
-        self.removed_eq_deletes = 0
+        self.metrics = UpdateMetrics()
+        self.partition_metrics = defaultdict(UpdateMetrics)
+        self.max_changed_partitions_for_summaries = 0
 
-    def add_file(self, data_file: DataFile) -> None:
-        self.added_file_size += data_file.file_size_in_bytes
+    def set_partition_summary_limit(self, limit: int) -> None:
+        self.max_changed_partitions_for_summaries = limit
 
-        if data_file.content == DataFileContent.DATA:
-            self.added_data_files += 1
-            self.added_records += data_file.record_count
-        elif data_file.content == DataFileContent.POSITION_DELETES:
-            self.added_delete_files += 1
-            self.added_pos_delete_files += 1
-            self.added_pos_deletes += data_file.record_count
-        elif data_file.content == DataFileContent.EQUALITY_DELETES:
-            self.added_delete_files += 1
-            self.added_eq_delete_files += 1
-            self.added_eq_deletes += data_file.record_count
+    def add_file(
+        self, data_file: DataFile, partition_spec: Optional[PartitionSpec] = None, schema: Optional[Schema] = None
+    ) -> None:
+        self.metrics.add_file(data_file)
+        if getattr(data_file, "partition", None) is not None and len(data_file.partition.record_fields()) != 0:
+            if partition_spec is None or schema is None:
+                raise ValueError("add data file with partition but without specifying the partiton_spec and schema")
+            self.update_partition_metrics(partition_spec=partition_spec, file=data_file, is_add_file=True, schema=schema)
+
+    def remove_file(self, data_file: DataFile, partition_spec: Optional[PartitionSpec], schema: Optional[Schema]) -> None:
+        self.metrics.remove_file(data_file)
+        if getattr(data_file, "partition", None) is not None and len(data_file.partition.record_fields()) != 0:
+            if partition_spec is None or schema is None:
+                raise ValueError("add data file with partition but without specifying the partiton_spec and schema")
+            self.update_partition_metrics(partition_spec=partition_spec, file=data_file, is_add_file=False, schema=schema)
+
+    def update_partition_metrics(self, partition_spec: PartitionSpec, file: DataFile, is_add_file: bool, schema: Schema) -> None:
+        partition_path = partition_spec.partition_to_path(file.partition, schema)
+        partition_metrics: UpdateMetrics = self.partition_metrics[partition_path]
+
+        if is_add_file:
+            partition_metrics.add_file(file)
         else:
-            raise ValueError(f"Unknown data file content: {data_file.content}")
-
-    def remove_file(self, data_file: DataFile) -> None:
-        self.removed_file_size += data_file.file_size_in_bytes
-
-        if data_file.content == DataFileContent.DATA:
-            self.removed_data_files += 1
-            self.deleted_records += data_file.record_count
-        elif data_file.content == DataFileContent.POSITION_DELETES:
-            self.removed_delete_files += 1
-            self.removed_pos_delete_files += 1
-            self.removed_pos_deletes += data_file.record_count
-        elif data_file.content == DataFileContent.EQUALITY_DELETES:
-            self.removed_delete_files += 1
-            self.removed_eq_delete_files += 1
-            self.removed_eq_deletes += data_file.record_count
-        else:
-            raise ValueError(f"Unknown data file content: {data_file.content}")
+            partition_metrics.remove_file(file)
 
     def build(self) -> Dict[str, str]:
-        def set_when_positive(properties: Dict[str, str], num: int, property_name: str) -> None:
-            if num > 0:
-                properties[property_name] = str(num)
-
-        properties: Dict[str, str] = {}
-        set_when_positive(properties, self.added_file_size, ADDED_FILE_SIZE)
-        set_when_positive(properties, self.removed_file_size, REMOVED_FILE_SIZE)
-        set_when_positive(properties, self.added_data_files, ADDED_DATA_FILES)
-        set_when_positive(properties, self.removed_data_files, DELETED_DATA_FILES)
-        set_when_positive(properties, self.added_eq_delete_files, ADDED_EQUALITY_DELETE_FILES)
-        set_when_positive(properties, self.removed_eq_delete_files, REMOVED_EQUALITY_DELETE_FILES)
-        set_when_positive(properties, self.added_pos_delete_files, ADDED_POSITION_DELETE_FILES)
-        set_when_positive(properties, self.removed_pos_delete_files, REMOVED_POSITION_DELETE_FILES)
-        set_when_positive(properties, self.added_delete_files, ADDED_DELETE_FILES)
-        set_when_positive(properties, self.removed_delete_files, REMOVED_DELETE_FILES)
-        set_when_positive(properties, self.added_records, ADDED_RECORDS)
-        set_when_positive(properties, self.deleted_records, DELETED_RECORDS)
-        set_when_positive(properties, self.added_pos_deletes, ADDED_POSITION_DELETES)
-        set_when_positive(properties, self.removed_pos_deletes, REMOVED_POSITION_DELETES)
-        set_when_positive(properties, self.added_eq_deletes, ADDED_EQUALITY_DELETES)
-        set_when_positive(properties, self.removed_eq_deletes, REMOVED_EQUALITY_DELETES)
+        properties = self.metrics.to_dict()
+        changed_partitions_size = len(self.partition_metrics)
+        set_when_positive(properties, changed_partitions_size, CHANGED_PARTITION_COUNT_PROP)
+        if changed_partitions_size <= self.max_changed_partitions_for_summaries:
+            for partition_path, update_metrics_partition in self.partition_metrics.items():
+                if (summary := self.partition_summary(update_metrics_partition)) and len(summary) != 0:
+                    properties[CHANGED_PARTITION_PREFIX + partition_path] = summary
 
         return properties
+
+    def partition_summary(self, update_metrics: UpdateMetrics) -> str:
+        return ",".join([f"{prop}={val}" for prop, val in update_metrics.to_dict().items()])
 
 
 def _truncate_table_summary(summary: Summary, previous_summary: Mapping[str, str]) -> Summary:
@@ -366,3 +461,8 @@ def update_snapshot_summaries(
     )
 
     return summary
+
+
+def set_when_positive(properties: Dict[str, str], num: int, property_name: str) -> None:
+    if num > 0:
+        properties[property_name] = str(num)

--- a/pyiceberg/table/snapshots.py
+++ b/pyiceberg/table/snapshots.py
@@ -128,38 +128,6 @@ class UpdateMetrics:
         self.added_eq_deletes = 0
         self.removed_eq_deletes = 0
 
-    # def added_file(file: DataFile) -> None:
-    #     self.added_file_size += file.file_size_in_bytes
-    #     if file.content == DataFileContent.DATA:
-    #         self.added_data_files += 1
-    #         self.added_records += file.record_count
-    #     elif file.content == DataFileContent.POSITION_DELETES:
-    #         self.added_delete_files += 1
-    #         self.added_pos_delete_files += 1
-    #         self.added_pos_deletes += file.record_count
-    #     elif file.content == DataFileContent.EQUALITY_DELETES:
-    #         self.added_delete_files += 1
-    #         self.added_eq_delete_files += 1
-    #         self.added_eq_deletes += file.record_count
-    #     else:
-    #         raise ValueError("Unsupported file content type: " + file.content())
-
-    # def removed_file(file: DataFile) -> None:
-    #     self.removed_file_size += file.file_size_in_bytes
-    #     if file.content == DataFileContent.DATA:
-    #         self.removed_data_files += 1
-    #         self.deleted_records += file.record_count
-    #     elif file.content == DataFileContent.POSITION_DELETES:
-    #         self.removed_delete_files += 1
-    #         self.removed_pos_delete_files += 1
-    #         self.removed_pos_deletes += file.record_count
-    #     elif file.content == DataFileContent.EQUALITY_DELETES
-    #         self.removed_delete_files += 1
-    #         self.removed_eq_delete_files += 1
-    #         self.removed_eq_deletes += file.record_count
-    #     else:
-    #         raise ValueError("Unsupported file content type: " + file.content())
-
     def add_file(self, data_file: DataFile) -> None:
         self.added_file_size += data_file.file_size_in_bytes
 

--- a/tests/integration/test_writes.py
+++ b/tests/integration/test_writes.py
@@ -525,12 +525,15 @@ def test_summaries_with_only_nulls(
         'total-records': '2',
     }
 
-    assert summaries[0] == {
-        'total-data-files': '0',
-        'total-delete-files': '0',
+    assert summaries[2] == {
+        'removed-files-size': '4239',
         'total-equality-deletes': '0',
-        'total-files-size': '0',
         'total-position-deletes': '0',
+        'deleted-data-files': '1',
+        'total-delete-files': '0',
+        'total-files-size': '0',
+        'deleted-records': '2',
+        'total-data-files': '0',
         'total-records': '0',
     }
 

--- a/tests/table/test_snapshots.py
+++ b/tests/table/test_snapshots.py
@@ -18,7 +18,17 @@
 import pytest
 
 from pyiceberg.manifest import DataFile, DataFileContent, ManifestContent, ManifestFile
+from pyiceberg.partitioning import PartitionField, PartitionSpec
+from pyiceberg.schema import Schema
 from pyiceberg.table.snapshots import Operation, Snapshot, SnapshotSummaryCollector, Summary, update_snapshot_summaries
+from pyiceberg.transforms import IdentityTransform
+from pyiceberg.typedef import Record
+from pyiceberg.types import (
+    BooleanType,
+    IntegerType,
+    NestedField,
+    StringType,
+)
 
 
 @pytest.fixture
@@ -146,6 +156,11 @@ def data_file() -> DataFile:
     )
 
 
+@pytest.fixture
+def data_file_with_partition() -> DataFile:
+    return DataFile(content=DataFileContent.DATA, record_count=100, file_size_in_bytes=1234, partition=Record(int_field=1))
+
+
 def test_snapshot_summary_collector(data_file: DataFile) -> None:
     ssc = SnapshotSummaryCollector()
 
@@ -157,6 +172,32 @@ def test_snapshot_summary_collector(data_file: DataFile) -> None:
         'added-data-files': '1',
         'added-files-size': '1234',
         'added-records': '100',
+    }
+
+
+def test_snapshot_summary_collector_with_partition(data_file_with_partition: DataFile) -> None:
+    ssc = SnapshotSummaryCollector()
+
+    assert ssc.build() == {}
+    schema = Schema(
+        NestedField(field_id=1, name="bool_field", field_type=BooleanType(), required=False),
+        NestedField(field_id=2, name="string_field", field_type=StringType(), required=False),
+        NestedField(field_id=3, name="int_field", field_type=IntegerType(), required=False),
+    )
+    spec = PartitionSpec(PartitionField(source_id=3, field_id=1001, transform=IdentityTransform(), name='int_field'))
+    ssc.set_partition_summary_limit(10)
+    ssc.add_file(data_file=data_file_with_partition, schema=schema, partition_spec=spec)
+    ssc.remove_file(data_file=data_file_with_partition, schema=schema, partition_spec=spec)
+
+    assert ssc.build() == {
+        'added-files-size': '1234',
+        'removed-files-size': '1234',
+        'added-data-files': '1',
+        'deleted-data-files': '1',
+        'added-records': '100',
+        'deleted-records': '100',
+        'changed-partition-count': '1',
+        'partitions.int_field=1': 'added-files-size=1234,removed-files-size=1234,added-data-files=1,deleted-data-files=1,added-records=100,deleted-records=100',
     }
 
 

--- a/tests/table/test_snapshots.py
+++ b/tests/table/test_snapshots.py
@@ -147,21 +147,13 @@ def manifest_file() -> ManifestFile:
     )
 
 
-@pytest.fixture
-def data_file() -> DataFile:
-    return DataFile(
-        content=DataFileContent.DATA,
-        record_count=100,
-        file_size_in_bytes=1234,
-    )
-
-
-def test_snapshot_summary_collector(data_file: DataFile) -> None:
+@pytest.mark.integration
+def test_snapshot_summary_collector(table_schema_simple: Schema) -> None:
     ssc = SnapshotSummaryCollector()
 
     assert ssc.build() == {}
-
-    ssc.add_file(data_file)
+    data_file = DataFile(content=DataFileContent.DATA, record_count=100, file_size_in_bytes=1234, partition=Record())
+    ssc.add_file(data_file, schema=table_schema_simple)
 
     assert ssc.build() == {
         'added-data-files': '1',
@@ -170,6 +162,7 @@ def test_snapshot_summary_collector(data_file: DataFile) -> None:
     }
 
 
+@pytest.mark.integration
 def test_snapshot_summary_collector_with_partition() -> None:
     # Given
 


### PR DESCRIPTION
Changes include:

- add write.summary.partition-limit to table properties
- add changed-partition-count to snapshot summary
- add partition stats. these are key value pairs whose key is like partitiion.<partition_key> and whose value is like a nested mini-summary string concatenated by ','.
For example: 
```'partitions.int_field=1': 'added-files-size=1234,removed-files-size=1234,added-data-files=1,deleted-data-files=1,added-records=100,deleted-records=100'```