### PR TITLE
Bump pyiceberg to 0.6.0 on integration tests

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -39,7 +39,7 @@ WORKDIR ${SPARK_HOME}
 ENV SPARK_VERSION=3.4.3
 ENV ICEBERG_SPARK_RUNTIME_VERSION=3.4_2.12
 ENV ICEBERG_VERSION=1.4.2
-ENV PYICEBERG_VERSION=0.5.1
+ENV PYICEBERG_VERSION=0.6.0
 
 RUN curl --retry 3 -s -C - https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz -o spark-${SPARK_VERSION}-bin-hadoop3.tgz \
  && tar xzf spark-${SPARK_VERSION}-bin-hadoop3.tgz --directory /opt/spark --strip-components 1 \


### PR DESCRIPTION
Resolves #625 

Just for documentation purposes, the integration tests do not run on ARM processors, so we need to define the default platform as amd64.

`export DOCKER_DEFAULT_PLATFORM=linux/amd64` 