### PR TITLE
Fix Glue Integration test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1858,7 +1858,7 @@ def get_s3_path(bucket_name: str, database_name: Optional[str] = None, table_nam
 
 @pytest.fixture(name="s3", scope="module")
 def fixture_s3_client() -> boto3.client:
-    """Real S3 client for AWS Integration Tests"""
+    """Real S3 client for AWS Integration Tests."""
     yield boto3.client("s3")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1858,8 +1858,8 @@ def get_s3_path(bucket_name: str, database_name: Optional[str] = None, table_nam
 
 @pytest.fixture(name="s3", scope="module")
 def fixture_s3_client() -> boto3.client:
-    with mock_aws():
-        yield boto3.client("s3")
+    """Real S3 client for AWS Integration Tests"""
+    yield boto3.client("s3")
 
 
 def clean_up(test_catalog: Catalog) -> None:


### PR DESCRIPTION
Currently, the glue integration tests fail because the real s3 client fixture is wrapped with mocking environment. 