### PR TITLE
uses actions/setup-python@v5 with python 3.8

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -43,7 +43,9 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: |
+            3.8
+            3.11
 
       - name: Install poetry
         run: pip install poetry


### PR DESCRIPTION
Attempting to resolve an issue with repairing the wheel on macos.

Source that makes this recommendation for the potential fix: https://github.com/pypa/cibuildwheel/issues/1828

Using multiple python version syntax from: https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md


Download and set up multiple Python versions:

```
jobs:
  build:
    runs-on: ubuntu-latest
    steps:
    - uses: actions/checkout@v4
    - uses: actions/setup-python@v5
      with:
        python-version: |
            3.8
            3.9
            3.10
    - run: python my_script.py
 ```