### PR TITLE
Allow writing `pa.Table` that are either a subset of table schema or in arbitrary order, and support type promotion on write

### DIFF
--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -1453,17 +1453,14 @@ class ArrowAccessor(PartnerAccessor[pa.Array]):
             except ValueError:
                 return None
 
-            try:
-                if isinstance(partner_struct, pa.StructArray):
-                    return partner_struct.field(name)
-                elif isinstance(partner_struct, pa.Table):
-                    return partner_struct.column(name).combine_chunks()
-                elif isinstance(partner_struct, pa.RecordBatch):
-                    return partner_struct.column(name)
-                else:
-                    raise ValueError(f"Cannot find {name} in expected partner_struct type {type(partner_struct)}")
-            except KeyError:
-                return None
+            if isinstance(partner_struct, pa.StructArray):
+                return partner_struct.field(name)
+            elif isinstance(partner_struct, pa.Table):
+                return partner_struct.column(name).combine_chunks()
+            elif isinstance(partner_struct, pa.RecordBatch):
+                return partner_struct.column(name)
+            else:
+                raise ValueError(f"Cannot find {name} in expected partner_struct type {type(partner_struct)}")
 
         return None
 

--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -2003,7 +2003,6 @@ def write_file(io: FileIO, table_metadata: TableMetadata, tasks: Iterator[WriteT
 
     def write_parquet(task: WriteTask) -> DataFile:
         table_schema = task.schema
-
         # if schema needs to be transformed, use the transformed schema and adjust the arrow table accordingly
         # otherwise use the original schema
         if (sanitized_schema := sanitize_column_names(table_schema)) != table_schema:
@@ -2123,15 +2122,12 @@ def _check_schema_compatible(table_schema: Schema, other_schema: pa.Schema, down
         ):
             continue
         elif lhs.field_type != rhs.field_type:
-            try:
-                promote(rhs.field_type, lhs.field_type)
-            except ResolveError:
-                rich_table.add_row(
-                    field_name,
-                    "Type",
-                    f"{print_nullability(lhs.required)} {str(lhs.field_type)}",
-                    f"{print_nullability(rhs.required)} {str(rhs.field_type)}",
-                )
+            rich_table.add_row(
+                field_name,
+                "Type",
+                f"{print_nullability(lhs.required)} {str(lhs.field_type)}",
+                f"{print_nullability(rhs.required)} {str(rhs.field_type)}",
+            )
 
     for field_name in extra_fields:
         rhs = task_schema.find_field(field_name)

--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -1906,16 +1906,6 @@ def data_file_statistics_from_parquet_metadata(
             set the mode for column metrics collection
         parquet_column_mapping (Dict[str, int]): The mapping of the parquet file name to the field ID
     """
-    if parquet_metadata.num_columns != len(stats_columns):
-        raise ValueError(
-            f"Number of columns in statistics configuration ({len(stats_columns)}) is different from the number of columns in pyarrow table ({parquet_metadata.num_columns})"
-        )
-
-    if parquet_metadata.num_columns != len(parquet_column_mapping):
-        raise ValueError(
-            f"Number of columns in column mapping ({len(parquet_column_mapping)}) is different from the number of columns in pyarrow table ({parquet_metadata.num_columns})"
-        )
-
     column_sizes: Dict[int, int] = {}
     value_counts: Dict[int, int] = {}
     split_offsets: List[int] = []

--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -1552,9 +1552,16 @@ class StatsAggregator:
 
         expected_physical_type = _primitive_to_physical(iceberg_type)
         if expected_physical_type != physical_type_string:
-            raise ValueError(
-                f"Unexpected physical type {physical_type_string} for {iceberg_type}, expected {expected_physical_type}"
-            )
+            # Allow promotable physical types
+            # INT32 -> INT64 and FLOAT -> DOUBLE are safe type casts
+            if (physical_type_string == "INT32" and expected_physical_type == "INT64") or (
+                physical_type_string == "FLOAT" and expected_physical_type == "DOUBLE"
+            ):
+                pass
+            else:
+                raise ValueError(
+                    f"Unexpected physical type {physical_type_string} for {iceberg_type}, expected {expected_physical_type}"
+                )
 
         self.primitive_type = iceberg_type
 

--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -2123,12 +2123,15 @@ def _check_schema_compatible(table_schema: Schema, other_schema: pa.Schema, down
         ):
             continue
         elif lhs.field_type != rhs.field_type:
-            rich_table.add_row(
-                field_name,
-                "Type",
-                f"{print_nullability(lhs.required)} {str(lhs.field_type)}",
-                f"{print_nullability(rhs.required)} {str(rhs.field_type)}",
-            )
+            try:
+                promote(rhs.field_type, lhs.field_type)
+            except ResolveError:
+                rich_table.add_row(
+                    field_name,
+                    "Type",
+                    f"{print_nullability(lhs.required)} {str(lhs.field_type)}",
+                    f"{print_nullability(rhs.required)} {str(rhs.field_type)}",
+                )
 
     for field_name in extra_fields:
         rhs = task_schema.find_field(field_name)

--- a/pyiceberg/schema.py
+++ b/pyiceberg/schema.py
@@ -1673,7 +1673,10 @@ class _SchemaCompatibilityVisitor(PreOrderSchemaVisitor[bool]):
             return True
         # We only check that the parent node is also of the same type.
         # We check the type of the child nodes when we traverse them later.
-        elif not lhs.is_primtive and not rhs.is_primitive:
+        elif any(
+            (isinstance(lhs.field_type, container_type) and isinstance(rhs.field_type, container_type))
+            for container_type in {StructType, MapType, ListType}
+        ):
             self.rich_table.add_row("✅", str(lhs), str(rhs))
             return True
         else:

--- a/pyiceberg/schema.py
+++ b/pyiceberg/schema.py
@@ -324,6 +324,11 @@ class Schema(IcebergBaseModel):
         """Return the IDs of the current schema."""
         return set(self._name_to_id.values())
 
+    @property
+    def field_names(self) -> Set[str]:
+        """Return the Names of the current schema."""
+        return set(self._name_to_id.keys())
+
     def _validate_identifier_field(self, field_id: int) -> None:
         """Validate that the field with the given ID is a valid identifier field.
 

--- a/pyiceberg/schema.py
+++ b/pyiceberg/schema.py
@@ -1673,10 +1673,7 @@ class _SchemaCompatibilityVisitor(PreOrderSchemaVisitor[bool]):
             return True
         # We only check that the parent node is also of the same type.
         # We check the type of the child nodes when we traverse them later.
-        elif any(
-            (isinstance(lhs.field_type, container_type) and isinstance(rhs.field_type, container_type))
-            for container_type in {StructType, MapType, ListType}
-        ):
+        elif not lhs.is_primtive and not rhs.is_primitive:
             self.rich_table.add_row("✅", str(lhs), str(rhs))
             return True
         else:

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -470,7 +470,7 @@ class Transaction:
         except ModuleNotFoundError as e:
             raise ModuleNotFoundError("For writes PyArrow needs to be installed") from e
 
-        from pyiceberg.io.pyarrow import _check_schema_compatible, _dataframe_to_data_files
+        from pyiceberg.io.pyarrow import _check_pyarrow_schema_compatible, _dataframe_to_data_files
 
         if not isinstance(df, pa.Table):
             raise ValueError(f"Expected PyArrow table, got: {df}")
@@ -482,8 +482,8 @@ class Transaction:
                 f"Not all partition types are supported for writes. Following partitions cannot be written using pyarrow: {unsupported_partitions}."
             )
         downcast_ns_timestamp_to_us = Config().get_bool(DOWNCAST_NS_TIMESTAMP_TO_US_ON_WRITE) or False
-        _check_schema_compatible(
-            self._table.schema(), other_schema=df.schema, downcast_ns_timestamp_to_us=downcast_ns_timestamp_to_us
+        _check_pyarrow_schema_compatible(
+            self._table.schema(), provided_schema=df.schema, downcast_ns_timestamp_to_us=downcast_ns_timestamp_to_us
         )
 
         manifest_merge_enabled = PropertyUtil.property_as_bool(
@@ -529,7 +529,7 @@ class Transaction:
         except ModuleNotFoundError as e:
             raise ModuleNotFoundError("For writes PyArrow needs to be installed") from e
 
-        from pyiceberg.io.pyarrow import _check_schema_compatible, _dataframe_to_data_files
+        from pyiceberg.io.pyarrow import _check_pyarrow_schema_compatible, _dataframe_to_data_files
 
         if not isinstance(df, pa.Table):
             raise ValueError(f"Expected PyArrow table, got: {df}")
@@ -541,8 +541,8 @@ class Transaction:
                 f"Not all partition types are supported for writes. Following partitions cannot be written using pyarrow: {unsupported_partitions}."
             )
         downcast_ns_timestamp_to_us = Config().get_bool(DOWNCAST_NS_TIMESTAMP_TO_US_ON_WRITE) or False
-        _check_schema_compatible(
-            self._table.schema(), other_schema=df.schema, downcast_ns_timestamp_to_us=downcast_ns_timestamp_to_us
+        _check_pyarrow_schema_compatible(
+            self._table.schema(), provided_schema=df.schema, downcast_ns_timestamp_to_us=downcast_ns_timestamp_to_us
         )
 
         self.delete(delete_filter=overwrite_filter, snapshot_properties=snapshot_properties)

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -73,7 +73,6 @@ from pyiceberg.expressions.visitors import (
     manifest_evaluator,
 )
 from pyiceberg.io import FileIO, OutputFile, load_file_io
-from pyiceberg.io.pyarrow import _check_schema_compatible, _dataframe_to_data_files, expression_to_pyarrow, project_table
 from pyiceberg.manifest import (
     POSITIONAL_DELETE_SCHEMA,
     DataFile,
@@ -471,6 +470,8 @@ class Transaction:
         except ModuleNotFoundError as e:
             raise ModuleNotFoundError("For writes PyArrow needs to be installed") from e
 
+        from pyiceberg.io.pyarrow import _check_schema_compatible, _dataframe_to_data_files
+
         if not isinstance(df, pa.Table):
             raise ValueError(f"Expected PyArrow table, got: {df}")
 
@@ -528,6 +529,8 @@ class Transaction:
         except ModuleNotFoundError as e:
             raise ModuleNotFoundError("For writes PyArrow needs to be installed") from e
 
+        from pyiceberg.io.pyarrow import _check_schema_compatible, _dataframe_to_data_files
+
         if not isinstance(df, pa.Table):
             raise ValueError(f"Expected PyArrow table, got: {df}")
 
@@ -566,6 +569,8 @@ class Transaction:
             delete_filter: A boolean expression to delete rows from a table
             snapshot_properties: Custom properties to be added to the snapshot summary
         """
+        from pyiceberg.io.pyarrow import _dataframe_to_data_files, expression_to_pyarrow, project_table
+
         if (
             self.table_metadata.properties.get(TableProperties.DELETE_MODE, TableProperties.DELETE_MODE_DEFAULT)
             == TableProperties.DELETE_MODE_MERGE_ON_READ

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2509,8 +2509,8 @@ def table_schema_with_all_microseconds_timestamp_precision() -> Schema:
 
 
 @pytest.fixture(scope="session")
-def table_schema_with_longs() -> Schema:
-    """Iceberg table Schema with longs in simple and nested types."""
+def table_schema_with_promoted_types() -> Schema:
+    """Iceberg table Schema with longs, doubles and uuid in simple and nested types."""
     return Schema(
         NestedField(field_id=1, name="long", field_type=LongType(), required=False),
         NestedField(
@@ -2532,12 +2532,13 @@ def table_schema_with_longs() -> Schema:
             required=True,
         ),
         NestedField(field_id=7, name="double", field_type=DoubleType(), required=False),
+        NestedField(field_id=8, name="uuid", field_type=UUIDType(), required=False),
     )
 
 
 @pytest.fixture(scope="session")
-def pyarrow_schema_with_longs() -> "pa.Schema":
-    """Pyarrow Schema with longs in simple and nested types."""
+def pyarrow_schema_with_promoted_types() -> "pa.Schema":
+    """Pyarrow Schema with longs, doubles and uuid in simple and nested types."""
     import pyarrow as pa
 
     return pa.schema((
@@ -2545,12 +2546,13 @@ def pyarrow_schema_with_longs() -> "pa.Schema":
         pa.field("list", pa.list_(pa.int32()), nullable=False),  # can support upcasting integer to long
         pa.field("map", pa.map_(pa.string(), pa.int32()), nullable=False),  # can support upcasting integer to long
         pa.field("double", pa.float32(), nullable=True),  # can support upcasting float to double
+        pa.field("uuid", pa.binary(length=16), nullable=True),  # can support upcasting float to double
     ))
 
 
 @pytest.fixture(scope="session")
-def pyarrow_table_with_longs(pyarrow_schema_with_longs: "pa.Schema") -> "pa.Table":
-    """Pyarrow table with longs in simple and nested types."""
+def pyarrow_table_with_promoted_types(pyarrow_schema_with_promoted_types: "pa.Schema") -> "pa.Table":
+    """Pyarrow table with longs, doubles and uuid in simple and nested types."""
     import pyarrow as pa
 
     return pa.Table.from_pydict(
@@ -2559,6 +2561,7 @@ def pyarrow_table_with_longs(pyarrow_schema_with_longs: "pa.Schema") -> "pa.Tabl
             "list": [[1, 1], [2, 2]],
             "map": [{"a": 1}, {"b": 2}],
             "double": [1.1, 9.2],
+            "uuid": [b"qZx\xefNS@\x89\x9b\xf9:\xd0\xee\x9b\xf5E", b"\x97]\x87T^JDJ\x96\x97\xf4v\xe4\x03\x0c\xde"],
         },
-        schema=pyarrow_schema_with_longs,
+        schema=pyarrow_schema_with_promoted_types,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2506,3 +2506,56 @@ def table_schema_with_all_microseconds_timestamp_precision() -> Schema:
         NestedField(field_id=10, name="timestamptz_ns_z", field_type=TimestamptzType(), required=False),
         NestedField(field_id=11, name="timestamptz_s_0000", field_type=TimestamptzType(), required=False),
     )
+
+
+@pytest.fixture(scope="session")
+def table_schema_with_longs() -> Schema:
+    """Iceberg table Schema with longs in simple and nested types."""
+    return Schema(
+        NestedField(field_id=1, name="long", field_type=LongType(), required=False),
+        NestedField(
+            field_id=2,
+            name="list",
+            field_type=ListType(element_id=4, element_type=LongType(), element_required=False),
+            required=True,
+        ),
+        NestedField(
+            field_id=3,
+            name="map",
+            field_type=MapType(
+                key_id=5,
+                key_type=StringType(),
+                value_id=6,
+                value_type=LongType(),
+                value_required=False,
+            ),
+            required=True,
+        ),
+    )
+
+
+@pytest.fixture(scope="session")
+def pyarrow_schema_with_longs() -> "pa.Schema":
+    """Pyarrow Schema with longs in simple and nested types."""
+    import pyarrow as pa
+
+    return pa.schema((
+        pa.field("long", pa.int32(), nullable=True),  # can support upcasting integer to long
+        pa.field("list", pa.list_(pa.int32()), nullable=False),  # can support upcasting integer to long
+        pa.field("map", pa.map_(pa.string(), pa.int32()), nullable=False),  # can support upcasting integer to long
+    ))
+
+
+@pytest.fixture(scope="session")
+def pyarrow_table_with_longs(pyarrow_schema_with_longs: "pa.Schema") -> "pa.Table":
+    """Pyarrow table with longs in simple and nested types."""
+    import pyarrow as pa
+
+    return pa.Table.from_pydict(
+        {
+            "long": [1, 9],
+            "list": [[1, 1], [2, 2]],
+            "map": [{"a": 1}, {"b": 2}],
+        },
+        schema=pyarrow_schema_with_longs,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2531,6 +2531,7 @@ def table_schema_with_longs() -> Schema:
             ),
             required=True,
         ),
+        NestedField(field_id=7, name="double", field_type=DoubleType(), required=False),
     )
 
 
@@ -2543,6 +2544,7 @@ def pyarrow_schema_with_longs() -> "pa.Schema":
         pa.field("long", pa.int32(), nullable=True),  # can support upcasting integer to long
         pa.field("list", pa.list_(pa.int32()), nullable=False),  # can support upcasting integer to long
         pa.field("map", pa.map_(pa.string(), pa.int32()), nullable=False),  # can support upcasting integer to long
+        pa.field("double", pa.float32(), nullable=True),  # can support upcasting float to double
     ))
 
 
@@ -2556,6 +2558,7 @@ def pyarrow_table_with_longs(pyarrow_schema_with_longs: "pa.Schema") -> "pa.Tabl
             "long": [1, 9],
             "list": [[1, 1], [2, 2]],
             "map": [{"a": 1}, {"b": 2}],
+            "double": [1.1, 9.2],
         },
         schema=pyarrow_schema_with_longs,
     )

--- a/tests/integration/test_add_files.py
+++ b/tests/integration/test_add_files.py
@@ -501,11 +501,14 @@ def test_add_files_fails_on_schema_mismatch(spark: SparkSession, session_catalog
             )
 
     expected = """Mismatch in fields:
-┏━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┓
-┃ Field Name ┃ Category ┃ Table field  ┃ Dataframe field ┃
-┡━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━┩
-│ baz        │ Type     │ optional int │ optional string │
-└────────────┴──────────┴──────────────┴─────────────────┘
+┏━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃    ┃ Table field              ┃ Dataframe field          ┃
+┡━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ ✅ │ 1: foo: optional boolean │ 1: foo: optional boolean │
+│ ✅ │ 2: bar: optional string  │ 2: bar: optional string  │
+│ ❌ │ 3: baz: optional int     │ 3: baz: optional string  │
+│ ✅ │ 4: qux: optional date    │ 4: qux: optional date    │
+└────┴──────────────────────────┴──────────────────────────┘
 """
 
     with pytest.raises(ValueError, match=expected):

--- a/tests/integration/test_add_files.py
+++ b/tests/integration/test_add_files.py
@@ -501,14 +501,11 @@ def test_add_files_fails_on_schema_mismatch(spark: SparkSession, session_catalog
             )
 
     expected = """Mismatch in fields:
-┏━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃    ┃ Table field              ┃ Dataframe field          ┃
-┡━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ ✅ │ 1: foo: optional boolean │ 1: foo: optional boolean │
-| ✅ │ 2: bar: optional string  │ 2: bar: optional string  │
-│ ❌ │ 3: baz: optional int     │ 3: baz: optional string  │
-│ ✅ │ 4: qux: optional date    │ 4: qux: optional date    │
-└────┴──────────────────────────┴──────────────────────────┘
+┏━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┓
+┃ Field Name ┃ Category ┃ Table field  ┃ Dataframe field ┃
+┡━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━┩
+│ baz        │ Type     │ optional int │ optional string │
+└────────────┴──────────┴──────────────┴─────────────────┘
 """
 
     with pytest.raises(ValueError, match=expected):

--- a/tests/integration/test_writes/test_writes.py
+++ b/tests/integration/test_writes/test_writes.py
@@ -43,7 +43,7 @@ from pyiceberg.partitioning import PartitionField, PartitionSpec
 from pyiceberg.schema import Schema
 from pyiceberg.table import TableProperties
 from pyiceberg.transforms import IdentityTransform
-from pyiceberg.types import BooleanType, IntegerType, LongType, NestedField
+from pyiceberg.types import IntegerType, ListType, LongType, MapType, NestedField, StringType
 from utils import _create_table
 
 
@@ -997,37 +997,96 @@ def test_table_write_out_of_order_schema(session_catalog: Catalog, arrow_table_w
 @pytest.mark.integration
 @pytest.mark.parametrize("format_version", [1, 2])
 def test_table_write_schema_with_valid_nullability_diff(
-    session_catalog: Catalog, arrow_table_with_null: pa.Table, format_version: int
+    spark: SparkSession, session_catalog: Catalog, arrow_table_with_null: pa.Table, format_version: int
 ) -> None:
     identifier = "default.test_table_write_with_valid_nullability_diff"
     table_schema = Schema(
-        NestedField(field_id=1, name="boolean", field_type=BooleanType(), required=False),
-        NestedField(field_id=2, name="integer", field_type=IntegerType(), required=False),
-        NestedField(field_id=3, name="long", field_type=LongType(), required=False),
+        NestedField(field_id=1, name="long", field_type=LongType(), required=False),
     )
     other_schema = pa.schema((
-        pa.field("boolean", pa.bool_(), nullable=True),
-        pa.field("integer", pa.int32(), nullable=True),
         pa.field("long", pa.int64(), nullable=False),  # can support writing required pyarrow field to optional Iceberg field
     ))
     arrow_table = pa.Table.from_pydict(
         {
-            "boolean": [False, True],
-            "integer": [1, 9],
             "long": [1, 9],
         },
         schema=other_schema,
     )
     tbl = _create_table(session_catalog, identifier, {"format-version": format_version}, [arrow_table], schema=table_schema)
-    tbl.overwrite(arrow_table)
+    # table's long field should cast to be optional on read
+    written_arrow_table = tbl.scan().to_arrow()
+    assert written_arrow_table == arrow_table.cast(pa.schema((pa.field("long", pa.int64(), nullable=True),)))
+    lhs = spark.table(f"{identifier}").toPandas()
+    rhs = written_arrow_table.to_pandas()
+
+    for column in written_arrow_table.column_names:
+        for left, right in zip(lhs[column].to_list(), rhs[column].to_list()):
+            assert left == right
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("format_version", [1, 2])
+def test_table_write_schema_with_valid_upcast(
+    spark: SparkSession, session_catalog: Catalog, arrow_table_with_null: pa.Table, format_version: int
+) -> None:
+    identifier = "default.test_table_write_with_valid_upcast"
+    table_schema = Schema(
+        NestedField(field_id=1, name="long", field_type=LongType(), required=False),
+        NestedField(
+            field_id=2,
+            name="list",
+            field_type=ListType(element_id=4, element_type=LongType(), element_required=False),
+            required=True,
+        ),
+        NestedField(
+            field_id=3,
+            name="map",
+            field_type=MapType(
+                key_id=5,
+                key_type=StringType(),
+                value_id=6,
+                value_type=LongType(),
+                value_required=False,
+            ),
+            required=True,
+        ),
+    )
+    other_schema = pa.schema((
+        pa.field("long", pa.int32(), nullable=True),  # can support upcasting integer to long
+        pa.field("list", pa.list_(pa.int32()), nullable=False),  # can support upcasting integer to long
+        pa.field("map", pa.map_(pa.string(), pa.int32()), nullable=False),  # can support upcasting integer to long
+    ))
+    arrow_table = pa.Table.from_pydict(
+        {
+            "long": [1, 9],
+            "list": [[1, 1], [2, 2]],
+            "map": [{"a": 1}, {"b": 2}],
+        },
+        schema=other_schema,
+    )
+    tbl = _create_table(session_catalog, identifier, {"format-version": format_version}, [arrow_table], schema=table_schema)
     # table's long field should cast to long on read
-    assert tbl.scan().to_arrow() == arrow_table.cast(
+    written_arrow_table = tbl.scan().to_arrow()
+    assert written_arrow_table == arrow_table.cast(
         pa.schema((
-            pa.field("boolean", pa.bool_(), nullable=True),
-            pa.field("integer", pa.int32(), nullable=True),
             pa.field("long", pa.int64(), nullable=True),
+            pa.field("list", pa.large_list(pa.int64()), nullable=False),
+            pa.field("map", pa.map_(pa.large_string(), pa.int64()), nullable=False),
         ))
     )
+    lhs = spark.table(f"{identifier}").toPandas()
+    rhs = written_arrow_table.to_pandas()
+
+    for column in written_arrow_table.column_names:
+        for left, right in zip(lhs[column].to_list(), rhs[column].to_list()):
+            print(f"{left=}, {right=}")
+            if column == "map":
+                # Arrow returns a list of tuples, instead of a dict
+                right = dict(right)
+            if column == "list":
+                # Arrow returns an array
+                right = list(right)
+            assert left == right
 
 
 @pytest.mark.integration

--- a/tests/integration/test_writes/test_writes.py
+++ b/tests/integration/test_writes/test_writes.py
@@ -43,7 +43,7 @@ from pyiceberg.partitioning import PartitionField, PartitionSpec
 from pyiceberg.schema import Schema
 from pyiceberg.table import TableProperties
 from pyiceberg.transforms import IdentityTransform
-from pyiceberg.types import IntegerType, NestedField
+from pyiceberg.types import BooleanType, IntegerType, LongType, NestedField
 from utils import _create_table
 
 
@@ -992,6 +992,42 @@ def test_table_write_out_of_order_schema(session_catalog: Catalog, arrow_table_w
     tbl.append(arrow_table_with_null)
     # overwrite and then append should produce twice the data
     assert len(tbl.scan().to_arrow()) == len(arrow_table_with_null) * 2
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("format_version", [1, 2])
+def test_table_write_schema_with_valid_nullability_diff(
+    session_catalog: Catalog, arrow_table_with_null: pa.Table, format_version: int
+) -> None:
+    identifier = "default.test_table_write_with_valid_nullability_diff"
+    table_schema = Schema(
+        NestedField(field_id=1, name="boolean", field_type=BooleanType(), required=False),
+        NestedField(field_id=2, name="integer", field_type=IntegerType(), required=False),
+        NestedField(field_id=3, name="long", field_type=LongType(), required=False),
+    )
+    other_schema = pa.schema((
+        pa.field("boolean", pa.bool_(), nullable=True),
+        pa.field("integer", pa.int32(), nullable=True),
+        pa.field("long", pa.int64(), nullable=False),  # can support writing required pyarrow field to optional Iceberg field
+    ))
+    arrow_table = pa.Table.from_pydict(
+        {
+            "boolean": [False, True],
+            "integer": [1, 9],
+            "long": [1, 9],
+        },
+        schema=other_schema,
+    )
+    tbl = _create_table(session_catalog, identifier, {"format-version": format_version}, [arrow_table], schema=table_schema)
+    tbl.overwrite(arrow_table)
+    # table's long field should cast to long on read
+    assert tbl.scan().to_arrow() == arrow_table.cast(
+        pa.schema((
+            pa.field("boolean", pa.bool_(), nullable=True),
+            pa.field("integer", pa.int32(), nullable=True),
+            pa.field("long", pa.int64(), nullable=True),
+        ))
+    )
 
 
 @pytest.mark.integration

--- a/tests/integration/test_writes/test_writes.py
+++ b/tests/integration/test_writes/test_writes.py
@@ -1079,13 +1079,12 @@ def test_table_write_schema_with_valid_upcast(
 
     for column in written_arrow_table.column_names:
         for left, right in zip(lhs[column].to_list(), rhs[column].to_list()):
-            print(f"{left=}, {right=}")
             if column == "map":
                 # Arrow returns a list of tuples, instead of a dict
                 right = dict(right)
             if column == "list":
-                # Arrow returns an array
-                right = list(right)
+                # Arrow returns an array, convert to list for equality check
+                left, right = list(left), list(right)
             assert left == right
 
 

--- a/tests/integration/test_writes/test_writes.py
+++ b/tests/integration/test_writes/test_writes.py
@@ -970,8 +970,6 @@ def test_table_write_subset_of_schema(session_catalog: Catalog, arrow_table_with
     identifier = "default.test_table_write_subset_of_schema"
     tbl = _create_table(session_catalog, identifier, {"format-version": format_version}, [arrow_table_with_null])
     arrow_table_without_some_columns = arrow_table_with_null.combine_chunks().drop(arrow_table_with_null.column_names[0])
-    print(arrow_table_without_some_columns.schema)
-    print(arrow_table_with_null.schema)
     assert len(arrow_table_without_some_columns.columns) < len(arrow_table_with_null.columns)
     tbl.overwrite(arrow_table_without_some_columns)
     tbl.append(arrow_table_without_some_columns)

--- a/tests/integration/test_writes/test_writes.py
+++ b/tests/integration/test_writes/test_writes.py
@@ -1050,6 +1050,7 @@ def test_table_write_schema_with_valid_upcast(
             pa.field("long", pa.int64(), nullable=True),
             pa.field("list", pa.large_list(pa.int64()), nullable=False),
             pa.field("map", pa.map_(pa.large_string(), pa.int64()), nullable=False),
+            pa.field("double", pa.float64(), nullable=True),  # can support upcasting float to double
         ))
     )
     lhs = spark.table(f"{identifier}").toPandas()

--- a/tests/integration/test_writes/test_writes.py
+++ b/tests/integration/test_writes/test_writes.py
@@ -43,7 +43,7 @@ from pyiceberg.partitioning import PartitionField, PartitionSpec
 from pyiceberg.schema import Schema
 from pyiceberg.table import TableProperties
 from pyiceberg.transforms import IdentityTransform
-from pyiceberg.types import IntegerType, NestedField
+from pyiceberg.types import BooleanType, IntegerType, LongType, NestedField
 from utils import _create_table
 
 
@@ -962,6 +962,42 @@ def test_sanitize_character_partitioned(catalog: Catalog) -> None:
     )
 
     assert len(tbl.scan().to_arrow()) == 22
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("format_version", [1, 2])
+def test_table_write_schema_with_valid_upcast(
+    session_catalog: Catalog, arrow_table_with_null: pa.Table, format_version: int
+) -> None:
+    identifier = "default.test_table_write_with_valid_upcast"
+    table_schema = Schema(
+        NestedField(field_id=1, name="boolean", field_type=BooleanType(), required=True),
+        NestedField(field_id=2, name="integer", field_type=IntegerType(), required=True),
+        NestedField(field_id=3, name="long", field_type=LongType(), required=True),
+    )
+    other_schema = pa.schema((
+        pa.field("boolean", pa.bool_(), nullable=False),
+        pa.field("integer", pa.int32(), nullable=False),
+        pa.field("long", pa.int32(), nullable=False),  # IntegerType can be cast to LongType
+    ))
+    arrow_table = pa.Table.from_pydict(
+        {
+            "bool": [False, True],
+            "integer": [1, 9],
+            "long": [1, 9],
+        },
+        schema=other_schema,
+    )
+    tbl = _create_table(session_catalog, identifier, {"format-version": format_version}, [arrow_table], schema=table_schema)
+    tbl.append(arrow_table)
+    # table's long field should cast to long on read
+    assert tbl.scan().to_arrow() == arrow_table.cast(
+        pa.schema((
+            pa.field("boolean", pa.bool_(), nullable=False),
+            pa.field("integer", pa.int32(), nullable=False),
+            pa.field("long", pa.int64(), nullable=False),  # IntegerType can be cast to LongType
+        ))
+    )
 
 
 @pytest.mark.integration

--- a/tests/io/test_pyarrow.py
+++ b/tests/io/test_pyarrow.py
@@ -1856,6 +1856,24 @@ def test_schema_compatible(table_schema_simple: Schema) -> None:
         pytest.fail("Unexpected Exception raised when calling `_check_schema_compatible`")
 
 
+def test_schema_compatible_upcast() -> None:
+    table_schema = Schema(
+        NestedField(field_id=1, name="boolean", field_type=BooleanType(), required=True),
+        NestedField(field_id=2, name="integer", field_type=IntegerType(), required=True),
+        NestedField(field_id=3, name="long", field_type=LongType(), required=True),
+    )
+    other_schema = pa.schema((
+        pa.field("boolean", pa.bool_(), nullable=False),
+        pa.field("integer", pa.int32(), nullable=False),
+        pa.field("long", pa.int32(), nullable=False),  # IntegerType can be cast to LongType
+    ))
+
+    try:
+        _check_schema_compatible(table_schema, other_schema)
+    except Exception:
+        pytest.fail("Unexpected Exception raised when calling `_check_schema_compatible`")
+
+
 def test_schema_projection(table_schema_simple: Schema) -> None:
     # remove optional `baz` field from `table_schema_simple`
     other_schema = pa.schema((

--- a/tests/io/test_pyarrow.py
+++ b/tests/io/test_pyarrow.py
@@ -1757,7 +1757,7 @@ def test_schema_mismatch_nullability(table_schema_simple: Schema) -> None:
 ┃    ┃ Table field              ┃ Dataframe field          ┃
 ┡━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━┩
 │ ✅ │ 1: foo: optional string  │ 1: foo: optional string  │
-│ ❌ │ 2: bar: required int     │ Missing                  │
+│ ❌ │ 2: bar: required int     │ 2: bar: optional int     │
 │ ✅ │ 3: baz: optional boolean │ 3: baz: optional boolean │
 └────┴──────────────────────────┴──────────────────────────┘
 """
@@ -1836,29 +1836,29 @@ def test_schema_mismatch_missing_required_field_nested(table_schema_nested: Sche
 │ ✅ │ 1: foo: optional string            │ 1: foo: optional string            │
 │ ✅ │ 2: bar: required int               │ 2: bar: required int               │
 │ ✅ │ 3: baz: optional boolean           │ 3: baz: optional boolean           │
-│ ✅ │ 5: element: required string        │ 5: element: required string        │
 │ ✅ │ 4: qux: required list<string>      │ 4: qux: required list<string>      │
-│ ✅ │ 9: key: required string            │ 9: key: required string            │
-│ ✅ │ 10: value: required int            │ 10: value: required int            │
+│ ✅ │ 5: element: required string        │ 5: element: required string        │
+│ ✅ │ 6: quux: required map<string,      │ 6: quux: required map<string,      │
+│    │ map<string, int>>                  │ map<string, int>>                  │
 │ ✅ │ 7: key: required string            │ 7: key: required string            │
 │ ✅ │ 8: value: required map<string,     │ 8: value: required map<string,     │
 │    │ int>                               │ int>                               │
-│ ✅ │ 6: quux: required map<string,      │ 6: quux: required map<string,      │
-│    │ map<string, int>>                  │ map<string, int>>                  │
-│ ✅ │ 13: latitude: optional float       │ 13: latitude: optional float       │
-│ ✅ │ 14: longitude: optional float      │ 14: longitude: optional float      │
-│ ✅ │ 12: element: required struct<13:   │ 12: element: required struct<13:   │
-│    │ latitude: optional float, 14:      │ latitude: optional float, 14:      │
-│    │ longitude: optional float>         │ longitude: optional float>         │
+│ ✅ │ 9: key: required string            │ 9: key: required string            │
+│ ✅ │ 10: value: required int            │ 10: value: required int            │
 │ ✅ │ 11: location: required             │ 11: location: required             │
 │    │ list<struct<13: latitude: optional │ list<struct<13: latitude: optional │
 │    │ float, 14: longitude: optional     │ float, 14: longitude: optional     │
 │    │ float>>                            │ float>>                            │
-│ ✅ │ 16: name: optional string          │ 16: name: optional string          │
-│ ❌ │ 17: age: required int              │ Missing                            │
+│ ✅ │ 12: element: required struct<13:   │ 12: element: required struct<13:   │
+│    │ latitude: optional float, 14:      │ latitude: optional float, 14:      │
+│    │ longitude: optional float>         │ longitude: optional float>         │
+│ ✅ │ 13: latitude: optional float       │ 13: latitude: optional float       │
+│ ✅ │ 14: longitude: optional float      │ 14: longitude: optional float      │
 │ ✅ │ 15: person: optional struct<16:    │ 15: person: optional struct<16:    │
 │    │ name: optional string, 17: age:    │ name: optional string>             │
 │    │ required int>                      │                                    │
+│ ✅ │ 16: name: optional string          │ 16: name: optional string          │
+│ ❌ │ 17: age: required int              │ Missing                            │
 └────┴────────────────────────────────────┴────────────────────────────────────┘
 """
 

--- a/tests/io/test_pyarrow.py
+++ b/tests/io/test_pyarrow.py
@@ -1856,24 +1856,6 @@ def test_schema_compatible(table_schema_simple: Schema) -> None:
         pytest.fail("Unexpected Exception raised when calling `_check_schema_compatible`")
 
 
-def test_schema_compatible_upcast() -> None:
-    table_schema = Schema(
-        NestedField(field_id=1, name="boolean", field_type=BooleanType(), required=True),
-        NestedField(field_id=2, name="integer", field_type=IntegerType(), required=True),
-        NestedField(field_id=3, name="long", field_type=LongType(), required=True),
-    )
-    other_schema = pa.schema((
-        pa.field("boolean", pa.bool_(), nullable=False),
-        pa.field("integer", pa.int32(), nullable=False),
-        pa.field("long", pa.int32(), nullable=False),  # IntegerType can be cast to LongType
-    ))
-
-    try:
-        _check_schema_compatible(table_schema, other_schema)
-    except Exception:
-        pytest.fail("Unexpected Exception raised when calling `_check_schema_compatible`")
-
-
 def test_schema_projection(table_schema_simple: Schema) -> None:
     # remove optional `baz` field from `table_schema_simple`
     other_schema = pa.schema((


### PR DESCRIPTION
Another attempt at fixing #674 

This PR is motivated by work started off by @kevinjqliu in https://github.com/apache/iceberg-python/pull/829

- it enables support for writing dataframes that are a subset of the Iceberg Table's schema
- it enables support for writing dataframes that have fields in any arbitrary order
- we convert the pyarrow schema to Iceberg Schema using the name mapping of the Table, and checks for nullability and type consistency.

Here we introduce terminologies `requested_schema` to refer to the Iceberg Table schema we are checking against, and the `provided_schema` which represents the schema of the Dataframe we are attempting to write.

A field is considered compatible if satisfies the following checks:
- An `optional` field in the `requested_schema` can be `required`, `optional` or missing in the `provided_schema`
- A `required` field in the `requested_schema` must also be a `required` field in the `provided_schema`
- A primitive type in the `requested_schema` must be represented as its own type, or a smaller type that can be `promote`-ed to the said primitive type (e.g. `LongType` in `requested_schema` and `IntegerType` in `provided_schema`)
- MapType, ListType, or StructType must be of the same type, but the validity of its child fields will be checked independently from the validity of the parent field.

EDIT: 
    This PR also includes changes to support type promotion on write.
    For instance, a `pa.int32()` column from the pyarrow construct can be written into an Iceberg Table field of `LongType()`.

