### PR TITLE
Support `Table.to_arrow_batch_reader` to return RecordBatchReader instead of a fully materialized Arrow Table

### DIFF
--- a/mkdocs/docs/api.md
+++ b/mkdocs/docs/api.md
@@ -981,6 +981,15 @@ tpep_dropoff_datetime: [[2021-04-01 00:47:59.000000,...,2021-05-01 00:14:47.0000
 
 This will only pull in the files that that might contain matching rows.
 
+One can also return a PyArrow RecordBatchReader, if reading one record batch at a time is preferred:
+
+```python
+table.scan(
+    row_filter=GreaterThanOrEqual("trip_distance", 10.0),
+    selected_fields=("VendorID", "tpep_pickup_datetime", "tpep_dropoff_datetime"),
+).to_arrow_batch_reader()
+```
+
 ### Pandas
 
 <!-- prettier-ignore-start -->

--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -1041,7 +1041,7 @@ def _task_to_table(
     # Hence we only use it to infer the pyarrow schema when the table is guaranteed to be empty
     list_of_batches = list(batches)
     if len(list_of_batches) > 0 and len(list_of_batches[0]) > 0:
-        pa.Table.from_batches(list_of_batches)
+        return pa.Table.from_batches(list_of_batches)
     else:
         return pa.Table.from_batches(list_of_batches, schema=schema_to_pyarrow(projected_schema, include_field_ids=False))
 

--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -1918,9 +1918,9 @@ def write_file(io: FileIO, table_metadata: TableMetadata, tasks: Iterator[WriteT
             file_schema = table_schema
 
         batches = [
-                to_requested_schema(requested_schema=file_schema, file_schema=table_schema, batch=batch)
-                for batch in task.record_batches
-            ]
+            to_requested_schema(requested_schema=file_schema, file_schema=table_schema, batch=batch)
+            for batch in task.record_batches
+        ]
         arrow_table = pa.Table.from_batches(batches)
         file_path = f'{table_metadata.location}/data/{task.generate_data_file_path("parquet")}'
         fo = io.new_output(file_path)

--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -1219,7 +1219,7 @@ def project_batches(
         for batch in batches:
             if limit is not None:
                 if total_row_count + len(batch) >= limit:
-                    yield batch.take(limit - total_row_count)
+                    yield batch.slice(0, limit - total_row_count)
                     break
             yield batch
             total_row_count += len(batch)

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -33,6 +33,7 @@ from typing import (
     Dict,
     Generic,
     Iterable,
+    Iterator,
     List,
     Literal,
     Optional,
@@ -1763,7 +1764,7 @@ class DataScan(TableScan):
             limit=self.limit,
         )
 
-    def to_arrow_batches(self) -> pa.Table:
+    def to_arrow_batches(self) -> Iterator[pa.RecordBatch]:
         from pyiceberg.io.pyarrow import project_batches
 
         return project_batches(

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -1763,6 +1763,19 @@ class DataScan(TableScan):
             limit=self.limit,
         )
 
+    def to_arrow_batches(self) -> pa.Table:
+        from pyiceberg.io.pyarrow import project_batches
+
+        return project_batches(
+            self.plan_files(),
+            self.table_metadata,
+            self.io,
+            self.row_filter,
+            self.projection(),
+            case_sensitive=self.case_sensitive,
+            limit=self.limit,
+        )
+
     def to_pandas(self, **kwargs: Any) -> pd.DataFrame:
         return self.to_arrow().to_pandas(**kwargs)
 

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -1781,10 +1781,11 @@ class DataScan(TableScan):
         )
 
     def to_arrow_batch_reader(self) -> pa.RecordBatchReader:
-        from pyiceberg.io.pyarrow import project_batches, schema_to_pyarrow
         import pyarrow as pa
-        
-        reader = pa.RecordBatchReader.from_batches(
+
+        from pyiceberg.io.pyarrow import project_batches, schema_to_pyarrow
+
+        return pa.RecordBatchReader.from_batches(
             schema_to_pyarrow(self.projection()),
             project_batches(
                 self.plan_files(),
@@ -1796,9 +1797,6 @@ class DataScan(TableScan):
                 limit=self.limit,
             ),
         )
-        # Cast the reader to its projected schema its projected schema for consistency
-        # https://github.com/apache/iceberg-python/issues/791
-        return reader.cast(reader.schema)
 
     def to_pandas(self, **kwargs: Any) -> pd.DataFrame:
         return self.to_arrow().to_pandas(**kwargs)

--- a/tests/integration/test_reads.py
+++ b/tests/integration/test_reads.py
@@ -179,7 +179,7 @@ def test_pyarrow_not_nan_count(catalog: Catalog) -> None:
 @pytest.mark.integration
 @pytest.mark.parametrize("catalog", [pytest.lazy_fixture("session_catalog_hive"), pytest.lazy_fixture("session_catalog")])
 def test_pyarrow_batches_nan(catalog: Catalog) -> None:
-    table_test_null_nan = catalog.load_table("default.table_test_null_nan")
+    table_test_null_nan = catalog.load_table("default.test_null_nan")
     arrow_batches = table_test_null_nan.scan(
         row_filter=IsNaN("col_numeric"), selected_fields=("idx", "col_numeric")
     ).to_arrow_batches()

--- a/tests/integration/test_reads.py
+++ b/tests/integration/test_reads.py
@@ -19,7 +19,6 @@
 import math
 import time
 import uuid
-from typing import Iterator
 from urllib.parse import urlparse
 
 import pyarrow as pa
@@ -180,13 +179,11 @@ def test_pyarrow_not_nan_count(catalog: Catalog) -> None:
 @pytest.mark.parametrize("catalog", [pytest.lazy_fixture("session_catalog_hive"), pytest.lazy_fixture("session_catalog")])
 def test_pyarrow_batches_nan(catalog: Catalog) -> None:
     table_test_null_nan = catalog.load_table("default.test_null_nan")
-    arrow_batches = table_test_null_nan.scan(
+    arrow_batch_reader = table_test_null_nan.scan(
         row_filter=IsNaN("col_numeric"), selected_fields=("idx", "col_numeric")
-    ).to_arrow_batches()
-    assert isinstance(arrow_batches, Iterator)
-    list_of_batches = list(arrow_batches)
-    assert len(list_of_batches) == 1
-    arrow_table = pa.Table.from_batches(list_of_batches)
+    ).to_arrow_batch_reader()
+    assert isinstance(arrow_batch_reader, pa.RecordBatchReader)
+    arrow_table = arrow_batch_reader.read_all()
     assert len(arrow_table) == 1
     assert arrow_table["idx"][0].as_py() == 1
     assert math.isnan(arrow_table["col_numeric"][0].as_py())
@@ -196,13 +193,11 @@ def test_pyarrow_batches_nan(catalog: Catalog) -> None:
 @pytest.mark.parametrize("catalog", [pytest.lazy_fixture("session_catalog_hive"), pytest.lazy_fixture("session_catalog")])
 def test_pyarrow_batches_nan_rewritten(catalog: Catalog) -> None:
     table_test_null_nan_rewritten = catalog.load_table("default.test_null_nan_rewritten")
-    arrow_batches = table_test_null_nan_rewritten.scan(
+    arrow_batch_reader = table_test_null_nan_rewritten.scan(
         row_filter=IsNaN("col_numeric"), selected_fields=("idx", "col_numeric")
-    ).to_arrow_batches()
-    assert isinstance(arrow_batches, Iterator)
-    list_of_batches = list(arrow_batches)
-    assert len(list_of_batches) == 1
-    arrow_table = pa.Table.from_batches(list_of_batches)
+    ).to_arrow_batch_reader()
+    assert isinstance(arrow_batch_reader, pa.RecordBatchReader)
+    arrow_table = arrow_batch_reader.read_all()
     assert len(arrow_table) == 1
     assert arrow_table["idx"][0].as_py() == 1
     assert math.isnan(arrow_table["col_numeric"][0].as_py())
@@ -213,11 +208,11 @@ def test_pyarrow_batches_nan_rewritten(catalog: Catalog) -> None:
 @pytest.mark.skip(reason="Fixing issues with NaN's: https://github.com/apache/arrow/issues/34162")
 def test_pyarrow_batches_not_nan_count(catalog: Catalog) -> None:
     table_test_null_nan = catalog.load_table("default.test_null_nan")
-    arrow_batches = table_test_null_nan.scan(row_filter=NotNaN("col_numeric"), selected_fields=("idx",)).to_arrow_batches()
-    assert isinstance(arrow_batches, Iterator)
-    list_of_batches = list(arrow_batches)
-    assert len(list_of_batches) == 1
-    arrow_table = pa.Table.from_batches(list_of_batches)
+    arrow_batch_reader = table_test_null_nan.scan(
+        row_filter=NotNaN("col_numeric"), selected_fields=("idx",)
+    ).to_arrow_batch_reader()
+    assert isinstance(arrow_batch_reader, pa.RecordBatchReader)
+    arrow_table = arrow_batch_reader.read_all()
     assert len(arrow_table) == 2
 
 
@@ -418,27 +413,27 @@ def test_pyarrow_batches_deletes(catalog: Catalog) -> None:
     #  (11, 'k'),
     #  (12, 'l')
     test_positional_mor_deletes = catalog.load_table("default.test_positional_mor_deletes")
-    arrow_table = pa.Table.from_batches(test_positional_mor_deletes.scan().to_arrow_batches())
+    arrow_table = test_positional_mor_deletes.scan().to_arrow_batch_reader().read_all()
     assert arrow_table["number"].to_pylist() == [1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12]
 
     # Checking the filter
-    arrow_table = pa.Table.from_batches(
-        test_positional_mor_deletes.scan(
-            row_filter=And(GreaterThanOrEqual("letter", "e"), LessThan("letter", "k"))
-        ).to_arrow_batches()
+    arrow_table = (
+        test_positional_mor_deletes.scan(row_filter=And(GreaterThanOrEqual("letter", "e"), LessThan("letter", "k")))
+        .to_arrow_batch_reader()
+        .read_all()
     )
     assert arrow_table["number"].to_pylist() == [5, 6, 7, 8, 10]
 
     # Testing the combination of a filter and a limit
-    arrow_table = pa.Table.from_batches(
-        test_positional_mor_deletes.scan(
-            row_filter=And(GreaterThanOrEqual("letter", "e"), LessThan("letter", "k")), limit=1
-        ).to_arrow_batches()
+    arrow_table = (
+        test_positional_mor_deletes.scan(row_filter=And(GreaterThanOrEqual("letter", "e"), LessThan("letter", "k")), limit=1)
+        .to_arrow_batch_reader()
+        .read_all()
     )
     assert arrow_table["number"].to_pylist() == [5]
 
     # Testing the slicing of indices
-    arrow_table = pa.Table.from_batches(test_positional_mor_deletes.scan(limit=3).to_arrow_batches())
+    arrow_table = test_positional_mor_deletes.scan(limit=3).to_arrow_batch_reader().read_all()
     assert arrow_table["number"].to_pylist() == [1, 2, 3]
 
 
@@ -459,27 +454,29 @@ def test_pyarrow_batches_deletes_double(catalog: Catalog) -> None:
     #  (11, 'k'),
     #  (12, 'l')
     test_positional_mor_double_deletes = catalog.load_table("default.test_positional_mor_double_deletes")
-    arrow_table = pa.Table.from_batches(test_positional_mor_double_deletes.scan().to_arrow_batches())
+    arrow_table = test_positional_mor_double_deletes.scan().to_arrow_batch_reader().read_all()
     assert arrow_table["number"].to_pylist() == [1, 2, 3, 4, 5, 7, 8, 10, 11, 12]
 
     # Checking the filter
-    arrow_table = pa.Table.from_batches(
-        test_positional_mor_double_deletes.scan(
-            row_filter=And(GreaterThanOrEqual("letter", "e"), LessThan("letter", "k"))
-        ).to_arrow_batches()
+    arrow_table = (
+        test_positional_mor_double_deletes.scan(row_filter=And(GreaterThanOrEqual("letter", "e"), LessThan("letter", "k")))
+        .to_arrow_batch_reader()
+        .read_all()
     )
     assert arrow_table["number"].to_pylist() == [5, 7, 8, 10]
 
     # Testing the combination of a filter and a limit
-    arrow_table = pa.Table.from_batches(
+    arrow_table = (
         test_positional_mor_double_deletes.scan(
             row_filter=And(GreaterThanOrEqual("letter", "e"), LessThan("letter", "k")), limit=1
-        ).to_arrow_batches()
+        )
+        .to_arrow_batch_reader()
+        .read_all()
     )
     assert arrow_table["number"].to_pylist() == [5]
 
     # Testing the slicing of indices
-    arrow_table = pa.Table.from_batches(test_positional_mor_double_deletes.scan(limit=8).to_arrow_batches())
+    arrow_table = test_positional_mor_double_deletes.scan(limit=8).to_arrow_batch_reader().read_all()
     assert arrow_table["number"].to_pylist() == [1, 2, 3, 4, 5, 7, 8, 10]
 
 

--- a/tests/integration/test_reads.py
+++ b/tests/integration/test_reads.py
@@ -212,7 +212,7 @@ def test_pyarrow_batches_nan_rewritten(catalog: Catalog) -> None:
 @pytest.mark.parametrize("catalog", [pytest.lazy_fixture("session_catalog_hive"), pytest.lazy_fixture("session_catalog")])
 @pytest.mark.skip(reason="Fixing issues with NaN's: https://github.com/apache/arrow/issues/34162")
 def test_pyarrow_batches_not_nan_count(catalog: Catalog) -> None:
-    table_test_null_nan = catalog.load_table("default.test_batches_null_nan")
+    table_test_null_nan = catalog.load_table("default.test_null_nan")
     arrow_batches = table_test_null_nan.scan(row_filter=NotNaN("col_numeric"), selected_fields=("idx",)).to_arrow_batches()
     assert isinstance(arrow_batches, Iterator)
     list_of_batches = list(arrow_batches)


### PR DESCRIPTION
- `RecordBatchReader` is preferable for memory constrained applications
- update `to_requested_schema` to take pa.RecordBatch instead of pa.Table

Question: pyarrow schema is currently inconsistent - it either returns pyarrow schema without Parquet metadata, or it adds the Parquet metadata and returns the value in some cases - we should make this consistent across our table scans and update the unit tests accordingly. 

Edit: Opened up the Issue here to discuss above question https://github.com/apache/iceberg-python/issues/788