### PR TITLE
Raise error on nonexistent namespace on sql.py

### DIFF
--- a/pyiceberg/catalog/sql.py
+++ b/pyiceberg/catalog/sql.py
@@ -556,6 +556,8 @@ class SqlCatalog(MetastoreCatalog):
                     )
                 )
                 session.commit()
+        else:
+            raise NoSuchNamespaceError(f"Namespace does not exist: {namespace}")
 
     def list_tables(self, namespace: Union[str, Identifier]) -> List[Identifier]:
         """List tables under the given namespace in the catalog.

--- a/pyiceberg/catalog/sql.py
+++ b/pyiceberg/catalog/sql.py
@@ -543,21 +543,21 @@ class SqlCatalog(MetastoreCatalog):
             NoSuchNamespaceError: If a namespace with the given name does not exist.
             NamespaceNotEmptyError: If the namespace is not empty.
         """
-        if self._namespace_exists(namespace):
-            namespace_str = Catalog.namespace_to_string(namespace)
-            if tables := self.list_tables(namespace):
-                raise NamespaceNotEmptyError(f"Namespace {namespace_str} is not empty. {len(tables)} tables exist.")
-
-            with Session(self.engine) as session:
-                session.execute(
-                    delete(IcebergNamespaceProperties).where(
-                        IcebergNamespaceProperties.catalog_name == self.name,
-                        IcebergNamespaceProperties.namespace == namespace_str,
-                    )
-                )
-                session.commit()
-        else:
+        if not self._namespace_exists(namespace):
             raise NoSuchNamespaceError(f"Namespace does not exist: {namespace}")
+
+        namespace_str = Catalog.namespace_to_string(namespace)
+        if tables := self.list_tables(namespace):
+            raise NamespaceNotEmptyError(f"Namespace {namespace_str} is not empty. {len(tables)} tables exist.")
+
+        with Session(self.engine) as session:
+            session.execute(
+                delete(IcebergNamespaceProperties).where(
+                    IcebergNamespaceProperties.catalog_name == self.name,
+                    IcebergNamespaceProperties.namespace == namespace_str,
+                )
+            )
+            session.commit()
 
     def list_tables(self, namespace: Union[str, Identifier]) -> List[Identifier]:
         """List tables under the given namespace in the catalog.

--- a/tests/catalog/test_sql.py
+++ b/tests/catalog/test_sql.py
@@ -1100,6 +1100,18 @@ def test_drop_namespace(catalog: SqlCatalog, table_schema_nested: Schema, table_
         lazy_fixture("catalog_sqlite"),
     ],
 )
+def test_drop_non_existing_namespaces(catalog: SqlCatalog) -> None:
+    with pytest.raises(NoSuchNamespaceError):
+        catalog.drop_namespace("does_not_exist")
+
+
+@pytest.mark.parametrize(
+    "catalog",
+    [
+        lazy_fixture("catalog_memory"),
+        lazy_fixture("catalog_sqlite"),
+    ],
+)
 @pytest.mark.parametrize("namespace", [lazy_fixture("database_name"), lazy_fixture("hierarchical_namespace_name")])
 def test_load_namespace_properties(catalog: SqlCatalog, namespace: str) -> None:
     warehouse_location = "/test/location"


### PR DESCRIPTION
Fixes bug listed at #864, where `drop_namespace` was not raising an error when the given namespace does not exist.