### PR TITLE
Bug Fix: Return the parsed path without schema/netloc for HDFS

### DIFF
--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -333,7 +333,7 @@ class PyArrowFileIO(FileIO):
         if not uri.scheme:
             return "file", uri.netloc, os.path.abspath(location)
         elif uri.scheme == "hdfs":
-            return uri.scheme, uri.netloc, location
+            return uri.scheme, uri.netloc, uri.path
         else:
             return uri.scheme, uri.netloc, f"{uri.netloc}{uri.path}"
 

--- a/tests/io/test_pyarrow.py
+++ b/tests/io/test_pyarrow.py
@@ -1644,9 +1644,9 @@ def test_parse_location() -> None:
         assert netloc == expected_netloc
         assert uri == expected_uri
 
-    check_results("hdfs://127.0.0.1:9000/root/foo.txt", "hdfs", "127.0.0.1:9000", "hdfs://127.0.0.1:9000/root/foo.txt")
-    check_results("hdfs://127.0.0.1/root/foo.txt", "hdfs", "127.0.0.1", "hdfs://127.0.0.1/root/foo.txt")
-    check_results("hdfs://clusterA/root/foo.txt", "hdfs", "clusterA", "hdfs://clusterA/root/foo.txt")
+    check_results("hdfs://127.0.0.1:9000/root/foo.txt", "hdfs", "127.0.0.1:9000", "/root/foo.txt")
+    check_results("hdfs://127.0.0.1/root/foo.txt", "hdfs", "127.0.0.1", "/root/foo.txt")
+    check_results("hdfs://clusterA/root/foo.txt", "hdfs", "clusterA", "/root/foo.txt")
 
     check_results("/root/foo.txt", "file", "", "/root/foo.txt")
     check_results("/root/tmp/foo.txt", "file", "", "/root/tmp/foo.txt")


### PR DESCRIPTION
When I try to test write support for Iceberg table on HDFS,  there is an error.
```
 File "/home/root/anaconda3/lib/python3.8/site-packages/pyiceberg/io/pyarrow.py", line 244, in exists
    self._file_info()  # raises FileNotFoundError if it does not exist
  File "/home/root/anaconda3/lib/python3.8/site-packages/pyiceberg/io/pyarrow.py", line 226, in _file_info
    file_info = self._filesystem.get_file_info(self._path)
  File "pyarrow/_fs.pyx", line 584, in pyarrow._fs.FileSystem.get_file_info
  File "pyarrow/error.pxi", line 154, in pyarrow.lib.pyarrow_internal_check_status
  File "pyarrow/error.pxi", line 91, in pyarrow.lib.check_status
pyarrow.lib.ArrowInvalid: GetFileInfo must not be passed a URI, got: hdfs://clusterXX/user/my_db/my_table/metadata/xxxxx.metadata.json
```
The root cause is that `file_info = self._filesystem.get_file_info(self._path)` does not support HDFS path with schema/ netloc `(like hdfs://clusterXX/user/my_db/my_table/metadata/xxxxx.metadata.json)` .

This PR uses uri.path instead.

