### PR TITLE
Use `pre-commit.ci` to automatically update pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,3 +75,14 @@ repos:
           # --line-length is set to a high value to deal with very long lines
           - --line-length
           - '99999'
+ci:
+    autofix_commit_msg: |
+        [pre-commit.ci] auto fixes from pre-commit.com hooks
+
+        for more information, see https://pre-commit.ci
+    autofix_prs: true
+    autoupdate_branch: ''
+    autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
+    autoupdate_schedule: weekly
+    skip: []
+    submodules: false


### PR DESCRIPTION
Motivation 
pre-commit hooks are running (very) old versions, and need to be updated.

To update pre-commit hook versions, we can manually run this command
```
poetry run pre-commit autoupdate
```

Alternatively, we can use `pre-commit.ci` to automate the update. This will automatically create PRs to update the hook versions. For example, see https://github.com/tiangolo/fastapi/pull/9259

Pre-comit.ci is [free for open source repositories](https://pre-commit.ci/#pricing) 


Source
https://chrisholdgraf.com/blog/2022/precommit-autoupdate/
https://pre-commit.ci/

Reference
https://github.com/tiangolo/fastapi/blob/1d41a7d2df5714e6598b541cac3cac5859b3ad4b/.pre-commit-config.yaml#L23
