### PR TITLE
CI: Update provision.py without rebuilding the integration-test image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ test-integration:
 	docker compose -f dev/docker-compose-integration.yml rm -f
 	docker compose -f dev/docker-compose-integration.yml up -d
 	sleep 10
+	docker compose -f dev/docker-compose-integration.yml cp ./dev/provision.py spark-iceberg:/opt/spark/provision.py
 	docker compose -f dev/docker-compose-integration.yml exec -T spark-iceberg ipython ./provision.py
 	poetry run pytest tests/ -v -m integration ${PYTEST_ARGS}
 
@@ -64,6 +65,7 @@ test-coverage:
 	sh ./dev/run-azurite.sh
 	sh ./dev/run-gcs-server.sh
 	sleep 10
+	docker compose -f dev/docker-compose-integration.yml cp ./dev/provision.py spark-iceberg:/opt/spark/provision.py
 	docker compose -f dev/docker-compose-integration.yml exec -T spark-iceberg ipython ./provision.py
 	poetry run coverage run --source=pyiceberg/ -m pytest tests/ ${PYTEST_ARGS}
 	poetry run coverage report -m --fail-under=90


### PR DESCRIPTION
When developers want to write an integration test,  we should add some DDLs  (create tables and insert data)  to `provision.py`.
Before running `make test-integration`, we should run `make test-integration-rebuild` to rebuild the image, which takes up a significant amount of time if the DDLs are modified frequently (the developer might make several attempts).

This PR uses `docker cp` to upload the latest `provision.py` to the running container without rebuild the image.