### PR TITLE
Allow empty `names` in mapped field of Name Mapping

### DIFF
--- a/pyiceberg/table/name_mapping.py
+++ b/pyiceberg/table/name_mapping.py
@@ -45,18 +45,6 @@ class MappedField(IcebergBaseModel):
     def convert_null_to_empty_List(cls, v: Any) -> Any:
         return v or []
 
-    @field_validator("names", mode="after")
-    @classmethod
-    def check_at_least_one(cls, v: List[str]) -> Any:
-        """
-        Conlist constraint does not seem to be validating the class on instantiation.
-
-        Adding a custom validator to enforce min_length=1 constraint.
-        """
-        if len(v) < 1:
-            raise ValueError("At least one mapped name must be provided for the field")
-        return v
-
     @model_serializer
     def ser_model(self) -> Dict[str, Any]:
         """Set custom serializer to leave out the field when it is empty."""

--- a/pyiceberg/table/name_mapping.py
+++ b/pyiceberg/table/name_mapping.py
@@ -37,7 +37,7 @@ from pyiceberg.types import ListType, MapType, NestedField, PrimitiveType, Struc
 
 class MappedField(IcebergBaseModel):
     field_id: int = Field(alias="field-id")
-    names: List[str] = conlist(str, min_length=1)
+    names: List[str] = conlist(str)
     fields: List[MappedField] = Field(default_factory=list)
 
     @field_validator("fields", mode="before")

--- a/tests/table/test_name_mapping.py
+++ b/tests/table/test_name_mapping.py
@@ -90,6 +90,22 @@ def test_json_mapped_field_deserialization() -> None:
     """
     assert MappedField(field_id=1, names=["id", "record_id"]) == MappedField.model_validate_json(mapped_field_with_null_fields)
 
+def test_json_mapped_field_no_names_deserialization() -> None:
+    mapped_field = """{
+        "field-id": 1,
+        "names": []
+    }
+    """
+    assert MappedField(field_id=1, names=[]) == MappedField.model_validate_json(mapped_field)
+
+    mapped_field_with_null_fields = """{
+        "field-id": 1,
+        "names": [],
+        "fields": null
+    }
+    """
+    assert MappedField(field_id=1, names=[]) == MappedField.model_validate_json(mapped_field_with_null_fields)
+
 
 def test_json_name_mapping_deserialization() -> None:
     name_mapping = """

--- a/tests/table/test_name_mapping.py
+++ b/tests/table/test_name_mapping.py
@@ -247,11 +247,6 @@ def test_mapping_lookup_by_name(table_name_mapping_nested: NameMapping) -> None:
         table_name_mapping_nested.find("boom")
 
 
-def test_invalid_mapped_field() -> None:
-    with pytest.raises(ValueError):
-        MappedField(field_id=1, names=[])
-
-
 def test_update_mapping_no_updates_or_adds(table_name_mapping_nested: NameMapping) -> None:
     assert update_mapping(table_name_mapping_nested, {}, {}) == table_name_mapping_nested
 

--- a/tests/table/test_name_mapping.py
+++ b/tests/table/test_name_mapping.py
@@ -90,6 +90,7 @@ def test_json_mapped_field_deserialization() -> None:
     """
     assert MappedField(field_id=1, names=["id", "record_id"]) == MappedField.model_validate_json(mapped_field_with_null_fields)
 
+
 def test_json_mapped_field_no_names_deserialization() -> None:
     mapped_field = """{
         "field-id": 1,


### PR DESCRIPTION
Attempt to fix #925. 

As described in the issue, the [Iceberg spec](https://iceberg.apache.org/spec/#column-projection) permits an empty list of names in the default name mapping. `check_at_least_one` is therefore unnecessary.
