### PR TITLE
Update last-updated-ms for DDL operations

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -908,6 +908,9 @@ class _TableMetadataUpdateContext:
             update.sort_order.order_id == sort_order_id for update in self._updates if isinstance(update, AddSortOrderUpdate)
         )
 
+    def has_changes(self) -> bool:
+        return len(self._updates) > 0
+
 
 @singledispatch
 def _apply_table_update(update: TableUpdate, base_metadata: TableMetadata, context: _TableMetadataUpdateContext) -> TableMetadata:
@@ -1178,13 +1181,12 @@ def update_table_metadata(
     """
     context = _TableMetadataUpdateContext()
     new_metadata = base_metadata
-    new_metadata = new_metadata.model_copy(update={"last_updated_ms": 0})
 
     for update in updates:
         new_metadata = _apply_table_update(update, new_metadata, context)
 
     # Update last_updated_ms if it was not updated by update operations
-    if new_metadata.last_updated_ms == 0:
+    if context.has_changes() and base_metadata.last_updated_ms == new_metadata.last_updated_ms:
         new_metadata = new_metadata.model_copy(update={"last_updated_ms": datetime_to_millis(datetime.now().astimezone())})
 
     if enforce_validation:

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -1178,9 +1178,14 @@ def update_table_metadata(
     """
     context = _TableMetadataUpdateContext()
     new_metadata = base_metadata
+    new_metadata = new_metadata.model_copy(update={"last_updated_ms": 0})
 
     for update in updates:
         new_metadata = _apply_table_update(update, new_metadata, context)
+
+    # Update last_updated_ms if it was not updated by update operations
+    if new_metadata.last_updated_ms == 0:
+        new_metadata = new_metadata.model_copy(update={"last_updated_ms": datetime_to_millis(datetime.now().astimezone())})
 
     if enforce_validation:
         return TableMetadataUtil.parse_obj(new_metadata.model_dump())

--- a/tests/catalog/test_glue.py
+++ b/tests/catalog/test_glue.py
@@ -707,6 +707,7 @@ def test_commit_table_update_schema(
     test_catalog.create_namespace(namespace=database_name)
     table = test_catalog.create_table(identifier, table_schema_nested)
     original_table_metadata = table.metadata
+    last_update_ms = original_table_metadata.last_updated_ms
 
     assert TABLE_METADATA_LOCATION_REGEX.match(table.metadata_location)
     assert test_catalog._parse_metadata_version(table.metadata_location) == 0
@@ -728,6 +729,7 @@ def test_commit_table_update_schema(
     assert new_schema
     assert new_schema == update._apply()
     assert new_schema.find_field("b").field_type == IntegerType()
+    assert updated_table_metadata.last_updated_ms > last_update_ms
 
     # Ensure schema is also pushed to Glue
     table_info = _glue.get_table(
@@ -759,6 +761,7 @@ def test_commit_table_properties(
     test_catalog = GlueCatalog(catalog_name, **{"s3.endpoint": moto_endpoint_url, "warehouse": f"s3://{BUCKET_NAME}"})
     test_catalog.create_namespace(namespace=database_name)
     table = test_catalog.create_table(identifier=identifier, schema=table_schema_nested, properties={"test_a": "test_a"})
+    last_updated_ms = table.metadata.last_updated_ms
 
     assert test_catalog._parse_metadata_version(table.metadata_location) == 0
 
@@ -770,6 +773,7 @@ def test_commit_table_properties(
     updated_table_metadata = table.metadata
     assert test_catalog._parse_metadata_version(table.metadata_location) == 1
     assert updated_table_metadata.properties == {"Description": "test_description", "test_a": "test_aa", "test_c": "test_c"}
+    assert updated_table_metadata.last_updated_ms > last_updated_ms
 
     table_info = _glue.get_table(
         DatabaseName=database_name,
@@ -865,6 +869,7 @@ def test_create_table_transaction(
         partition_spec=PartitionSpec(PartitionField(source_id=1, field_id=1000, transform=IdentityTransform(), name="foo")),
         properties={"format-version": format_version},
     ) as txn:
+        last_updated_metadata = txn.table_metadata.last_updated_ms
         with txn.update_schema() as update_schema:
             update_schema.add_column(path="b", field_type=IntegerType())
 
@@ -887,6 +892,7 @@ def test_create_table_transaction(
     assert table.spec().fields_by_source_id(2)[0].name == "bar"
     assert table.spec().fields_by_source_id(2)[0].field_id == 1001
     assert table.spec().fields_by_source_id(2)[0].transform == IdentityTransform()
+    assert table.metadata.last_updated_ms > last_updated_metadata
 
 
 @mock_aws

--- a/tests/catalog/test_glue.py
+++ b/tests/catalog/test_glue.py
@@ -707,7 +707,6 @@ def test_commit_table_update_schema(
     test_catalog.create_namespace(namespace=database_name)
     table = test_catalog.create_table(identifier, table_schema_nested)
     original_table_metadata = table.metadata
-    last_update_ms = original_table_metadata.last_updated_ms
 
     assert TABLE_METADATA_LOCATION_REGEX.match(table.metadata_location)
     assert test_catalog._parse_metadata_version(table.metadata_location) == 0
@@ -729,7 +728,6 @@ def test_commit_table_update_schema(
     assert new_schema
     assert new_schema == update._apply()
     assert new_schema.find_field("b").field_type == IntegerType()
-    assert updated_table_metadata.last_updated_ms > last_update_ms
 
     # Ensure schema is also pushed to Glue
     table_info = _glue.get_table(
@@ -761,7 +759,6 @@ def test_commit_table_properties(
     test_catalog = GlueCatalog(catalog_name, **{"s3.endpoint": moto_endpoint_url, "warehouse": f"s3://{BUCKET_NAME}"})
     test_catalog.create_namespace(namespace=database_name)
     table = test_catalog.create_table(identifier=identifier, schema=table_schema_nested, properties={"test_a": "test_a"})
-    last_updated_ms = table.metadata.last_updated_ms
 
     assert test_catalog._parse_metadata_version(table.metadata_location) == 0
 
@@ -773,7 +770,6 @@ def test_commit_table_properties(
     updated_table_metadata = table.metadata
     assert test_catalog._parse_metadata_version(table.metadata_location) == 1
     assert updated_table_metadata.properties == {"Description": "test_description", "test_a": "test_aa", "test_c": "test_c"}
-    assert updated_table_metadata.last_updated_ms > last_updated_ms
 
     table_info = _glue.get_table(
         DatabaseName=database_name,

--- a/tests/catalog/test_sql.py
+++ b/tests/catalog/test_sql.py
@@ -1255,6 +1255,7 @@ def test_commit_table(catalog: SqlCatalog, table_schema_nested: Schema, table_id
     namespace = Catalog.namespace_from(table_identifier_nocatalog)
     catalog.create_namespace(namespace)
     table = catalog.create_table(table_identifier, table_schema_nested)
+    last_updated_ms = table.metadata.last_updated_ms
 
     assert catalog._parse_metadata_version(table.metadata_location) == 0
     assert table.metadata.current_schema_id == 0
@@ -1274,6 +1275,7 @@ def test_commit_table(catalog: SqlCatalog, table_schema_nested: Schema, table_id
     assert new_schema
     assert new_schema == update._apply()
     assert new_schema.find_field("b").field_type == IntegerType()
+    assert updated_table_metadata.last_updated_ms > last_updated_ms
 
 
 @pytest.mark.parametrize(

--- a/tests/table/test_init.py
+++ b/tests/table/test_init.py
@@ -598,7 +598,7 @@ def test_apply_set_properties_update(table_v2: Table) -> None:
     base_metadata = table_v2.metadata
 
     new_metadata_no_update = update_table_metadata(base_metadata, (SetPropertiesUpdate(updates={}),))
-    assert new_metadata_no_update.properties == base_metadata.properties
+    assert new_metadata_no_update == base_metadata
 
     new_metadata = update_table_metadata(
         base_metadata, (SetPropertiesUpdate(updates={"read.split.target.size": "123", "test_a": "test_a", "test_b": "test_b"}),)

--- a/tests/table/test_init.py
+++ b/tests/table/test_init.py
@@ -615,6 +615,7 @@ def test_apply_set_properties_update(table_v2: Table) -> None:
         "test_b": "test_b",
         "test_c": "test_c",
     }
+    assert new_metadata_add_only.last_updated_ms > base_metadata.last_updated_ms
 
 
 def test_apply_remove_properties_update(table_v2: Table) -> None:
@@ -759,6 +760,7 @@ def test_update_metadata_add_update_sort_order(table_v2: Table) -> None:
     assert len(new_metadata.sort_orders) == 2
     assert new_metadata.sort_orders[-1] == new_sort_order
     assert new_metadata.default_sort_order_id == new_sort_order.order_id
+    assert new_metadata.last_updated_ms > table_v2.metadata.last_updated_ms
 
 
 def test_update_metadata_update_sort_order_invalid(table_v2: Table) -> None:

--- a/tests/table/test_init.py
+++ b/tests/table/test_init.py
@@ -598,7 +598,7 @@ def test_apply_set_properties_update(table_v2: Table) -> None:
     base_metadata = table_v2.metadata
 
     new_metadata_no_update = update_table_metadata(base_metadata, (SetPropertiesUpdate(updates={}),))
-    assert new_metadata_no_update == base_metadata
+    assert new_metadata_no_update.properties == base_metadata.properties
 
     new_metadata = update_table_metadata(
         base_metadata, (SetPropertiesUpdate(updates={"read.split.target.size": "123", "test_a": "test_a", "test_b": "test_b"}),)
@@ -689,7 +689,7 @@ def test_update_metadata_add_snapshot(table_v2: Table) -> None:
         snapshot_id=25,
         parent_snapshot_id=19,
         sequence_number=200,
-        timestamp_ms=1602638573590,
+        timestamp_ms=1602638593590,
         manifest_list="s3:/a/b/c.avro",
         summary=Summary(Operation.APPEND),
         schema_id=3,


### PR DESCRIPTION
Fixes: https://github.com/apache/iceberg-python/issues/948

Updates `last-updated-ms` for DDL operations like updating schema, properties, partition spec etc.
In `update_table_metadata` if `last_updated_ms` is not updated after invoking `_apply_table_update`, then set it current timestamp in milliseconds.

**Note**:
This [line](https://github.com/apache/iceberg-python/blob/main/tests/table/test_init.py#L600) seems like a no-op, but with this change a new metadata file will be generated.
@HonahX @kevinjqliu Please suggest if there is better way to handle this.