### PR TITLE
AssertTableUUID on all Transactions except CreateTableTransaction

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -511,6 +511,7 @@ class Transaction:
             The table with the updates applied.
         """
         if len(self._updates) > 0:
+            self._requirements += (AssertTableUUID(uuid=self.table_metadata.table_uuid),)
             self._table._do_commit(  # pylint: disable=W0212
                 updates=self._updates,
                 requirements=self._requirements,
@@ -565,7 +566,11 @@ class CreateTableTransaction(Transaction):
             The table with the updates applied.
         """
         self._requirements = (AssertCreate(),)
-        return super().commit_transaction()
+        self._table._do_commit(  # pylint: disable=W0212
+            updates=self._updates,
+            requirements=self._requirements,
+        )
+        return self._table
 
 
 class AssignUUIDUpdate(IcebergBaseModel):
@@ -2919,10 +2924,7 @@ class _MergingSnapshotProducer(UpdateTableMetadata["_MergingSnapshotProducer"]):
                     snapshot_id=self._snapshot_id, parent_snapshot_id=self._parent_snapshot_id, ref_name="main", type="branch"
                 ),
             ),
-            (
-                AssertTableUUID(uuid=self._transaction.table_metadata.table_uuid),
-                AssertRefSnapshotId(snapshot_id=self._parent_snapshot_id, ref="main"),
-            ),
+            (AssertRefSnapshotId(snapshot_id=self._parent_snapshot_id, ref="main"),),
         )
 
 


### PR DESCRIPTION
In the [java implementation](https://github.com/apache/iceberg/blob/c7de6cb345995cb47312edbef6edae2f17fb8aba/core/src/main/java/org/apache/iceberg/UpdateRequirements.java#L50), AssertTableUUID is required on all table update operations, except for table creation.

This is because AssertTableUUID guards against concurrency issues that can occur when different processes are dropping and creating the Iceberg table of the same name while an update is being built.
