### PR TITLE
Remove hard-coded release version

### DIFF
--- a/mkdocs/docs/verify-release.md
+++ b/mkdocs/docs/verify-release.md
@@ -48,6 +48,7 @@ Set an environment variable to the version to verify and path to use
 
 ```sh
 export PYICEBERG_VERSION=<version> # e.g. 0.6.1rc3
+export PYICEBERG_RELEASE_VERSION=${PYICEBERG_VERSION/rc?/}  # remove rcX qualifier
 export PYICEBERG_VERIFICATION_DIR=/tmp/pyiceberg/${PYICEBERG_VERSION}
 ```
 
@@ -77,8 +78,8 @@ done
 ## Verifying License Documentation
 
 ```sh
-tar xzf pyiceberg-0.5.0.tar.gz
-cd pyiceberg-0.5.0
+tar xzf pyiceberg-${PYICEBERG_RELEASE_VERSION}.tar.gz
+cd pyiceberg-${PYICEBERG_RELEASE_VERSION}
 ```
 
 Run RAT checks to validate license header:

--- a/mkdocs/docs/verify-release.md
+++ b/mkdocs/docs/verify-release.md
@@ -45,12 +45,14 @@ gpg --import KEYS
 ```
 
 Set an environment variable to the version to verify and path to use
+
 ```sh
 export PYICEBERG_VERSION=<version> # e.g. 0.6.1rc3
 export PYICEBERG_VERIFICATION_DIR=/tmp/pyiceberg/${PYICEBERG_VERSION}
 ```
 
 Next, verify the `.asc` file.
+
 ```sh
 svn checkout https://dist.apache.org/repos/dist/dev/iceberg/pyiceberg-${PYICEBERG_VERSION}/ ${PYICEBERG_VERIFICATION_DIR}
 

--- a/mkdocs/docs/verify-release.md
+++ b/mkdocs/docs/verify-release.md
@@ -48,7 +48,6 @@ Set an environment variable to the version to verify and path to use
 
 ```sh
 export PYICEBERG_VERSION=<version> # e.g. 0.6.1rc3
-export PYICEBERG_RELEASE_VERSION=${PYICEBERG_VERSION/rc?/}  # remove rcX qualifier
 export PYICEBERG_VERIFICATION_DIR=/tmp/pyiceberg/${PYICEBERG_VERSION}
 ```
 
@@ -78,6 +77,7 @@ done
 ## Verifying License Documentation
 
 ```sh
+export PYICEBERG_RELEASE_VERSION=${PYICEBERG_VERSION/rc?/}  # remove rcX qualifier
 tar xzf pyiceberg-${PYICEBERG_RELEASE_VERSION}.tar.gz
 cd pyiceberg-${PYICEBERG_RELEASE_VERSION}
 ```

--- a/mkdocs/docs/verify-release.md
+++ b/mkdocs/docs/verify-release.md
@@ -44,12 +44,19 @@ curl https://dist.apache.org/repos/dist/dev/iceberg/KEYS -o KEYS
 gpg --import KEYS
 ```
 
-Next, verify the `.asc` file.
-
+Set an environment variable to the version to verify and path to use
 ```sh
-svn checkout https://dist.apache.org/repos/dist/dev/iceberg/pyiceberg-0.5.0rc1/ /tmp/pyiceberg/
+export PYICEBERG_VERSION=<version> # e.g. 0.6.1rc3
+export PYICEBERG_VERIFICATION_DIR=/tmp/pyiceberg/${PYICEBERG_VERSION}
+```
 
-for name in $(ls /tmp/pyiceberg/pyiceberg-*.whl /tmp/pyiceberg/pyiceberg-*.tar.gz)
+Next, verify the `.asc` file.
+```sh
+svn checkout https://dist.apache.org/repos/dist/dev/iceberg/pyiceberg-${PYICEBERG_VERSION}/ ${PYICEBERG_VERIFICATION_DIR}
+
+cd ${PYICEBERG_VERIFICATION_DIR}
+
+for name in $(ls pyiceberg-*.whl pyiceberg-*.tar.gz)
 do
     gpg --verify ${name}.asc ${name}
 done
@@ -58,8 +65,8 @@ done
 ## Verifying checksums
 
 ```sh
-cd  /tmp/pyiceberg/
-for name in $(ls /tmp/pyiceberg/pyiceberg-*.whl.sha512 /tmp/pyiceberg/pyiceberg-*.tar.gz.sha512)
+cd ${PYICEBERG_VERIFICATION_DIR}
+for name in $(ls pyiceberg-*.whl.sha512 pyiceberg-*.tar.gz.sha512)
 do
     shasum -a 512 --check ${name}
 done


### PR DESCRIPTION
Improves the verification steps to:
- not include a hard coded version (could result in users verifying the wrong version)
- use distinct paths so that the verification directory isn't reused across versions