### PR TITLE
Changed class variable names in pyarrow.py

### DIFF
--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -206,7 +206,7 @@ class PyArrowFile(InputFile, OutputFile):
         >>> # output_file.create().write(b'foobytes')
     """
 
-    _fs: FileSystem
+    _filesystem: FileSystem
     _path: str
     _buffer_size: int
 


### PR DESCRIPTION
Renamed class variable in PyArrowFile from ._fs to _filesystem, in order to assign with the __init()__ method the Object FileSystem to the class, and not to the single instance of the Class, as it was happening before.