### PR TITLE
Verify release quality of life improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ test-coverage:
 	docker compose -f dev/docker-compose-integration.yml up -d
 	sh ./dev/run-azurite.sh
 	sh ./dev/run-gcs-server.sh
+	sleep 10
 	docker compose -f dev/docker-compose-integration.yml exec -T spark-iceberg ipython ./provision.py
 	poetry run coverage run --source=pyiceberg/ -m pytest tests/ ${PYTEST_ARGS}
 	poetry run coverage report -m --fail-under=90

--- a/mkdocs/docs/how-to-release.md
+++ b/mkdocs/docs/how-to-release.md
@@ -143,6 +143,10 @@ https://pypi.org/project/pyiceberg/$VERSION/
 
 And can be installed using: pip3 install pyiceberg==$VERSION
 
+Instructions for verifying a release can be found here:
+
+* https://py.iceberg.apache.org/verify-release/
+
 Please download, verify, and test.
 
 Please vote in the next 72 hours.

--- a/mkdocs/docs/verify-release.md
+++ b/mkdocs/docs/verify-release.md
@@ -108,7 +108,7 @@ To run the full integration tests:
 make test-integration
 ```
 
-This will spin up Docker containers to faciliate integration tests.
+This will spin up Docker containers to faciliate running integration tests.
 
 # Cast the vote
 

--- a/mkdocs/docs/verify-release.md
+++ b/mkdocs/docs/verify-release.md
@@ -108,7 +108,7 @@ To run the full integration tests:
 make test-integration
 ```
 
-This will include a Minio S3 container being spun up.
+This will spin up Docker containers to faciliate integration tests.
 
 # Cast the vote
 

--- a/mkdocs/docs/verify-release.md
+++ b/mkdocs/docs/verify-release.md
@@ -102,13 +102,13 @@ And then run the tests:
 make test
 ```
 
-To run the full integration tests:
+To run the full test coverage:
 
 ```sh
-make test-integration
+make test-coverage
 ```
 
-This will spin up Docker containers to faciliate running integration tests.
+This will spin up Docker containers to faciliate running test coverage.
 
 # Cast the vote
 

--- a/mkdocs/docs/verify-release.md
+++ b/mkdocs/docs/verify-release.md
@@ -105,7 +105,7 @@ make test
 To run the full integration tests:
 
 ```sh
-make test-s3
+make test-integration
 ```
 
 This will include a Minio S3 container being spun up.

--- a/mkdocs/docs/verify-release.md
+++ b/mkdocs/docs/verify-release.md
@@ -114,6 +114,8 @@ This will include a Minio S3 container being spun up.
 
 Votes are cast by replying to the release candidate announcement email on the dev mailing list with either `+1`, `0`, or `-1`. For example :
 
-> \[ \] +1 Release this as PyIceberg 0.3.0 \[ \] +0 \[ \] -1 Do not release this because…
+> \[ \] +1 Release this as PyIceberg 0.3.0  
+> \[ \] +0  
+> \[ \] -1 Do not release this because…
 
 In addition to your vote, it’s customary to specify if your vote is binding or non-binding. Only members of the Project Management Committee have formally binding votes. If you’re unsure, you can specify that your vote is non-binding. To read more about voting in the Apache framework, checkout the [Voting](https://www.apache.org/foundation/voting.html) information page on the Apache foundation’s website.

--- a/mkdocs/docs/verify-release.md
+++ b/mkdocs/docs/verify-release.md
@@ -114,8 +114,8 @@ This will spin up Docker containers to faciliate running integration tests.
 
 Votes are cast by replying to the release candidate announcement email on the dev mailing list with either `+1`, `0`, or `-1`. For example :
 
-> \[ \] +1 Release this as PyIceberg 0.3.0  
-> \[ \] +0  
-> \[ \] -1 Do not release this because…
+> \[ \] +1 Release this as PyIceberg 0.3.0 <br>
+> \[ \] +0 <br>
+> \[ \] -1 Do not release this because… <br>
 
 In addition to your vote, it’s customary to specify if your vote is binding or non-binding. Only members of the Project Management Committee have formally binding votes. If you’re unsure, you can specify that your vote is non-binding. To read more about voting in the Apache framework, checkout the [Voting](https://www.apache.org/foundation/voting.html) information page on the Apache foundation’s website.


### PR DESCRIPTION
Minor edits to the "Verify Release" instructions. 
Added link to "verify release" in the release email.

Here's what the "Cast the vote" section look like in Markdown. Versus [current](https://py.iceberg.apache.org/verify-release/)
![Screenshot 2024-04-18 at 3 05 03 PM](https://github.com/apache/iceberg-python/assets/9057843/aa78f859-16b8-4947-b0af-4f0ba084bc21)
