### PR TITLE
Read: fetch file_schema directly from pyarrow_to_schema

### DIFF
--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -969,9 +969,11 @@ def _task_to_table(
         schema_raw = None
         if metadata := physical_schema.metadata:
             schema_raw = metadata.get(ICEBERG_SCHEMA)
-        file_schema = (
-            Schema.model_validate_json(schema_raw) if schema_raw is not None else pyarrow_to_schema(physical_schema, name_mapping)
-        )
+        # file_schema = (
+        #     Schema.model_validate_json(schema_raw) if schema_raw is not None else pyarrow_to_schema(physical_schema, name_mapping)
+        # )
+
+        file_schema = pyarrow_to_schema(physical_schema, name_mapping)
 
         pyarrow_filter = None
         if bound_row_filter is not AlwaysTrue():
@@ -979,7 +981,7 @@ def _task_to_table(
             bound_file_filter = bind(file_schema, translated_row_filter, case_sensitive=case_sensitive)
             pyarrow_filter = expression_to_pyarrow(bound_file_filter)
 
-        file_project_schema = sanitize_column_names(prune_columns(file_schema, projected_field_ids, select_full_types=False))
+        file_project_schema = prune_columns(file_schema, projected_field_ids, select_full_types=False)
 
         if file_schema is None:
             raise ValueError(f"Missing Iceberg schema in Metadata for file: {path}")

--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -122,7 +122,6 @@ from pyiceberg.schema import (
     pre_order_visit,
     promote,
     prune_columns,
-    sanitize_column_names,
     visit,
     visit_with_partner,
 )
@@ -966,13 +965,6 @@ def _task_to_table(
     with fs.open_input_file(path) as fin:
         fragment = arrow_format.make_fragment(fin)
         physical_schema = fragment.physical_schema
-        schema_raw = None
-        if metadata := physical_schema.metadata:
-            schema_raw = metadata.get(ICEBERG_SCHEMA)
-        # file_schema = (
-        #     Schema.model_validate_json(schema_raw) if schema_raw is not None else pyarrow_to_schema(physical_schema, name_mapping)
-        # )
-
         file_schema = pyarrow_to_schema(physical_schema, name_mapping)
 
         pyarrow_filter = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,7 +92,7 @@ if TYPE_CHECKING:
     from moto.server import ThreadedMotoServer  # type: ignore
     from pyspark.sql import SparkSession
 
-    from pyiceberg.io.pyarrow import PyArrowFileIO
+    from pyiceberg.io.pyarrow import PyArrowFileIO, schema_to_pyarrow
 
 
 def pytest_collection_modifyitems(items: List[pytest.Item]) -> None:
@@ -1930,10 +1930,11 @@ def clean_up(test_catalog: Catalog) -> None:
 def data_file(table_schema_simple: Schema, tmp_path: str) -> str:
     import pyarrow as pa
     from pyarrow import parquet as pq
+    from pyiceberg.io.pyarrow import schema_to_pyarrow
 
     table = pa.table(
         {"foo": ["a", "b", "c"], "bar": [1, 2, 3], "baz": [True, False, None]},
-        metadata={"iceberg.schema": table_schema_simple.model_dump_json()},
+        schema=schema_to_pyarrow(table_schema_simple),
     )
 
     file_path = f"{tmp_path}/0000-data.parquet"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,7 +92,7 @@ if TYPE_CHECKING:
     from moto.server import ThreadedMotoServer  # type: ignore
     from pyspark.sql import SparkSession
 
-    from pyiceberg.io.pyarrow import PyArrowFileIO, schema_to_pyarrow
+    from pyiceberg.io.pyarrow import PyArrowFileIO
 
 
 def pytest_collection_modifyitems(items: List[pytest.Item]) -> None:
@@ -1930,6 +1930,7 @@ def clean_up(test_catalog: Catalog) -> None:
 def data_file(table_schema_simple: Schema, tmp_path: str) -> str:
     import pyarrow as pa
     from pyarrow import parquet as pq
+
     from pyiceberg.io.pyarrow import schema_to_pyarrow
 
     table = pa.table(

--- a/tests/integration/test_writes/test_writes.py
+++ b/tests/integration/test_writes/test_writes.py
@@ -767,3 +767,22 @@ def test_hive_catalog_storage_descriptor(
     assert len(tbl.scan().to_arrow()) == 3
     # check if spark can read the table
     assert spark.sql("SELECT * FROM hive.default.test_storage_descriptor").count() == 3
+
+
+@pytest.mark.integration
+def test_python_writes_special_character_column_with_spark_reads(spark: SparkSession, session_catalog: Catalog) -> None:
+    identifier = "default.python_writes_special_character_column_with_spark_reads"
+    column_name_with_special_character = "letter/abc"
+    TEST_DATA_WITH_SPECIAL_CHARACTER_COLUMN = {
+        column_name_with_special_character: ['a', None, 'z'],
+    }
+    pa_schema = pa.schema([
+        (column_name_with_special_character, pa.string()),
+    ])
+    arrow_table_with_special_character_column = pa.Table.from_pydict(TEST_DATA_WITH_SPECIAL_CHARACTER_COLUMN, schema=pa_schema)
+    tbl = _create_table(session_catalog, identifier, {"format-version": "1"}, schema=pa_schema)
+
+    tbl.overwrite(arrow_table_with_special_character_column)
+    spark_df = spark.sql(f"SELECT * FROM {identifier}").toPandas()
+    pyiceberg_df = tbl.scan().to_pandas()
+    assert spark_df.equals(pyiceberg_df)

--- a/tests/integration/test_writes/test_writes.py
+++ b/tests/integration/test_writes/test_writes.py
@@ -789,25 +789,3 @@ def test_hive_catalog_storage_descriptor(
     assert len(tbl.scan().to_arrow()) == 3
     # check if spark can read the table
     assert spark.sql("SELECT * FROM hive.default.test_storage_descriptor").count() == 3
-
-
-@pytest.mark.integration
-@pytest.mark.parametrize("format_version", [1, 2])
-def test_python_writes_special_character_column_with_spark_reads(
-    spark: SparkSession, session_catalog: Catalog, format_version: int
-) -> None:
-    identifier = "default.python_writes_special_character_column_with_spark_reads"
-    column_name_with_special_character = "letter/abc"
-    TEST_DATA_WITH_SPECIAL_CHARACTER_COLUMN = {
-        column_name_with_special_character: ['a', None, 'z'],
-    }
-    pa_schema = pa.schema([
-        (column_name_with_special_character, pa.string()),
-    ])
-    arrow_table_with_special_character_column = pa.Table.from_pydict(TEST_DATA_WITH_SPECIAL_CHARACTER_COLUMN, schema=pa_schema)
-    tbl = _create_table(session_catalog, identifier, {"format-version": format_version}, schema=pa_schema)
-
-    tbl.overwrite(arrow_table_with_special_character_column)
-    spark_df = spark.sql(f"SELECT * FROM {identifier}").toPandas()
-    pyiceberg_df = tbl.scan().to_pandas()
-    assert spark_df.equals(pyiceberg_df)

--- a/tests/integration/test_writes/test_writes.py
+++ b/tests/integration/test_writes/test_writes.py
@@ -272,7 +272,10 @@ def test_python_writes_with_spark_snapshot_reads(
 
 
 @pytest.mark.integration
-def test_python_writes_special_character_column_with_spark_reads(spark: SparkSession, session_catalog: Catalog) -> None:
+@pytest.mark.parametrize("format_version", [1, 2])
+def test_python_writes_special_character_column_with_spark_reads(
+    spark: SparkSession, session_catalog: Catalog, format_version: int
+) -> None:
     identifier = "default.python_writes_special_character_column_with_spark_reads"
     column_name_with_special_character = "letter/abc"
     TEST_DATA_WITH_SPECIAL_CHARACTER_COLUMN = {
@@ -282,7 +285,7 @@ def test_python_writes_special_character_column_with_spark_reads(spark: SparkSes
         (column_name_with_special_character, pa.string()),
     ])
     arrow_table_with_special_character_column = pa.Table.from_pydict(TEST_DATA_WITH_SPECIAL_CHARACTER_COLUMN, schema=pa_schema)
-    tbl = _create_table(session_catalog, identifier, {"format-version": "1"}, schema=pa_schema)
+    tbl = _create_table(session_catalog, identifier, {"format-version": format_version}, schema=pa_schema)
 
     tbl.overwrite(arrow_table_with_special_character_column)
     spark_df = spark.sql(f"SELECT * FROM {identifier}").toPandas()

--- a/tests/integration/test_writes/test_writes.py
+++ b/tests/integration/test_writes/test_writes.py
@@ -272,6 +272,25 @@ def test_python_writes_with_spark_snapshot_reads(
 
 
 @pytest.mark.integration
+def test_python_writes_special_character_column_with_spark_reads(spark: SparkSession, session_catalog: Catalog) -> None:
+    identifier = "default.python_writes_special_character_column_with_spark_reads"
+    column_name_with_special_character = "letter/abc"
+    TEST_DATA_WITH_SPECIAL_CHARACTER_COLUMN = {
+        column_name_with_special_character: ['a', None, 'z'],
+    }
+    pa_schema = pa.schema([
+        (column_name_with_special_character, pa.string()),
+    ])
+    arrow_table_with_special_character_column = pa.Table.from_pydict(TEST_DATA_WITH_SPECIAL_CHARACTER_COLUMN, schema=pa_schema)
+    tbl = _create_table(session_catalog, identifier, {"format-version": "1"}, schema=pa_schema)
+
+    tbl.overwrite(arrow_table_with_special_character_column)
+    spark_df = spark.sql(f"SELECT * FROM {identifier}").toPandas()
+    pyiceberg_df = tbl.scan().to_pandas()
+    assert spark_df.equals(pyiceberg_df)
+
+
+@pytest.mark.integration
 def test_write_bin_pack_data_files(spark: SparkSession, session_catalog: Catalog, arrow_table_with_null: pa.Table) -> None:
     identifier = "default.write_bin_pack_data_files"
     tbl = _create_table(session_catalog, identifier, {"format-version": "1"}, [])

--- a/tests/integration/test_writes/test_writes.py
+++ b/tests/integration/test_writes/test_writes.py
@@ -770,7 +770,10 @@ def test_hive_catalog_storage_descriptor(
 
 
 @pytest.mark.integration
-def test_python_writes_special_character_column_with_spark_reads(spark: SparkSession, session_catalog: Catalog) -> None:
+@pytest.mark.parametrize("format_version", [1, 2])
+def test_python_writes_special_character_column_with_spark_reads(
+    spark: SparkSession, session_catalog: Catalog, format_version: int
+) -> None:
     identifier = "default.python_writes_special_character_column_with_spark_reads"
     column_name_with_special_character = "letter/abc"
     TEST_DATA_WITH_SPECIAL_CHARACTER_COLUMN = {
@@ -780,7 +783,7 @@ def test_python_writes_special_character_column_with_spark_reads(spark: SparkSes
         (column_name_with_special_character, pa.string()),
     ])
     arrow_table_with_special_character_column = pa.Table.from_pydict(TEST_DATA_WITH_SPECIAL_CHARACTER_COLUMN, schema=pa_schema)
-    tbl = _create_table(session_catalog, identifier, {"format-version": "1"}, schema=pa_schema)
+    tbl = _create_table(session_catalog, identifier, {"format-version": format_version}, schema=pa_schema)
 
     tbl.overwrite(arrow_table_with_special_character_column)
     spark_df = spark.sql(f"SELECT * FROM {identifier}").toPandas()

--- a/tests/integration/test_writes/utils.py
+++ b/tests/integration/test_writes/utils.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint:disable=redefined-outer-name
-from typing import List, Optional
+from typing import List, Optional, Union
 
 import pyarrow as pa
 
@@ -65,6 +65,7 @@ def _create_table(
     properties: Properties,
     data: Optional[List[pa.Table]] = None,
     partition_spec: Optional[PartitionSpec] = None,
+    schema: Union[Schema, "pa.Schema"] = TABLE_SCHEMA,
 ) -> Table:
     try:
         session_catalog.drop_table(identifier=identifier)
@@ -73,10 +74,10 @@ def _create_table(
 
     if partition_spec:
         tbl = session_catalog.create_table(
-            identifier=identifier, schema=TABLE_SCHEMA, properties=properties, partition_spec=partition_spec
+            identifier=identifier, schema=schema, properties=properties, partition_spec=partition_spec
         )
     else:
-        tbl = session_catalog.create_table(identifier=identifier, schema=TABLE_SCHEMA, properties=properties)
+        tbl = session_catalog.create_table(identifier=identifier, schema=schema, properties=properties)
 
     if data:
         for d in data:

--- a/tests/io/test_pyarrow.py
+++ b/tests/io/test_pyarrow.py
@@ -1373,7 +1373,7 @@ def test_delete(deletes_file: str, example_task: FileScanTask, table_schema_simp
         str(with_deletes)
         == """pyarrow.Table
 foo: string
-bar: int64 not null
+bar: int32 not null
 baz: bool
 ----
 foo: [["a","c"]]
@@ -1411,7 +1411,7 @@ def test_delete_duplicates(deletes_file: str, example_task: FileScanTask, table_
         str(with_deletes)
         == """pyarrow.Table
 foo: string
-bar: int64 not null
+bar: int32 not null
 baz: bool
 ----
 foo: [["a","c"]]
@@ -1442,7 +1442,7 @@ def test_pyarrow_wrap_fsspec(example_task: FileScanTask, table_schema_simple: Sc
         str(projection)
         == """pyarrow.Table
 foo: string
-bar: int64 not null
+bar: int32 not null
 baz: bool
 ----
 foo: [["a","b","c"]]


### PR DESCRIPTION
https://github.com/apache/iceberg-python/issues/584#issuecomment-2049204249

> If we truly read by Field-IDs the names should be irrelevant, so we should probably update our mapping to ensure we correctly project by IDs.

I think we do correctly project by IDs. The real problem is the way that we sanitize the column names.
In https://github.com/apache/iceberg-python/pull/83, we add sanitize [the file_schema](https://github.com/apache/iceberg-python/blob/main/pyiceberg/io/pyarrow.py#L982C9-L982C126) in _task_to_table with the assumption that the column name  of the parquet file follows the Avro Naming spec. However, I think the "sanitization" should be more general here: it should just ensure that the final `file_project_schema` contains the same column names of the parquet file's schema. 

The names in `file_schema` are different from the actual column names in the parquet file because we first try to load the file schema from the json string stored in the parquet file metadata: [link](https://github.com/apache/iceberg-python/blob/main/pyiceberg/io/pyarrow.py#L982C9-L982C126)
```python
file_schema = (
            Schema.model_validate_json(schema_raw) if schema_raw is not None else pyarrow_to_schema(physical_schema, name_mapping)
        )
```
Parquet files written by iceberg java contain this metadata json string. The json string represents the iceberg table schema at the time of writting the file. Therefore, it contains un-sanitized column names. 

Since we always need to run a visitor to sanitize/ensure column names match, how about we just get the `file_schema` directly from the pyarrow physical schema?
```python
file_schema = pyarrow_to_schema(physical_schema, name_mapping)
```
This way, we can ensure that the column names match, and thus do not need to sanitize the column names later.

I have verified that changing to this can fix both the sanitization issue in #83 and the issue here. Given that we want to align the writing behavior with the java implementation, we should also proceed #590.

Borrowed the integration test from https://github.com/apache/iceberg-python/pull/590