### PR TITLE
Add pool_pre_ping param to SQLCatalog and fix echo parsing logic

### DIFF
--- a/mkdocs/docs/configuration.md
+++ b/mkdocs/docs/configuration.md
@@ -222,11 +222,11 @@ catalog:
     uri: sqlite:////tmp/pyiceberg.db
 ```
 
-| Key           | Example                                                      | Description                                                                                                                                                                                                         |
-| ------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| uri           | postgresql+psycopg2://username:password@localhost/mydatabase | SQLAlchemy backend URL for the catalog database (see [documentation for URL format](https://docs.sqlalchemy.org/en/20/core/engines.html#backend-specific-urls))                                                     |
-| echo          | true                                                         | SQLAlchemy engine [echo param](https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.create_engine.params.echo) to log all statements to the default log handler (default is `false`)                      |
-| pool_pre_ping | true                                                         | SQLAlchemy engine [pool_pre_ping param](https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.create_engine.params.pool_pre_ping) to test connections for liveness upon each checkout (default is `false`) |
+| Key           | Example                                                      | Default | Description                                                                                                                                                                                    |
+| ------------- | ------------------------------------------------------------ | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| uri           | postgresql+psycopg2://username:password@localhost/mydatabase |         | SQLAlchemy backend URL for the catalog database (see [documentation for URL format](https://docs.sqlalchemy.org/en/20/core/engines.html#backend-specific-urls))                                |
+| echo          | true                                                         | false   | SQLAlchemy engine [echo param](https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.create_engine.params.echo) to log all statements to the default log handler                      |
+| pool_pre_ping | true                                                         | false   | SQLAlchemy engine [pool_pre_ping param](https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.create_engine.params.pool_pre_ping) to test connections for liveness upon each checkout |
 
 ## Hive Catalog
 

--- a/mkdocs/docs/configuration.md
+++ b/mkdocs/docs/configuration.md
@@ -222,6 +222,12 @@ catalog:
     uri: sqlite:////tmp/pyiceberg.db
 ```
 
+| Key           | Example                                                      | Description                                                                                                                                                                                                         |
+| ------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| uri           | postgresql+psycopg2://username:password@localhost/mydatabase | SQLAlchemy backend URL for the catalog database (see [documentation for URL format](https://docs.sqlalchemy.org/en/20/core/engines.html#backend-specific-urls))                                                     |
+| echo          | true                                                         | SQLAlchemy engine [echo param](https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.create_engine.params.echo) to log all statements to the default log handler (default is `false`)                      |
+| pool_pre_ping | true                                                         | SQLAlchemy engine [pool_pre_ping param](https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.create_engine.params.pool_pre_ping) to test connections for liveness upon each checkout (default is `false`) |
+
 ## Hive Catalog
 
 ```yaml

--- a/pyiceberg/catalog/sql.py
+++ b/pyiceberg/catalog/sql.py
@@ -64,9 +64,13 @@ from pyiceberg.table import CommitTableRequest, CommitTableResponse, Table
 from pyiceberg.table.metadata import new_table_metadata
 from pyiceberg.table.sorting import UNSORTED_SORT_ORDER, SortOrder
 from pyiceberg.typedef import EMPTY_DICT, Identifier, Properties
+from pyiceberg.types import strtobool
 
 if TYPE_CHECKING:
     import pyarrow as pa
+
+DEFAULT_ECHO_VALUE = "false"
+DEFAULT_PRE_PING_VALUE = "false"
 
 
 class SqlCatalogBaseTable(MappedAsDataclass, DeclarativeBase):
@@ -112,24 +116,12 @@ class SqlCatalog(MetastoreCatalog):
             raise NoSuchPropertyException("SQL connection URI is required")
 
         echo: Union[str, bool]
-        echo_str = str(self.properties.get("echo", "false")).lower()
+        echo_str = str(self.properties.get("echo", DEFAULT_ECHO_VALUE)).lower()
         if echo_str == "debug":
             echo = "debug"
-        elif echo_str == "true":
-            echo = True
-        elif echo_str == "false":
-            echo = False
         else:
-            raise ValueError(f"Invalid value for echo parameter: {echo_str}")
-
-        pool_pre_ping: Union[str, bool]
-        pool_pre_ping_str = str(self.properties.get("pool_pre_ping", "false")).lower()
-        if pool_pre_ping_str == "true":
-            pool_pre_ping = True
-        elif pool_pre_ping_str == "false":
-            pool_pre_ping = False
-        else:
-            raise ValueError(f"Invalid value for pool_pre_ping parameter: {pool_pre_ping_str}")
+            echo = strtobool(echo_str)
+        pool_pre_ping = strtobool(self.properties.get("pool_pre_ping", DEFAULT_PRE_PING_VALUE))
 
         self.engine = create_engine(uri_prop, echo=echo, pool_pre_ping=pool_pre_ping)
 

--- a/pyiceberg/catalog/sql.py
+++ b/pyiceberg/catalog/sql.py
@@ -131,8 +131,6 @@ class SqlCatalog(MetastoreCatalog):
         else:
             raise ValueError(f"Invalid value for pool_pre_ping parameter: {pool_pre_ping_str}")
 
-        print(f"echo = {echo}")
-        print(f"pool_pre_ping = {pool_pre_ping}")
         self.engine = create_engine(uri_prop, echo=echo, pool_pre_ping=pool_pre_ping)
 
         self._ensure_tables_exist()

--- a/pyiceberg/catalog/sql.py
+++ b/pyiceberg/catalog/sql.py
@@ -115,10 +115,8 @@ class SqlCatalog(MetastoreCatalog):
         if not (uri_prop := self.properties.get("uri")):
             raise NoSuchPropertyException("SQL connection URI is required")
 
-        echo: Union[str, bool] = "debug"
         echo_str = str(self.properties.get("echo", DEFAULT_ECHO_VALUE)).lower()
-        if echo_str != "debug":
-            echo = strtobool(echo_str)
+        echo = strtobool(echo_str) if echo_str != "debug" else "debug"
         pool_pre_ping = strtobool(self.properties.get("pool_pre_ping", DEFAULT_PRE_PING_VALUE))
 
         self.engine = create_engine(uri_prop, echo=echo, pool_pre_ping=pool_pre_ping)

--- a/pyiceberg/catalog/sql.py
+++ b/pyiceberg/catalog/sql.py
@@ -70,7 +70,7 @@ if TYPE_CHECKING:
     import pyarrow as pa
 
 DEFAULT_ECHO_VALUE = "false"
-DEFAULT_PRE_PING_VALUE = "false"
+DEFAULT_POOL_PRE_PING_VALUE = "false"
 
 
 class SqlCatalogBaseTable(MappedAsDataclass, DeclarativeBase):
@@ -117,7 +117,7 @@ class SqlCatalog(MetastoreCatalog):
 
         echo_str = str(self.properties.get("echo", DEFAULT_ECHO_VALUE)).lower()
         echo = strtobool(echo_str) if echo_str != "debug" else "debug"
-        pool_pre_ping = strtobool(self.properties.get("pool_pre_ping", DEFAULT_PRE_PING_VALUE))
+        pool_pre_ping = strtobool(self.properties.get("pool_pre_ping", DEFAULT_POOL_PRE_PING_VALUE))
 
         self.engine = create_engine(uri_prop, echo=echo, pool_pre_ping=pool_pre_ping)
 

--- a/pyiceberg/catalog/sql.py
+++ b/pyiceberg/catalog/sql.py
@@ -110,8 +110,30 @@ class SqlCatalog(MetastoreCatalog):
 
         if not (uri_prop := self.properties.get("uri")):
             raise NoSuchPropertyException("SQL connection URI is required")
-        echo = bool(self.properties.get("echo", False))
-        self.engine = create_engine(uri_prop, echo=echo)
+
+        echo: Union[str, bool]
+        echo_str = str(self.properties.get("echo", "false")).lower()
+        if echo_str == "debug":
+            echo = "debug"
+        elif echo_str == "true":
+            echo = True
+        elif echo_str == "false":
+            echo = False
+        else:
+            raise ValueError(f"Invalid value for echo parameter: {echo_str}")
+
+        pool_pre_ping: Union[str, bool]
+        pool_pre_ping_str = str(self.properties.get("pool_pre_ping", "false")).lower()
+        if pool_pre_ping_str == "true":
+            pool_pre_ping = True
+        elif pool_pre_ping_str == "false":
+            pool_pre_ping = False
+        else:
+            raise ValueError(f"Invalid value for pool_pre_ping parameter: {pool_pre_ping_str}")
+
+        print(f"echo = {echo}")
+        print(f"pool_pre_ping = {pool_pre_ping}")
+        self.engine = create_engine(uri_prop, echo=echo, pool_pre_ping=pool_pre_ping)
 
         self._ensure_tables_exist()
 

--- a/pyiceberg/catalog/sql.py
+++ b/pyiceberg/catalog/sql.py
@@ -115,11 +115,9 @@ class SqlCatalog(MetastoreCatalog):
         if not (uri_prop := self.properties.get("uri")):
             raise NoSuchPropertyException("SQL connection URI is required")
 
-        echo: Union[str, bool]
+        echo: Union[str, bool] = "debug"
         echo_str = str(self.properties.get("echo", DEFAULT_ECHO_VALUE)).lower()
-        if echo_str == "debug":
-            echo = "debug"
-        else:
+        if echo_str != "debug":
             echo = strtobool(echo_str)
         pool_pre_ping = strtobool(self.properties.get("pool_pre_ping", DEFAULT_PRE_PING_VALUE))
 

--- a/tests/catalog/test_sql.py
+++ b/tests/catalog/test_sql.py
@@ -168,6 +168,30 @@ def test_creation_with_unsupported_uri(catalog_name: str) -> None:
         SqlCatalog(catalog_name, uri="unsupported:xxx")
 
 
+@pytest.mark.parametrize("echo_param, expected_echo_value", [("debug", "debug"), ("true", True), ("false", False)])
+def test_creation_with_echo_parameter(catalog_name: str, warehouse: Path, echo_param: str, expected_echo_value: Any) -> None:
+    props = {
+        "uri": f"sqlite:////{warehouse}/sql-catalog.db",
+        "warehouse": f"file://{warehouse}",
+        "echo": echo_param,
+    }
+    catalog = SqlCatalog(catalog_name, **props)
+    assert catalog.engine._echo == expected_echo_value
+
+
+@pytest.mark.parametrize("pre_ping_param, expected_pre_ping_value", [("true", True), ("false", False)])
+def test_creation_with_pool_pre_ping_parameter(
+    catalog_name: str, warehouse: Path, pre_ping_param: str, expected_pre_ping_value: Any
+) -> None:
+    props = {
+        "uri": f"sqlite:////{warehouse}/sql-catalog.db",
+        "warehouse": f"file://{warehouse}",
+        "pool_pre_ping": pre_ping_param,
+    }
+    catalog = SqlCatalog(catalog_name, **props)
+    assert catalog.engine.pool._pre_ping == expected_pre_ping_value
+
+
 @pytest.mark.parametrize(
     "catalog",
     [


### PR DESCRIPTION
When running code for a long time using the SQLCatalog, it is possible to face a situation where a DB connection from the pool has timed out.  When trying to use that connection again, the SQLAlchemy engine raises the following exception (when using a PostgreSQL backend):
```
sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) SSL SYSCALL error: EOF detected.
```
This happens when the connection has been closed by the server and the engine raises this exception.  My solution is fairly simple, but effective: when creating the engine, use `pool_pre_ping`.
```python
self.engine = create_engine(uri_prop, echo=echo, pool_pre_ping=True)
```
I can reproduce the problem with a Postgresql DB and the following code:
```python
from time import sleep
from pyiceberg.catalog import load_catalog

cat = load_catalog("my_sql_catalog")
for n in cat.list_namespaces():
    print(n)
    sleep(35 * 60)
    for t in cat.list_tables(n):
        print(f"\t{t}")
```
This will print the first namespace, sleep for 35 min and then raise the exception on the next operation.  When pool_pre_ping is set to True, everything is cool.

This PR also fixes the parsing logic for the `echo` engine parameter (to properly parse a boolean value as a string and supporting `debug` as a possible value, as defined by the SQLAlchemy documentation) as well as add documentation to both parameters.
