### PR TITLE
Compare `Schema` and `StructType` fields irrespective of ordering

### DIFF
--- a/pyiceberg/schema.py
+++ b/pyiceberg/schema.py
@@ -121,7 +121,13 @@ class Schema(IcebergBaseModel):
             return False
 
         identifier_field_ids_is_equal = self.identifier_field_ids == other.identifier_field_ids
-        schema_is_equal = set(self.columns) == set(other.columns)
+
+        def order_by_field_id(field: NestedField) -> int:
+            return field.field_id
+
+        left = sorted(self.columns, key=order_by_field_id)
+        right = sorted(other.columns, key=order_by_field_id)
+        schema_is_equal = all(lhs == rhs for lhs, rhs in zip(left, right))
 
         return identifier_field_ids_is_equal and schema_is_equal
 

--- a/pyiceberg/schema.py
+++ b/pyiceberg/schema.py
@@ -122,11 +122,8 @@ class Schema(IcebergBaseModel):
 
         identifier_field_ids_is_equal = self.identifier_field_ids == other.identifier_field_ids
 
-        def order_by_field_id(field: NestedField) -> int:
-            return field.field_id
-
-        left = sorted(self.columns, key=order_by_field_id)
-        right = sorted(other.columns, key=order_by_field_id)
+        left = sorted(self.columns, key=lambda field: field.field_id)
+        right = sorted(other.columns, key=lambda field: field.field_id)
         schema_is_equal = all(lhs == rhs for lhs, rhs in zip(left, right))
 
         return identifier_field_ids_is_equal and schema_is_equal

--- a/pyiceberg/schema.py
+++ b/pyiceberg/schema.py
@@ -121,7 +121,7 @@ class Schema(IcebergBaseModel):
             return False
 
         identifier_field_ids_is_equal = self.identifier_field_ids == other.identifier_field_ids
-        schema_is_equal = all(lhs == rhs for lhs, rhs in zip(self.columns, other.columns))
+        schema_is_equal = set(self.columns) == set(other.columns)
 
         return identifier_field_ids_is_equal and schema_is_equal
 

--- a/pyiceberg/types.py
+++ b/pyiceberg/types.py
@@ -393,7 +393,7 @@ class StructType(IcebergType):
 
     def __eq__(self, other: Any) -> bool:
         """Compare the object if it is equal to another object."""
-        return self.fields == other.fields if isinstance(other, StructType) else False
+        return set(self.fields) == set(other.fields) if isinstance(other, StructType) else False
 
 
 class ListType(IcebergType):

--- a/pyiceberg/types.py
+++ b/pyiceberg/types.py
@@ -393,7 +393,18 @@ class StructType(IcebergType):
 
     def __eq__(self, other: Any) -> bool:
         """Compare the object if it is equal to another object."""
-        return set(self.fields) == set(other.fields) if isinstance(other, StructType) else False
+        if not isinstance(other, StructType):
+            return False
+
+        if len(self.fields) != len(other.fields):
+            return False
+
+        def order_by_field_id(field: NestedField) -> int:
+            return field.field_id
+
+        left = sorted(self.fields, key=order_by_field_id)
+        right = sorted(other.fields, key=order_by_field_id)
+        return all(lhs == rhs for lhs, rhs in zip(left, right))
 
 
 class ListType(IcebergType):

--- a/pyiceberg/types.py
+++ b/pyiceberg/types.py
@@ -399,11 +399,8 @@ class StructType(IcebergType):
         if len(self.fields) != len(other.fields):
             return False
 
-        def order_by_field_id(field: NestedField) -> int:
-            return field.field_id
-
-        left = sorted(self.fields, key=order_by_field_id)
-        right = sorted(other.fields, key=order_by_field_id)
+        left = sorted(self.fields, key=lambda field: field.field_id)
+        right = sorted(other.fields, key=lambda field: field.field_id)
         return all(lhs == rhs for lhs, rhs in zip(left, right))
 
 

--- a/tests/avro/test_resolver.py
+++ b/tests/avro/test_resolver.py
@@ -372,7 +372,7 @@ def test_writer_ordering() -> None:
         ),
     )
 
-    expected = StructWriter(((1, DoubleWriter()), (0, StringWriter())))
+    expected = StructWriter(((0, DoubleWriter()), (1, StringWriter())))
 
     assert actual == expected
 

--- a/tests/integration/test_rest_schema.py
+++ b/tests/integration/test_rest_schema.py
@@ -1730,19 +1730,17 @@ def test_move_nested_field_after_first(catalog: Catalog) -> None:
     with tbl.update_schema() as schema_update:
         schema_update.move_before("struct.data", "struct.count")
 
-    assert str(tbl.schema()) == str(
-        Schema(
-            NestedField(field_id=1, name="id", field_type=LongType(), required=True),
-            NestedField(
-                field_id=2,
-                name="struct",
-                field_type=StructType(
-                    NestedField(field_id=4, name="data", field_type=StringType(), required=True),
-                    NestedField(field_id=3, name="count", field_type=LongType(), required=True),
-                ),
-                required=True,
+    assert tbl.schema() == Schema(
+        NestedField(field_id=1, name="id", field_type=LongType(), required=True),
+        NestedField(
+            field_id=2,
+            name="struct",
+            field_type=StructType(
+                NestedField(field_id=4, name="data", field_type=StringType(), required=True),
+                NestedField(field_id=3, name="count", field_type=LongType(), required=True),
             ),
-        )
+            required=True,
+        ),
     )
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -126,7 +126,10 @@ def test_schema_raise_on_duplicate_names() -> None:
 def test_schema_field_order_irrelevant() -> None:
     foo = NestedField(field_id=1, name="foo", field_type=StringType())
     bar = NestedField(field_id=2, name="bar", field_type=IntegerType(), required=False)
-    assert schema.Schema(foo, bar) == schema.Schema(bar, foo)
+    left = schema.Schema(foo, bar)
+    right = schema.Schema(bar, foo)
+    assert left == right
+    assert left.as_struct() == right.as_struct()
 
 
 def test_schema_index_by_id_visitor(table_schema_nested: Schema) -> None:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -123,6 +123,12 @@ def test_schema_raise_on_duplicate_names() -> None:
     assert "Invalid schema, multiple fields for name baz: 3 and 4" in str(exc_info.value)
 
 
+def test_schema_field_order_irrelevant() -> None:
+    foo = NestedField(field_id=1, name="foo", field_type=StringType())
+    bar = NestedField(field_id=2, name="bar", field_type=IntegerType(), required=False)
+    assert schema.Schema(foo, bar) == schema.Schema(bar, foo)
+
+
 def test_schema_index_by_id_visitor(table_schema_nested: Schema) -> None:
     """Test index_by_id visitor function"""
     index = schema.index_by_id(table_schema_nested)


### PR DESCRIPTION
Fixes #674

`Schema` and `StructType` `fields` variable is represented by `Tuple`, which means that ordering matters when performing comparison. 

Two `Schema`s with the same `fields` in different order should be consider the same


https://github.com/apache/iceberg-python/blob/7bd5d9e6c32bcc5b46993d6bfaeed50471e972ae/pyiceberg/schema.py#L88
https://github.com/apache/iceberg-python/blob/7bd5d9e6c32bcc5b46993d6bfaeed50471e972ae/pyiceberg/types.py#L346