### PR TITLE
Glue endpoint config variable

### DIFF
--- a/pyiceberg/catalog/glue.py
+++ b/pyiceberg/catalog/glue.py
@@ -105,6 +105,10 @@ GLUE_ID = "glue.id"
 GLUE_SKIP_ARCHIVE = "glue.skip-archive"
 GLUE_SKIP_ARCHIVE_DEFAULT = True
 
+# Configure an alternative endpoint of the Glue service for GlueCatalog to access.
+# This could be used to use GlueCatalog with any glue-compatible metastore service that has a different endpoint
+GLUE_CATALOG_ENDPOINT = "glue.endpoint"
+
 ICEBERG_FIELD_ID = "iceberg.field.id"
 ICEBERG_FIELD_OPTIONAL = "iceberg.field.optional"
 ICEBERG_FIELD_CURRENT = "iceberg.field.current"
@@ -285,7 +289,7 @@ class GlueCatalog(Catalog):
             aws_secret_access_key=properties.get("aws_secret_access_key"),
             aws_session_token=properties.get("aws_session_token"),
         )
-        self.glue: GlueClient = session.client("glue")
+        self.glue: GlueClient = session.client("glue", endpoint_url=properties.get(GLUE_CATALOG_ENDPOINT))
 
         if glue_catalog_id := properties.get(GLUE_ID):
             _register_glue_catalog_id_with_glue_client(self.glue, glue_catalog_id)

--- a/tests/catalog/test_glue.py
+++ b/tests/catalog/test_glue.py
@@ -700,11 +700,3 @@ def test_glue_endpoint_override(moto_endpoint_url: str, database_name: str) -> N
         catalog_name, **{"s3.endpoint": moto_endpoint_url, "warehouse": f"s3://{BUCKET_NAME}", "glue.endpoint": moto_endpoint_url}
     )
     assert test_catalog.glue.meta.endpoint_url == moto_endpoint_url
-
-    test_catalog.create_namespace(namespace=database_name)
-    assert (database_name,) in test_catalog.list_namespaces()
-
-    with mock_aws():
-        other_catalog = GlueCatalog(catalog_name, **{"s3.endpoint": moto_endpoint_url, "warehouse": f"s3://{BUCKET_NAME}"})
-        assert other_catalog.glue.meta.endpoint_url != moto_endpoint_url
-        assert (database_name,) not in other_catalog.list_namespaces()


### PR DESCRIPTION
Closes: https://github.com/apache/iceberg-python/issues/414

I don't know java, but tried to stay true to [the implementation](https://github.com/apache/iceberg/blob/053d54172fd903be9eda78957f3cbd3aadef1f7b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java#L97-L103), at least in regards to the commenting.

Open Questions:
1. I did a very basic test, but I wasn't sure if I should make the test more robust in any regard. Let me know if you think of an edge case I am missing. I could test creating/listing a namespace if that would be helpful to confirm its truly working properly, but that felt like a moto issue, rather than something that should be tested within pyiceberg.
2. On my end, I am using `glue.endpoint` for all pytests. I was not sure if within pyiceberg pytests, we wanted to migrate all tests to the endpoint, or continue to use `mock_aws()`. I started with the least invasive option, but can migrate all other glue tests if that is helpful.
3. I am not seeing a ton of docs regarding glue config variables, and its is undocumented in [the main docs](https://iceberg.apache.org/docs/latest/). Within pyiceberg docs, I do see [this Glue config](https://py.iceberg.apache.org/configuration/#glue-catalog), but not sure if this is the best place to put it. Should this get added to the docs, or should it remain undocumented, since its not a commonly used feature?

@Fokko @HonahX both of your thoughts or reviews would be helpful, thanks!