### PR TITLE
🐛 Write fields instead of spec object

### DIFF
--- a/tests/utils/test_manifest.py
+++ b/tests/utils/test_manifest.py
@@ -348,8 +348,8 @@ def test_write_manifest(
 
         expected_metadata = {
             "schema": test_schema.model_dump_json(),
-            "partition-spec": test_spec.model_dump_json(),
-            "partition-spec-id": str(test_spec.spec_id),
+            "partition-spec": """[{"source-id":1,"field-id":1,"transform":"identity","name":"VendorID"},{"source-id":2,"field-id":2,"transform":"identity","name":"tpep_pickup_datetime"}]""",
+            "partition-spec-id": str(demo_manifest_file.partition_spec_id),
             "format-version": str(format_version),
         }
         _verify_metadata_with_fastavro(


### PR DESCRIPTION
It should write the fields instead of the full spec: https://github.com/apache/iceberg-python/issues/208#issuecomment-2183015146

Also, did a small OOP refactor.