### PR TITLE
Metadata Log Entries metadata table

### DIFF
--- a/pyiceberg/table/metadata.py
+++ b/pyiceberg/table/metadata.py
@@ -292,6 +292,13 @@ class TableMetadataCommonFields(IcebergBaseModel):
             return self.snapshot_by_id(ref.snapshot_id)
         return None
 
+    def _snapshot_as_of_timestamp_ms(self, timestamp_ms: int) -> Optional[Snapshot]:
+        """ Return the snapshot that was current at the given timestamp or null if no such snapshot exists."""
+        for entry in reversed(self.snapshot_log):
+            if entry.timestamp_ms <= timestamp_ms:
+                return self.snapshot_by_id(entry.snapshot_id)
+        return None
+
     def current_snapshot(self) -> Optional[Snapshot]:
         """Get the current snapshot for this table, or None if there is no current snapshot."""
         if self.current_snapshot_id is not None:
@@ -520,6 +527,7 @@ def new_table_metadata(
     if table_uuid is None:
         table_uuid = uuid.uuid4()
 
+    # need to update metadata_log here
     # Remove format-version so it does not get persisted
     format_version = int(properties.pop(TableProperties.FORMAT_VERSION, TableProperties.DEFAULT_FORMAT_VERSION))
     if format_version == 1:

--- a/pyiceberg/table/snapshots.py
+++ b/pyiceberg/table/snapshots.py
@@ -226,7 +226,8 @@ class Summary(IcebergBaseModel, Mapping[str, str]):
 class Snapshot(IcebergBaseModel):
     snapshot_id: int = Field(alias="snapshot-id")
     parent_snapshot_id: Optional[int] = Field(alias="parent-snapshot-id", default=None)
-    sequence_number: Optional[int] = Field(alias="sequence-number", default=None)
+    # cannot import `INITIAL_SEQUENCE_NUMBER` due to circular import
+    sequence_number: Optional[int] = Field(alias="sequence-number", default=0)
     timestamp_ms: int = Field(alias="timestamp-ms", default_factory=lambda: int(time.time() * 1000))
     manifest_list: Optional[str] = Field(
         alias="manifest-list", description="Location of the snapshot's manifest list file", default=None


### PR DESCRIPTION
Resolves #594 (and part of #511) 

TODO:
* Add doc in `api.md`

This PR creates a metadata table for "Metadata Log Entries", similar to [its spark equivalent](https://iceberg.apache.org/docs/nightly/spark-queries/#metadata-log-entries) (`metadata_log_entries`). 

To query the metadata table, use 
```
tbl.inspect.metadata_log_entries()
```

References
* #524 (snapshots metadata table) 
* #602 (references metadata table)
* #551 (entries metadata table)

Spark metadata log entries table is implemented in [`MetadataLogEntriesTable.java`](https://github.com/apache/iceberg/blob/1e35bf96ecacd5c5175116f40fa3e097991d04d2/core/src/main/java/org/apache/iceberg/MetadataLogEntriesTable.java#L61)

The metadata log entries log is modified during `TableMetadata` creation, in which the current metadata log entry is appended ([1](https://github.com/apache/iceberg/blob/1e35bf96ecacd5c5175116f40fa3e097991d04d2/core/src/main/java/org/apache/iceberg/TableMetadata.java#L1454-L1457), [2](https://github.com/apache/iceberg/blob/1e35bf96ecacd5c5175116f40fa3e097991d04d2/core/src/main/java/org/apache/iceberg/TableMetadata.java#L1670-L1698), [3](https://github.com/apache/iceberg/blob/1e35bf96ecacd5c5175116f40fa3e097991d04d2/core/src/main/java/org/apache/iceberg/TableMetadata.java#L956))

Get `Snapshot` by timestamp (`_snapshot_as_of_timestamp_ms`) is modeled after [`snapshotIdAsOfTime` from Java](https://github.com/apache/iceberg/blob/1e35bf96ecacd5c5175116f40fa3e097991d04d2/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java#L339-L359)

There's an issue with reading V1 spec where the `sequence-number` is `None` instead of `0`. According to the Iceberg spec, when reading v1 metadata for v2, `Snapshot` field `sequence-number` must default to 0 ([source](https://iceberg.apache.org/spec/#version-2)).
 