### PR TITLE
Add mkdocs toc config section

### DIFF
--- a/mkdocs/mkdocs.yml
+++ b/mkdocs/mkdocs.yml
@@ -53,8 +53,11 @@ theme:
       toggle:
         icon: material/brightness-4
         name: Switch to light mode
+
 markdown_extensions:
   - admonition
   - pymdownx.highlight:
       anchor_linenums: true
   - pymdownx.superfences
+  - toc:
+      permalink: true


### PR DESCRIPTION
Fixes #808

It seems that enabling the `toc` extension and its `permalink` option should enable anchors in the section headers as per https://python-markdown.github.io/extensions/toc/#usage