### PR TITLE
Fix: Table-Exists if Server returns 204

### DIFF
--- a/pyiceberg/catalog/rest.py
+++ b/pyiceberg/catalog/rest.py
@@ -790,4 +790,4 @@ class RestCatalog(Catalog):
         response = self._session.head(
             self.url(Endpoints.load_table, prefixed=True, **self._split_identifier_for_path(identifier_tuple))
         )
-        return response.status_code == 200
+        return response.status_code in (200, 204)

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -673,6 +673,16 @@ def test_table_exist_200(rest_mock: Mocker) -> None:
     assert catalog.table_exists(("fokko", "table"))
 
 
+def test_table_exist_204(rest_mock: Mocker) -> None:
+    rest_mock.head(
+        f"{TEST_URI}v1/namespaces/fokko/tables/table",
+        status_code=204,
+        request_headers=TEST_HEADERS,
+    )
+    catalog = RestCatalog("rest", uri=TEST_URI, token=TEST_TOKEN)
+    assert catalog.table_exists(("fokko", "table"))
+
+
 def test_table_exist_500(rest_mock: Mocker) -> None:
     rest_mock.head(
         f"{TEST_URI}v1/namespaces/fokko/tables/table",


### PR DESCRIPTION
Fixes https://github.com/apache/iceberg-python/issues/735