### PR TITLE
Hive catalog: Add retry logic for hive locking

### DIFF
--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -122,12 +122,12 @@ OWNER = "owner"
 HIVE2_COMPATIBLE = "hive.hive2-compatible"
 HIVE2_COMPATIBLE_DEFAULT = False
 
-LOCK_CHECK_MIN_WAIT_TIME = "lock_check_min_wait_time"
-LOCK_CHECK_MAX_WAIT_TIME = "lock_check_max_wait_time"
-LOCK_CHECK_RETRIES = "lock_check_retries"
-DEFAULT_LOCK_CHECK_MIN_WAIT_TIME = 2
-DEFAULT_LOCK_CHECK_MAX_WAIT_TIME = 30
-DEFAULT_LOCK_CHECK_RETRIES = 10
+LOCK_CHECK_MIN_WAIT_TIME = "lock-check-min-wait-time"
+LOCK_CHECK_MAX_WAIT_TIME = "lock-check-max-wait-time"
+LOCK_CHECK_RETRIES = "lock-check-retries"
+DEFAULT_LOCK_CHECK_MIN_WAIT_TIME = 0.1  # 100 milliseconds
+DEFAULT_LOCK_CHECK_MAX_WAIT_TIME = 60  # 1 min
+DEFAULT_LOCK_CHECK_RETRIES = 4
 
 logger = logging.getLogger(__name__)
 
@@ -391,7 +391,7 @@ class HiveCatalog(MetastoreCatalog):
     def _wait_for_lock(self, database_name: str, table_name: str, lockid: int, open_client: Client) -> LockResponse:
         @retry(
             retry=retry_if_exception_type(WaitingForLockException),
-            wait=wait_exponential(multiplier=1.5, min=self._lock_check_min_wait_time, max=self._lock_check_max_wait_time),
+            wait=wait_exponential(multiplier=2, min=self._lock_check_min_wait_time, max=self._lock_check_max_wait_time),
             stop=stop_after_attempt(self._lock_check_retries),
             reraise=True,
         )

--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -15,6 +15,7 @@
 #  specific language governing permissions and limitations
 #  under the License.
 import getpass
+import logging
 import socket
 import time
 from types import TracebackType
@@ -33,6 +34,7 @@ from urllib.parse import urlparse
 from hive_metastore.ThriftHiveMetastore import Client
 from hive_metastore.ttypes import (
     AlreadyExistsException,
+    CheckLockRequest,
     FieldSchema,
     InvalidOperationException,
     LockComponent,
@@ -49,6 +51,7 @@ from hive_metastore.ttypes import (
 )
 from hive_metastore.ttypes import Database as HiveDatabase
 from hive_metastore.ttypes import Table as HiveTable
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 from thrift.protocol import TBinaryProtocol
 from thrift.transport import TSocket, TTransport
 
@@ -69,12 +72,20 @@ from pyiceberg.exceptions import (
     NoSuchNamespaceError,
     NoSuchTableError,
     TableAlreadyExistsError,
+    WaitingForLockException,
 )
 from pyiceberg.io import FileIO, load_file_io
 from pyiceberg.partitioning import UNPARTITIONED_PARTITION_SPEC, PartitionSpec
 from pyiceberg.schema import Schema, SchemaVisitor, visit
 from pyiceberg.serializers import FromInputFile
-from pyiceberg.table import CommitTableRequest, CommitTableResponse, PropertyUtil, Table, TableProperties, update_table_metadata
+from pyiceberg.table import (
+    CommitTableRequest,
+    CommitTableResponse,
+    PropertyUtil,
+    Table,
+    TableProperties,
+    update_table_metadata,
+)
 from pyiceberg.table.metadata import new_table_metadata
 from pyiceberg.table.sorting import UNSORTED_SORT_ORDER, SortOrder
 from pyiceberg.typedef import EMPTY_DICT, Identifier, Properties
@@ -110,6 +121,13 @@ OWNER = "owner"
 # If set to true, HiveCatalog will operate in Hive2 compatibility mode
 HIVE2_COMPATIBLE = "hive.hive2-compatible"
 HIVE2_COMPATIBLE_DEFAULT = False
+
+DEFAULT_LOCK_CHECK_MIN_WAIT_TIME = 2
+DEFAULT_LOCK_CHECK_MAX_WAIT_TIME = 30
+DEFAULT_LOCK_CHECK_RETRIES = 5
+DEFAULT_LOCK_CHECK_MULTIPLIER = 2
+
+logger = logging.getLogger(__name__)
 
 
 class _HiveClient:
@@ -239,6 +257,10 @@ class HiveCatalog(MetastoreCatalog):
     def __init__(self, name: str, **properties: str):
         super().__init__(name, **properties)
         self._client = _HiveClient(properties["uri"], properties.get("ugi"))
+        self._lock_check_min_wait_time = int(properties.get("lock_check_min_wait_time", DEFAULT_LOCK_CHECK_MIN_WAIT_TIME))
+        self._lock_check_max_wait_time = int(properties.get("lock_check_max_wait_time", DEFAULT_LOCK_CHECK_MAX_WAIT_TIME))
+        self._lock_check_retries = int(properties.get("lock_check_retries", DEFAULT_LOCK_CHECK_RETRIES))
+        self._lock_check_multiplier = float(properties.get("lock_check_multiplier", DEFAULT_LOCK_CHECK_MULTIPLIER))
 
     def _convert_hive_into_iceberg(self, table: HiveTable, io: FileIO) -> Table:
         properties: Dict[str, str] = table.parameters
@@ -356,6 +378,28 @@ class HiveCatalog(MetastoreCatalog):
 
         return lock_request
 
+    def _wait_for_lock(self, database_name: str, table_name: str, lockid: int, open_client: Client) -> LockResponse:
+        @retry(
+            retry=retry_if_exception_type(WaitingForLockException),
+            wait=wait_exponential(
+                multiplier=self._lock_check_multiplier, min=self._lock_check_min_wait_time, max=self._lock_check_max_wait_time
+            ),
+            stop=stop_after_attempt(self._lock_check_retries),
+            reraise=True,
+        )
+        def _do_wait_for_lock() -> LockResponse:
+            response: LockResponse = open_client.check_lock(CheckLockRequest(lockid=lockid))
+            if response.state == LockState.ACQUIRED:
+                return response
+            elif response.state == LockState.WAITING:
+                msg = f"Wait on lock for {database_name}:{table_name}"
+                logger.warning(msg)
+                raise WaitingForLockException(msg)
+            else:
+                raise CommitFailedException(f"Failed to lock for {database_name}:{table_name}, state: {response.state}")
+
+        return _do_wait_for_lock()
+
     def _commit_table(self, table_request: CommitTableRequest) -> CommitTableResponse:
         """Update the table.
 
@@ -380,7 +424,10 @@ class HiveCatalog(MetastoreCatalog):
 
             try:
                 if lock.state != LockState.ACQUIRED:
-                    raise CommitFailedException(f"Failed to acquire lock for {table_request.identifier}, state: {lock.state}")
+                    if lock.state == LockState.WAITING:
+                        self._wait_for_lock(database_name, table_name, lock.lockid, open_client)
+                    else:
+                        raise CommitFailedException(f"Failed to acquire lock for {table_request.identifier}, state: {lock.state}")
 
                 hive_table = open_client.get_table(dbname=database_name, tbl_name=table_name)
                 io = load_file_io({**self.properties, **hive_table.parameters}, hive_table.sd.location)
@@ -406,6 +453,8 @@ class HiveCatalog(MetastoreCatalog):
                 open_client.alter_table(dbname=database_name, tbl_name=table_name, new_tbl=hive_table)
             except NoSuchObjectException as e:
                 raise NoSuchTableError(f"Table does not exist: {table_name}") from e
+            except WaitingForLockException as e:
+                raise CommitFailedException(f"Failed to acquire lock for {table_request.identifier}, state: {lock.state}") from e
             finally:
                 open_client.unlock(UnlockRequest(lockid=lock.lockid))
 

--- a/pyiceberg/exceptions.py
+++ b/pyiceberg/exceptions.py
@@ -110,3 +110,7 @@ class CommitFailedException(Exception):
 
 class CommitStateUnknownException(RESTError):
     """Commit failed due to unknown reason."""
+
+
+class WaitingForLockException(Exception):
+    """Need to wait for a lock, try again."""

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -252,6 +252,16 @@ class PropertyUtil:
             return default
 
     @staticmethod
+    def property_as_float(properties: Dict[str, str], property_name: str, default: Optional[float] = None) -> Optional[float]:
+        if value := properties.get(property_name):
+            try:
+                return float(value)
+            except ValueError as e:
+                raise ValueError(f"Could not parse table property {property_name} to a float: {value}") from e
+        else:
+            return default
+
+    @staticmethod
     def property_as_bool(properties: Dict[str, str], property_name: str, default: bool) -> bool:
         if value := properties.get(property_name):
             return value.lower() == "true"

--- a/tests/integration/test_reads.py
+++ b/tests/integration/test_reads.py
@@ -17,6 +17,7 @@
 # pylint:disable=redefined-outer-name
 
 import math
+import time
 import uuid
 from urllib.parse import urlparse
 
@@ -48,6 +49,7 @@ from pyiceberg.types import (
     StringType,
     TimestampType,
 )
+from pyiceberg.utils.concurrent import ExecutorFactory
 
 DEFAULT_PROPERTIES = {'write.parquet.compression-codec': 'zstd'}
 
@@ -506,3 +508,40 @@ def test_hive_locking(session_catalog_hive: HiveCatalog) -> None:
                 table.transaction().set_properties(lock="fail").commit_transaction()
         finally:
             open_client.unlock(UnlockRequest(lock.lockid))
+
+
+@pytest.mark.integration
+def test_hive_locking_with_retry(session_catalog_hive: HiveCatalog) -> None:
+    table = create_table(session_catalog_hive)
+    database_name: str
+    table_name: str
+    _, database_name, table_name = table.identifier
+
+    hive_client: _HiveClient = _HiveClient(session_catalog_hive.properties["uri"])
+
+    executor = ExecutorFactory.get_or_create()
+
+    with hive_client as open_client:
+
+        def another_task() -> None:
+            lock1: LockResponse = open_client.lock(session_catalog_hive._create_lock_request(database_name, table_name))
+            time.sleep(5)
+            open_client.unlock(UnlockRequest(lock1.lockid))
+
+        # test the lock_with_retry with concurrent locking
+        executor.submit(another_task)
+        time.sleep(1)
+        try:
+            lock2: LockResponse = open_client.lock(session_catalog_hive._create_lock_request(database_name, table_name))
+            assert lock2.state == LockState.WAITING
+            lock2 = session_catalog_hive._wait_for_lock(database_name, table_name, lock2.lockid, open_client)
+            assert lock2.state == LockState.ACQUIRED
+        finally:
+            open_client.unlock(UnlockRequest(lock2.lockid))
+
+        # test transaction commit with concurrent locking
+        executor.submit(another_task)
+        time.sleep(1)
+
+        table.transaction().set_properties(lock="xxx").commit_transaction()
+        assert table.properties.get("lock") == "xxx"


### PR DESCRIPTION
In the current hive catalog implementation, locking will only be executed once.
If another task has already locked the target table, the locking will fail inevitably.

Since Iceberg-Java has implemented retry on `org.apache.iceberg.hive.MetastoreLock`, we could refer this to improve Iceberg-python.
This PR adds retry and wait logic for hive catalog with the following modifications.

1.  add `_wait_for_lock` on hive catalog
2. add `WaitingForLockException`
3. add a new UT that two tasks are locking the same table.