### PR TITLE
Backport: Exclude `docutils!=0.21` as a dependency (#615)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ typing-extensions = "4.9.0"
 pytest-mock = "3.12.0"
 pyspark = "3.5.0"
 cython = "3.0.8"
+docutils = "!=0.21"
 
 [[tool.mypy.overrides]]
 module = "pytest_mock.*"


### PR DESCRIPTION
This release is bodged, and causes Poetry to fail when it tries to fetch the tar:

https://github.com/python-poetry/poetry/issues/9293#issuecomment-2048205226

It is being tracked:
https://github.com/pypi/warehouse/issues/15749

A fix is inbound here:
https://github.com/pypi/warehouse/pull/15795

This is a hotfix for this particular package, until the fixes from `pypi/warehouse` are out. The `post` notation is very unique: https://github.com/pypi/warehouse/issues/15749#issuecomment-2048216953 and is being used in 0.004% of the releases.