### PR TITLE
Change suggestions to PyArrow

### DIFF
--- a/mkdocs/docs/contributing.md
+++ b/mkdocs/docs/contributing.md
@@ -71,7 +71,7 @@ pip3 install -e ".[s3fs,hive]"
 Install it directly for GitHub (not recommended), but sometimes handy:
 
 ```
-pip install "git+https://github.com/apache/iceberg-python.git#egg=pyiceberg[s3fs]"
+pip install "git+https://github.com/apache/iceberg-python.git#egg=pyiceberg[pyarrow]"
 ```
 
 ## Linting

--- a/pyiceberg/io/__init__.py
+++ b/pyiceberg/io/__init__.py
@@ -338,5 +338,5 @@ def load_file_io(properties: Properties = EMPTY_DICT, location: Optional[str] = 
         return PyArrowFileIO(properties)
     except ModuleNotFoundError as e:
         raise ModuleNotFoundError(
-            'Could not load a FileIO, please consider installing one: pip3 install "pyiceberg[s3fs]", for more options refer to the docs.'
+            'Could not load a FileIO, please consider installing one: pip3 install "pyiceberg[pyarrow]", for more options refer to the docs.'
         ) from e


### PR DESCRIPTION
PyIceberg first started with s3fs as the default FileIO implementation because it is more lightweight. At some point we've changed the default to PyArrow since it is more feature rich.

We've missed this comment back then.