### PR TITLE
[Bug Fix] Fix TableMetadataV1 Validators

### DIFF
--- a/pyiceberg/table/metadata.py
+++ b/pyiceberg/table/metadata.py
@@ -366,6 +366,11 @@ class TableMetadataV1(TableMetadataCommonFields, IcebergBaseModel):
                 fields = data[PARTITION_SPEC]
                 data[PARTITION_SPECS] = [{SPEC_ID: INITIAL_SPEC_ID, FIELDS: fields}]
                 data[DEFAULT_SPEC_ID] = INITIAL_SPEC_ID
+            elif data.get("partition_spec") is not None:
+                # Promote the spec from partition_spec to partition-specs
+                fields = data["partition_spec"]
+                data[PARTITION_SPECS] = [{SPEC_ID: INITIAL_SPEC_ID, FIELDS: fields}]
+                data[DEFAULT_SPEC_ID] = INITIAL_SPEC_ID
             else:
                 data[PARTITION_SPECS] = [{"field-id": 0, "fields": ()}]
 
@@ -389,7 +394,7 @@ class TableMetadataV1(TableMetadataCommonFields, IcebergBaseModel):
         Returns:
             The TableMetadata with the sort_orders set, if not provided.
         """
-        if not data.get(SORT_ORDERS):
+        if not data.get(SORT_ORDERS) and not data.get("sort_orders"):
             data[SORT_ORDERS] = [UNSORTED_SORT_ORDER]
         return data
 

--- a/tests/table/test_metadata.py
+++ b/tests/table/test_metadata.py
@@ -233,6 +233,11 @@ def test_new_table_metadata_with_explicit_v1_format() -> None:
 
     expected_spec = PartitionSpec(PartitionField(source_id=2, field_id=1000, transform=IdentityTransform(), name="bar"))
 
+    expected_sort_order = SortOrder(
+        SortField(source_id=1, transform=IdentityTransform(), direction=SortDirection.ASC, null_order=NullOrder.NULLS_LAST),
+        order_id=1,
+    )
+
     expected = TableMetadataV1(
         location="s3://some_v1_location/",
         table_uuid=actual.table_uuid,
@@ -250,20 +255,16 @@ def test_new_table_metadata_with_explicit_v1_format() -> None:
         snapshots=[],
         snapshot_log=[],
         metadata_log=[],
-        sort_orders=[
-            SortOrder(
-                SortField(
-                    source_id=1, transform=IdentityTransform(), direction=SortDirection.ASC, null_order=NullOrder.NULLS_LAST
-                ),
-                order_id=1,
-            )
-        ],
+        sort_orders=[expected_sort_order],
         default_sort_order_id=1,
         refs={},
         format_version=1,
     )
 
     assert actual.model_dump() == expected.model_dump()
+    assert actual.schemas == [expected_schema]
+    assert actual.partition_specs == [expected_spec]
+    assert actual.sort_orders == [expected_sort_order]
 
 
 def test_invalid_format_version(example_table_metadata_v1: Dict[str, Any]) -> None:


### PR DESCRIPTION
When working on https://github.com/apache/iceberg-python/pull/498, I noticed that `new_table_metadata` cannot correctly initialize `partition_specs` and `sort_oders` fields for V1 Metadata. For example:

```python
    schema = ... 
    
   partition_spec = PartitionSpec(
        PartitionField(source_id=22, field_id=1022, transform=IdentityTransform(), name="bar"), spec_id=10
    )

    sort_order = SortOrder(
        SortField(source_id=10, transform=IdentityTransform(), direction=SortDirection.ASC, null_order=NullOrder.NULLS_LAST),
        order_id=10,
    )

    actual = new_table_metadata(
        schema=schema,
        partition_spec=partition_spec,
        sort_order=sort_order,
        location="s3://some_v1_location/",
        properties={'format-version': "1"},
    )
--------   
print(actual.partition_specs)
--- output ---
[PartitionSpec(spec_id=0)]

--------
print(actual.sort_orders)
--- output ---
[SortOrder(order_id=0)]

```

We may update the validators to consider both the field name and its alias. (ex "sort_orders" and "sort-orders") so that the validators won't override any initialized fields.

cc: @Fokko @amogh-jahagirdar 