### PR TITLE
Avoid Upcasting to `pa.large_binary()`

### DIFF
--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -554,7 +554,7 @@ class _ConvertToArrowSchema(SchemaVisitorPerPrimitiveType[pa.DataType]):
         return pa.binary(16)
 
     def visit_binary(self, _: BinaryType) -> pa.DataType:
-        return pa.large_binary()
+        return pa.binary()
 
 
 def _convert_scalar(value: Any, iceberg_type: IcebergType) -> pa.scalar:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2131,7 +2131,7 @@ def pa_schema() -> "pa.Schema":
         # ("time", pa.time64("us")),
         # Not natively supported by Arrow
         # ("uuid", pa.fixed(16)),
-        ("binary", pa.large_binary()),
+        ("binary", pa.binary()),
         ("fixed", pa.binary(16)),
     ])
 

--- a/tests/io/test_pyarrow.py
+++ b/tests/io/test_pyarrow.py
@@ -491,7 +491,7 @@ def test_string_type_to_pyarrow() -> None:
 
 def test_binary_type_to_pyarrow() -> None:
     iceberg_type = BinaryType()
-    assert visit(iceberg_type, _ConvertToArrowSchema()) == pa.large_binary()
+    assert visit(iceberg_type, _ConvertToArrowSchema()) == pa.binary()
 
 
 def test_struct_type_to_pyarrow(table_schema_simple: Schema) -> None:

--- a/tests/io/test_pyarrow_visitor.py
+++ b/tests/io/test_pyarrow_visitor.py
@@ -216,7 +216,7 @@ def test_pyarrow_string_to_iceberg() -> None:
 
 
 def test_pyarrow_variable_binary_to_iceberg() -> None:
-    pyarrow_type = pa.large_binary()
+    pyarrow_type = pa.binary()
     converted_iceberg_type = visit_pyarrow(pyarrow_type, _ConvertToIceberg())
     assert converted_iceberg_type == BinaryType()
     assert visit(converted_iceberg_type, _ConvertToArrowSchema()) == pyarrow_type


### PR DESCRIPTION
Fixes https://github.com/apache/iceberg-python/issues/791

Parquet seems to have a [2GB upper limit](https://github.com/apache/parquet-format/blob/e91ab5e892391bd179d3c16b7c1cf4fbaeebbfe7/src/main/thrift/parquet.thrift#L711-L714) on the size of a single Page within each column. Attempting to write data that is larger than 2GB in a single cell/page results in errors observed in the issue linked above.

This PR seeks to limit `schema_to_pyarrow` to cast to regular types that restrict Arrow data representations to 2GB, which aligns with the limitations of Parquet.

EDIT:

Based on the discussions on https://github.com/apache/iceberg-python/issues/791 it looks like we'd benefit from decoupling the motivation to support larger arrow types from the size limitations of parquet.

https://github.com/apache/iceberg-python/pull/807 resolves the schema inconsistency issue by always casting to `large_*` types instead 