### PR TITLE
strtobool support for python 3.12

### DIFF
--- a/pyiceberg/types.py
+++ b/pyiceberg/types.py
@@ -92,6 +92,22 @@ def _parse_fixed_type(fixed: Any) -> int:
         return fixed
 
 
+def strtobool(val: str) -> bool:
+    """Convert a string representation of truth to true (1) or false (0).
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+    """
+    val = val.lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return True
+    elif val in ("n", "no", "f", "false", "off", "0"):
+        return False
+    else:
+        raise ValueError(f"invalid truth value {val!r}")
+
+
 class IcebergType(IcebergBaseModel):
     """Base type for all Iceberg Types.
 

--- a/pyiceberg/types.py
+++ b/pyiceberg/types.py
@@ -105,7 +105,7 @@ def strtobool(val: str) -> bool:
     elif val in ("n", "no", "f", "false", "off", "0"):
         return False
     else:
-        raise ValueError(f"invalid truth value {val!r}")
+        raise ValueError(f"Invalid truth value: {val!r}")
 
 
 class IcebergType(IcebergBaseModel):

--- a/pyiceberg/utils/config.py
+++ b/pyiceberg/utils/config.py
@@ -16,12 +16,12 @@
 # under the License.
 import logging
 import os
-from distutils.util import strtobool
 from typing import List, Optional
 
 import strictyaml
 
 from pyiceberg.typedef import UTF8, FrozenDict, RecursiveDict
+from pyiceberg.types import strtobool
 
 PYICEBERG = "pyiceberg_"
 DEFAULT = "default"

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -633,28 +633,19 @@ def test_deepcopy_of_singleton_fixed_type() -> None:
         assert id(lhs) == id(rhs)
 
 
-@pytest.mark.parametrize(
-    "val, expected",
-    [
-        ("y", True),
-        ("yes", True),
-        ("t", True),
-        ("true", True),
-        ("on", True),
-        ("1", True),
-        ("n", False),
-        ("no", False),
-        ("f", False),
-        ("false", False),
-        ("off", False),
-        ("0", False),
-    ],
-)
-def test_strtobool_valid(val: str, expected: bool) -> None:
-    assert strtobool(val) == expected
+def test_strtobool() -> None:
+    # Values that should return True
+    true_values = ["y", "yes", "t", "true", "on", "1"]
+    for val in true_values:
+        assert strtobool(val) == 1, f"Expected True for value: {val}"
 
+    # Values that should return False
+    false_values = ["n", "no", "f", "false", "off", "0"]
+    for val in false_values:
+        assert strtobool(val) == 0, f"Expected False for value: {val}"
 
-@pytest.mark.parametrize("val", ["maybe", "2", "trueish", "falseish", "", " "])
-def test_strtobool_invalid(val: str) -> None:
-    with pytest.raises(ValueError):
-        strtobool(val)
+    # Values that should raise ValueError
+    invalid_values = ["maybe", "2", "trueish", "falseish", "", " "]
+    for val in invalid_values:
+        with pytest.raises(ValueError, match=f"Invalid truth value: {val!r}"):
+            strtobool(val)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -637,12 +637,12 @@ def test_strtobool() -> None:
     # Values that should return True
     true_values = ["y", "yes", "t", "true", "on", "1"]
     for val in true_values:
-        assert strtobool(val) == 1, f"Expected True for value: {val}"
+        assert strtobool(val) is True, f"Expected True for value: {val}"
 
     # Values that should return False
     false_values = ["n", "no", "f", "false", "off", "0"]
     for val in false_values:
-        assert strtobool(val) == 0, f"Expected False for value: {val}"
+        assert strtobool(val) is False, f"Expected False for value: {val}"
 
     # Values that should raise ValueError
     invalid_values = ["maybe", "2", "trueish", "falseish", "", " "]

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -43,6 +43,7 @@ from pyiceberg.types import (
     TimestamptzType,
     TimeType,
     UUIDType,
+    strtobool,
 )
 
 non_parameterized_types = [
@@ -630,3 +631,30 @@ def test_deepcopy_of_singleton_fixed_type() -> None:
 
     for lhs, rhs in zip(list_of_fixed_types, copied_list):
         assert id(lhs) == id(rhs)
+
+
+@pytest.mark.parametrize(
+    "val, expected",
+    [
+        ("y", True),
+        ("yes", True),
+        ("t", True),
+        ("true", True),
+        ("on", True),
+        ("1", True),
+        ("n", False),
+        ("no", False),
+        ("f", False),
+        ("false", False),
+        ("off", False),
+        ("0", False),
+    ],
+)
+def test_strtobool_valid(val: str, expected: bool) -> None:
+    assert strtobool(val) == expected
+
+
+@pytest.mark.parametrize("val", ["maybe", "2", "trueish", "falseish", "", " "])
+def test_strtobool_invalid(val: str) -> None:
+    with pytest.raises(ValueError):
+        strtobool(val)


### PR DESCRIPTION
Python 3.12 has dropped support for distutil package [PEP632](https://peps.python.org/pep-0632/) and any util imported via the same, will no longer be supported in 3.12 venv.

- [x] inbuilt `strtobool` utility function
- [x] Unitest 

Closes #859