### PR TITLE
Add support for categorical type

### DIFF
--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -737,6 +737,7 @@ def _(obj: pa.DictionaryType, visitor: PyArrowSchemaVisitor[T]) -> T:
     # as an encoding detail, not as a separate type.
     # We will follow this approach in determining the Iceberg Type,
     # as we only support parquet in PyIceberg for now.
+    logger.warning(f"Iceberg does not have a dictionary type. {type(obj)} will be inferred as {obj.value_type} on read.")
     return visit_pyarrow(obj.value_type, visitor)
 
 

--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -731,6 +731,15 @@ def _(obj: pa.MapType, visitor: PyArrowSchemaVisitor[T]) -> T:
     return visitor.map(obj, key_result, value_result)
 
 
+@visit_pyarrow.register(pa.DictionaryType)
+def _(obj: pa.DictionaryType, visitor: PyArrowSchemaVisitor[T]) -> T:
+    # Parquet has no dictionary type. dictionary-encoding is handled
+    # as an encoding detail, not as a separate type.
+    # We will follow this approach in determining the Iceberg Type,
+    # as we only support parquet in PyIceberg for now.
+    return visit_pyarrow(obj.value_type, visitor)
+
+
 @visit_pyarrow.register(pa.DataType)
 def _(obj: pa.DataType, visitor: PyArrowSchemaVisitor[T]) -> T:
     if pa.types.is_nested(obj):

--- a/tests/integration/test_writes/test_writes.py
+++ b/tests/integration/test_writes/test_writes.py
@@ -316,7 +316,7 @@ def test_python_writes_special_character_column_with_spark_reads(
 def test_python_writes_dictionary_encoded_column_with_spark_reads(
     spark: SparkSession, session_catalog: Catalog, format_version: int
 ) -> None:
-    identifier = "default.ython_writes_dictionary_encoded_column_with_spark_reads"
+    identifier = "default.python_writes_dictionary_encoded_column_with_spark_reads"
     TEST_DATA = {
         'id': [1, 2, 3, 1, 1],
         'name': ['AB', 'CD', 'EF', 'CD', 'EF'],

--- a/tests/io/test_pyarrow_visitor.py
+++ b/tests/io/test_pyarrow_visitor.py
@@ -39,6 +39,7 @@ from pyiceberg.types import (
     DoubleType,
     FixedType,
     FloatType,
+    IcebergType,
     IntegerType,
     ListType,
     LongType,
@@ -278,6 +279,19 @@ def test_pyarrow_map_to_iceberg() -> None:
         value_required=True,
     )
     assert visit_pyarrow(pyarrow_map, _ConvertToIceberg()) == expected
+
+
+@pytest.mark.parametrize(
+    "value_type, expected_result",
+    [
+        (pa.string(), StringType()),
+        (pa.int32(), IntegerType()),
+        (pa.float64(), DoubleType()),
+    ],
+)
+def test_pyarrow_dictionary_encoded_type_to_iceberg(value_type: pa.DataType, expected_result: IcebergType) -> None:
+    pyarrow_dict = pa.dictionary(pa.int32(), value_type)
+    assert visit_pyarrow(pyarrow_dict, _ConvertToIceberg()) == expected_result
 
 
 def test_round_schema_conversion_simple(table_schema_simple: Schema) -> None:


### PR DESCRIPTION
Fixes: https://github.com/apache/iceberg-python/issues/450

DictionaryType is a separate type in Arrow, but isn't in Parquet.

Similar to how [Arrow handles Dictionary Types](https://github.com/apache/arrow/blob/22f88fa4a8f5ac7250f1845aace5a78d20006ef2/cpp/src/parquet/arrow/schema.cc#L419-L427), we will simply infer the Iceberg Type from the `value_type` of the provided `DictionaryType` field.