### PR TITLE
Handle error when trying to drop a non-empty namespace on rest.py

### DIFF
--- a/pyiceberg/catalog/rest.py
+++ b/pyiceberg/catalog/rest.py
@@ -47,6 +47,7 @@ from pyiceberg.exceptions import (
     CommitStateUnknownException,
     ForbiddenError,
     NamespaceAlreadyExistsError,
+    NamespaceNotEmptyError,
     NoSuchNamespaceError,
     NoSuchTableError,
     OAuthError,
@@ -725,7 +726,7 @@ class RestCatalog(Catalog):
         try:
             response.raise_for_status()
         except HTTPError as exc:
-            self._handle_non_200_response(exc, {404: NoSuchNamespaceError})
+            self._handle_non_200_response(exc, {404: NoSuchNamespaceError, 409: NamespaceNotEmptyError})
 
     @retry(**_RETRY_ARGS)
     def list_namespaces(self, namespace: Union[str, Identifier] = ()) -> List[Identifier]:


### PR DESCRIPTION
Fixes bug listed at #864, where `drop_namespace` on rest.py was not handling an error when trying to drop a non-empty namespace.