### PR TITLE
Bump Iceberg to 1.5.0 on integration tests

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -38,7 +38,7 @@ WORKDIR ${SPARK_HOME}
 
 ENV SPARK_VERSION=3.5.0
 ENV ICEBERG_SPARK_RUNTIME_VERSION=3.5_2.12
-ENV ICEBERG_VERSION=1.4.2
+ENV ICEBERG_VERSION=1.5.0
 ENV PYICEBERG_VERSION=0.6.0
 
 RUN curl --retry 3 -s -C - https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz -o spark-${SPARK_VERSION}-bin-hadoop3.tgz \


### PR DESCRIPTION
Resolves #624 