### PR TITLE
Remove macos-11 runners from Github Actions Python Release

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-22.04, windows-2022, macos-11, macos-12, macos-13, macos-14 ]
+        os: [ ubuntu-22.04, windows-2022, macos-12, macos-13, macos-14 ]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
macos-11 is no longer a supported runner:

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources