### PR TITLE
table_exists unit/integration test for NoSuchTableError

### DIFF
--- a/pyiceberg/catalog/__init__.py
+++ b/pyiceberg/catalog/__init__.py
@@ -394,6 +394,11 @@ class Catalog(ABC):
         Returns:
             bool: True if the table exists, False otherwise.
         """
+        try:
+            self.load_table(identifier)
+            return True
+        except NoSuchTableError:
+            return False
 
     @abstractmethod
     def register_table(self, identifier: Union[str, Identifier], metadata_location: str) -> Table:

--- a/pyiceberg/catalog/__init__.py
+++ b/pyiceberg/catalog/__init__.py
@@ -661,14 +661,6 @@ class MetastoreCatalog(Catalog, ABC):
         )
 
     def table_exists(self, identifier: Union[str, Identifier]) -> bool:
-        """Check if a table exists.
-
-        Args:
-            identifier (str | Identifier): Table identifier.
-
-        Returns:
-            bool: True if the table exists, False otherwise.
-        """
         try:
             self.load_table(identifier)
             return True

--- a/pyiceberg/catalog/__init__.py
+++ b/pyiceberg/catalog/__init__.py
@@ -394,11 +394,6 @@ class Catalog(ABC):
         Returns:
             bool: True if the table exists, False otherwise.
         """
-        try:
-            self.load_table(identifier)
-            return True
-        except NoSuchTableError:
-            return False
 
     @abstractmethod
     def register_table(self, identifier: Union[str, Identifier], metadata_location: str) -> Table:
@@ -666,6 +661,14 @@ class MetastoreCatalog(Catalog, ABC):
         )
 
     def table_exists(self, identifier: Union[str, Identifier]) -> bool:
+        """Check if a table exists.
+
+        Args:
+            identifier (str | Identifier): Table identifier.
+
+        Returns:
+            bool: True if the table exists, False otherwise.
+        """
         try:
             self.load_table(identifier)
             return True

--- a/tests/catalog/integration_test_dynamodb.py
+++ b/tests/catalog/integration_test_dynamodb.py
@@ -262,6 +262,8 @@ def test_update_namespace_properties(test_catalog: Catalog, database_name: str) 
         else:
             assert k in update_report.removed
     assert "updated test description" == test_catalog.load_namespace_properties(database_name)["comment"]
+
+
 def test_table_exists(test_catalog: Catalog, table_schema_nested: Schema, database_name: str, table_name: str) -> None:
     test_catalog.create_namespace(database_name)
     test_catalog.create_table((database_name, table_name), table_schema_nested)

--- a/tests/catalog/integration_test_dynamodb.py
+++ b/tests/catalog/integration_test_dynamodb.py
@@ -262,3 +262,8 @@ def test_update_namespace_properties(test_catalog: Catalog, database_name: str) 
         else:
             assert k in update_report.removed
     assert "updated test description" == test_catalog.load_namespace_properties(database_name)["comment"]
+
+    def test_table_exists(test_catalog: Catalog, table_schema_nested: Schema, database_name: str, table_name: str) -> None:
+        test_catalog.create_namespace(database_name)
+        test_catalog.create_table((database_name, table_name), table_schema_nested)
+        assert test_catalog.table_exists((database_name, table_name)) is True

--- a/tests/catalog/integration_test_dynamodb.py
+++ b/tests/catalog/integration_test_dynamodb.py
@@ -262,8 +262,7 @@ def test_update_namespace_properties(test_catalog: Catalog, database_name: str) 
         else:
             assert k in update_report.removed
     assert "updated test description" == test_catalog.load_namespace_properties(database_name)["comment"]
-
-    def test_table_exists(test_catalog: Catalog, table_schema_nested: Schema, database_name: str, table_name: str) -> None:
-        test_catalog.create_namespace(database_name)
-        test_catalog.create_table((database_name, table_name), table_schema_nested)
-        assert test_catalog.table_exists((database_name, table_name)) is True
+def test_table_exists(test_catalog: Catalog, table_schema_nested: Schema, database_name: str, table_name: str) -> None:
+    test_catalog.create_namespace(database_name)
+    test_catalog.create_table((database_name, table_name), table_schema_nested)
+    assert test_catalog.table_exists((database_name, table_name)) is True

--- a/tests/catalog/integration_test_glue.py
+++ b/tests/catalog/integration_test_glue.py
@@ -558,3 +558,9 @@ def test_create_table_transaction(
             ]
         },
     ]
+
+
+def test_table_exists(test_catalog: Catalog, table_schema_nested: Schema, table_name: str, database_name: str) -> None:
+    test_catalog.create_namespace(database_name)
+    test_catalog.create_table((database_name, table_name), table_schema_nested)
+    assert test_catalog.table_exists((database_name, table_name)) is True

--- a/tests/catalog/test_dynamodb.py
+++ b/tests/catalog/test_dynamodb.py
@@ -562,3 +562,17 @@ def test_passing_provided_profile() -> None:
         assert test_catalog.dynamodb is mock_client
         mock_session.assert_called_with(**session_props)
         assert test_catalog.dynamodb is mock_session().client()
+
+
+@mock_aws
+def test_table_exists(
+    _bucket_initialize: None, moto_endpoint_url: str, table_schema_nested: Schema, database_name: str, table_name: str
+) -> None:
+    identifier = (database_name, table_name)
+    test_catalog = DynamoDbCatalog("test_ddb_catalog", **{"warehouse": f"s3://{BUCKET_NAME}", "s3.endpoint": moto_endpoint_url})
+    test_catalog.create_namespace(namespace=database_name)
+    test_catalog.create_table(identifier, table_schema_nested)
+    # Act and Assert for an existing table
+    assert test_catalog.table_exists(identifier) is True
+    # Act and Assert for an non-existing  table
+    assert test_catalog.table_exists(('non', 'exist')) is False

--- a/tests/catalog/test_glue.py
+++ b/tests/catalog/test_glue.py
@@ -817,3 +817,18 @@ def test_create_table_transaction(
     assert table.spec().fields_by_source_id(2)[0].name == "bar"
     assert table.spec().fields_by_source_id(2)[0].field_id == 1001
     assert table.spec().fields_by_source_id(2)[0].transform == IdentityTransform()
+
+
+@mock_aws
+def test_table_exists(
+    _bucket_initialize: None, moto_endpoint_url: str, table_schema_simple: Schema, database_name: str, table_name: str
+) -> None:
+    catalog_name = "glue"
+    identifier = (database_name, table_name)
+    test_catalog = GlueCatalog(catalog_name, **{"s3.endpoint": moto_endpoint_url, "warehouse": f"s3://{BUCKET_NAME}"})
+    test_catalog.create_namespace(namespace=database_name)
+    test_catalog.create_table(identifier=identifier, schema=table_schema_simple)
+    # Act and Assert for an existing table
+    assert test_catalog.table_exists(identifier) is True
+    # Act and Assert for a non-existing table
+    assert test_catalog.table_exists(('non', 'exist')) is False

--- a/tests/catalog/test_sql.py
+++ b/tests/catalog/test_sql.py
@@ -982,3 +982,22 @@ def test_table_properties_raise_for_none_value(
     with pytest.raises(ValidationError) as exc_info:
         _ = catalog.create_table(random_identifier, table_schema_simple, properties=property_with_none)
     assert "None type is not a supported value in properties: property_name" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    'catalog',
+    [
+        lazy_fixture('catalog_memory'),
+        lazy_fixture('catalog_sqlite'),
+    ],
+)
+def test_table_exists(catalog: SqlCatalog, table_schema_simple: Schema, random_identifier: Identifier) -> None:
+    database_name, _table_name = random_identifier
+    catalog.create_namespace(database_name)
+    catalog.create_table(random_identifier, table_schema_simple, properties={"format-version": "2"})
+    existing_table = random_identifier
+    # Act and Assert for an existing table
+    assert catalog.table_exists(existing_table) is True
+
+    # Act and Assert for a non-existing table
+    assert catalog.table_exists(('non', 'exist')) is False


### PR DESCRIPTION
* Implementation of table_exists method at Initialization level already exists bypassing it.
* Unit Test for glue, sqlcatalog and dynamodb.
* Integration test for glue and dynamodb.