### PR TITLE
Bump CI to Hive 4

### DIFF
--- a/dev/hive/Dockerfile
+++ b/dev/hive/Dockerfile
@@ -17,18 +17,17 @@ FROM openjdk:8-jre-slim AS build
 
 RUN apt-get update -qq && apt-get -qq -y install curl
 
-ENV AWSSDK_VERSION=2.20.18
-ENV HADOOP_VERSION=3.1.0
+ENV HADOOP_VERSION=3.3.6
+ENV AWS_SDK_BUNDLE=1.12.753
 
-RUN curl https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.11.271/aws-java-sdk-bundle-1.11.271.jar -Lo /tmp/aws-java-sdk-bundle-1.11.271.jar
 RUN curl https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/${HADOOP_VERSION}/hadoop-aws-${HADOOP_VERSION}.jar -Lo /tmp/hadoop-aws-${HADOOP_VERSION}.jar
+RUN curl https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/${AWS_SDK_BUNDLE}/aws-java-sdk-bundle-${AWS_SDK_BUNDLE}.jar -Lo /tmp/aws-java-sdk-bundle-${AWS_SDK_BUNDLE}.jar
 
+FROM apache/hive:4.0.0
 
-FROM apache/hive:3.1.3
-
-ENV AWSSDK_VERSION=2.20.18
-ENV HADOOP_VERSION=3.1.0
+ENV HADOOP_VERSION=3.3.6
+ENV AWS_SDK_BUNDLE=1.12.753
 
 COPY --from=build /tmp/hadoop-aws-${HADOOP_VERSION}.jar /opt/hive/lib/hadoop-aws-${HADOOP_VERSION}.jar
-COPY --from=build /tmp/aws-java-sdk-bundle-1.11.271.jar /opt/hive/lib/aws-java-sdk-bundle-1.11.271.jar
+COPY --from=build /tmp/aws-java-sdk-bundle-${AWS_SDK_BUNDLE}.jar /opt/hive/lib/aws-java-sdk-bundle-${AWS_SDK_BUNDLE}.jar
 COPY core-site.xml /opt/hadoop/etc/hadoop/core-site.xml


### PR DESCRIPTION
I'm having some issues with the Hive 3.1.3 images on my new MacBook. The Hive 4.x images are also available for the arm64 architecture.

Resolves https://github.com/apache/iceberg-python/issues/835