### PR TITLE
fix: update all namespace properties in update_namespace_properties

### DIFF
--- a/pyiceberg/catalog/sql.py
+++ b/pyiceberg/catalog/sql.py
@@ -673,11 +673,16 @@ class SqlCatalog(MetastoreCatalog):
                     IcebergNamespaceProperties.property_key.in_(set(updates.keys())),
                 )
                 session.execute(delete_stmt)
-                insert_stmt = insert(IcebergNamespaceProperties)
-                for property_key, property_value in updates.items():
-                    insert_stmt = insert_stmt.values(
-                        catalog_name=self.name, namespace=namespace_str, property_key=property_key, property_value=property_value
-                    )
+                insert_stmt_values = [
+                    {
+                        "catalog_name": self.name,
+                        "namespace": namespace_str,
+                        "property_key": property_key,
+                        "property_value": property_value,
+                    }
+                    for property_key, property_value in updates.items()
+                ]
+                insert_stmt = insert(IcebergNamespaceProperties).values(insert_stmt_values)
                 session.execute(insert_stmt)
             session.commit()
         return properties_update_summary

--- a/pyiceberg/catalog/sql.py
+++ b/pyiceberg/catalog/sql.py
@@ -675,10 +675,10 @@ class SqlCatalog(MetastoreCatalog):
                 session.execute(delete_stmt)
                 insert_stmt_values = [
                     {
-                        "catalog_name": self.name,
-                        "namespace": namespace_str,
-                        "property_key": property_key,
-                        "property_value": property_value,
+                        IcebergNamespaceProperties.catalog_name: self.name,
+                        IcebergNamespaceProperties.namespace: namespace_str,
+                        IcebergNamespaceProperties.property_key: property_key,
+                        IcebergNamespaceProperties.property_value: property_value,
                     }
                     for property_key, property_value in updates.items()
                 ]

--- a/tests/catalog/test_sql.py
+++ b/tests/catalog/test_sql.py
@@ -1165,16 +1165,19 @@ def test_update_namespace_properties(catalog: SqlCatalog, namespace: str) -> Non
     updates = {"test_property4": "4", "test_property5": "5", "comment": "updated test description"}
     catalog.create_namespace(namespace, test_properties)
     update_report = catalog.update_namespace_properties(namespace, removals, updates)
-    updated_properties = catalog.load_namespace_properties(namespace)
-    for k, v in updates.items():
+    for k in updates.keys():
         assert k in update_report.updated
-        assert k in updated_properties
-        assert v == updated_properties[k]
     for k in removals:
         if k == "should_not_removed":
             assert k in update_report.missing
         else:
             assert k in update_report.removed
+    assert catalog.load_namespace_properties(namespace) == {
+        "comment": "updated test description",
+        "test_property4": "4",
+        "test_property5": "5",
+        "location": f"{warehouse_location}/{namespace}.db",
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/catalog/test_sql.py
+++ b/tests/catalog/test_sql.py
@@ -1173,6 +1173,8 @@ def test_update_namespace_properties(catalog: SqlCatalog, namespace: str) -> Non
         else:
             assert k in update_report.removed
     assert "updated test description" == catalog.load_namespace_properties(namespace)["comment"]
+    assert "5" == catalog.load_namespace_properties(namespace)["test_property5"]
+    assert "4" == catalog.load_namespace_properties(namespace)["test_property4"]
 
 
 @pytest.mark.parametrize(

--- a/tests/catalog/test_sql.py
+++ b/tests/catalog/test_sql.py
@@ -1165,16 +1165,16 @@ def test_update_namespace_properties(catalog: SqlCatalog, namespace: str) -> Non
     updates = {"test_property4": "4", "test_property5": "5", "comment": "updated test description"}
     catalog.create_namespace(namespace, test_properties)
     update_report = catalog.update_namespace_properties(namespace, removals, updates)
-    for k in updates.keys():
+    updated_properties = catalog.load_namespace_properties(namespace)
+    for k, v in updates.items():
         assert k in update_report.updated
+        assert k in updated_properties
+        assert v == updated_properties[k]
     for k in removals:
         if k == "should_not_removed":
             assert k in update_report.missing
         else:
             assert k in update_report.removed
-    assert "updated test description" == catalog.load_namespace_properties(namespace)["comment"]
-    assert "5" == catalog.load_namespace_properties(namespace)["test_property5"]
-    assert "4" == catalog.load_namespace_properties(namespace)["test_property4"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes 3rd bug listed at https://github.com/apache/iceberg-python/issues/864, where update_namespace_properties function only updates the first property and drops the rest