### PR TITLE
Implement __getstate__ and __setstate__ on PyArrowFileIO and FsSpecFileIO so that they can be pickled

### DIFF
--- a/pyiceberg/io/fsspec.py
+++ b/pyiceberg/io/fsspec.py
@@ -20,6 +20,7 @@ import errno
 import json
 import logging
 import os
+from copy import copy
 from functools import lru_cache, partial
 from typing import (
     Any,
@@ -338,3 +339,14 @@ class FsspecFileIO(FileIO):
         if scheme not in self._scheme_to_fs:
             raise ValueError(f"No registered filesystem for scheme: {scheme}")
         return self._scheme_to_fs[scheme](self.properties)
+
+    def __getstate__(self) -> Dict[str, Any]:
+        """Create a dictionary of the FsSpecFileIO fields used when pickling."""
+        fileio_copy = copy(self.__dict__)
+        fileio_copy["get_fs"] = None
+        return fileio_copy
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        """Deserialize the state into a FsSpecFileIO instance."""
+        self.__dict__ = state
+        self.get_fs = lru_cache(self._get_fs)


### PR DESCRIPTION
We cannot pickle FileIO implementations currently due to the file system initialization being inside a LruCache wrapper instance.

For example if one tries to pickle.dumps(pyarowfileIO) now they will encounter the following error.

```
_pickle.PicklingError: Can't pickle <functools._lru_cache_wrapper object at 0x75ebdf179010>: it's not the same object as pyiceberg.io.pyarrow.PyArrowFileIO._initialize_fs
```

This change implements __getstate__ and __setstate__ on PyArrowFileIO and FsSpecFileIO so that they can be pickled

This is a pre-requisite to being able to serialize the Table instance.