### PR TITLE
Makefile clean utility to remove cython cached objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,3 +71,14 @@ test-coverage:
 	poetry run coverage report -m --fail-under=90
 	poetry run coverage html
 	poetry run coverage xml
+
+
+clean:
+	@echo "Cleaning up Cython and Python cached files"
+	@rm -rf build dist *.egg-info
+	@find . -name "*.so" -exec echo Deleting {} \; -delete
+	@find . -name "*.pyc" -exec echo Deleting {} \; -delete
+	@find . -name "__pycache__" -exec echo Deleting {} \; -exec rm -rf {} +
+	@find . -name "*.pyd" -exec echo Deleting {} \; -delete
+	@find . -name "*.pyo" -exec echo Deleting {} \; -delete
+	@echo "Cleanup complete"

--- a/mkdocs/docs/contributing.md
+++ b/mkdocs/docs/contributing.md
@@ -88,6 +88,16 @@ In contrast to the name suggest, it doesn't run the checks on the commit. If thi
 
 You can bump the integrations to the latest version using `pre-commit autoupdate`. This will check if there is a newer version of `{black,mypy,isort,...}` and update the yaml.
 
+## Cleaning
+
+Removal of old cached files generated during the Cython build process:
+
+```bash
+make clean
+```
+
+Helps prevent build failures and unexpected behavior by removing outdated files, ensuring that only up-to-date sources are used & build environment is always clean.
+
 ## Testing
 
 For Python, `pytest` is used a testing framework in combination with `coverage` to enforce 90%+ code coverage.

--- a/mkdocs/docs/contributing.md
+++ b/mkdocs/docs/contributing.md
@@ -96,7 +96,7 @@ Removal of old cached files generated during the Cython build process:
 make clean
 ```
 
-Helps prevent build failures and unexpected behavior by removing outdated files, ensuring that only up-to-date sources are used & build environment is always clean.
+Helps prevent build failures and unexpected behavior by removing outdated files, ensuring that only up-to-date sources are used & the build environment is always clean.
 
 ## Testing
 


### PR DESCRIPTION
This PR introduces a make clean command in the Makefile to automate the removal of old cached files. The make clean command will find and delete files with specific extensions that are typically generated during the Cython build process.

- [x] Make clean utility
- [x] Mkdocs change

closes: https://github.com/apache/iceberg-python/issues/875