### PR TITLE
Remove support for catalog_name in table identifier string

### DIFF
--- a/pyiceberg/catalog/__init__.py
+++ b/pyiceberg/catalog/__init__.py
@@ -70,8 +70,7 @@ from pyiceberg.typedef import (
     RecursiveDict,
 )
 from pyiceberg.utils.config import Config, merge_config
-from pyiceberg.utils.deprecated import deprecated as deprecated
-from pyiceberg.utils.deprecated import deprecation_message
+from pyiceberg.utils.deprecated import deprecated, deprecation_message
 
 if TYPE_CHECKING:
     import pyarrow as pa

--- a/pyiceberg/catalog/__init__.py
+++ b/pyiceberg/catalog/__init__.py
@@ -70,7 +70,8 @@ from pyiceberg.typedef import (
     RecursiveDict,
 )
 from pyiceberg.utils.config import Config, merge_config
-from pyiceberg.utils.deprecated import deprecated, deprecation_message
+from pyiceberg.utils.deprecated import deprecated as deprecated
+from pyiceberg.utils.deprecated import deprecation_message
 
 if TYPE_CHECKING:
     import pyarrow as pa

--- a/pyiceberg/catalog/__init__.py
+++ b/pyiceberg/catalog/__init__.py
@@ -630,44 +630,6 @@ class Catalog(ABC):
             NoSuchViewError: If a view with the given name does not exist.
         """
 
-    @deprecated(
-        deprecated_in="0.8.0",
-        removed_in="0.9.0",
-        help_message="Support for parsing catalog level identifier in Catalog identifiers is deprecated. Please refer to the table using only its namespace and its table name.",
-    )
-    def identifier_to_tuple_without_catalog(self, identifier: Union[str, Identifier]) -> Identifier:
-        """Convert an identifier to a tuple and drop this catalog's name from the first element.
-
-        Args:
-            identifier (str | Identifier): Table identifier.
-
-        Returns:
-            Identifier: a tuple of strings with this catalog's name removed
-        """
-        identifier_tuple = Catalog.identifier_to_tuple(identifier)
-        if len(identifier_tuple) >= 3 and identifier_tuple[0] == self.name:
-            identifier_tuple = identifier_tuple[1:]
-        return identifier_tuple
-
-    def _identifier_to_tuple_without_catalog(self, identifier: Union[str, Identifier]) -> Identifier:
-        """Convert an identifier to a tuple and drop this catalog's name from the first element.
-
-        Args:
-            identifier (str | Identifier): Table identifier.
-
-        Returns:
-            Identifier: a tuple of strings with this catalog's name removed
-        """
-        identifier_tuple = Catalog.identifier_to_tuple(identifier)
-        if len(identifier_tuple) >= 3 and identifier_tuple[0] == self.name:
-            deprecation_message(
-                deprecated_in="0.8.0",
-                removed_in="0.9.0",
-                help_message="Support for parsing catalog level identifier in Catalog identifiers is deprecated. Please refer to the table using only its namespace and its table name.",
-            )
-            identifier_tuple = identifier_tuple[1:]
-        return identifier_tuple
-
     @staticmethod
     def identifier_to_tuple(identifier: Union[str, Identifier]) -> Identifier:
         """Parse an identifier to a tuple.
@@ -809,9 +771,8 @@ class MetastoreCatalog(Catalog, ABC):
             return False
 
     def purge_table(self, identifier: Union[str, Identifier]) -> None:
-        identifier_tuple = self._identifier_to_tuple_without_catalog(identifier)
-        table = self.load_table(identifier_tuple)
-        self.drop_table(identifier_tuple)
+        table = self.load_table(identifier)
+        self.drop_table(identifier)
         io = load_file_io(self.properties, table.metadata_location)
         metadata = table.metadata
         manifest_lists_to_delete = set()

--- a/pyiceberg/catalog/dynamodb.py
+++ b/pyiceberg/catalog/dynamodb.py
@@ -244,8 +244,7 @@ class DynamoDbCatalog(MetastoreCatalog):
         Raises:
             NoSuchTableError: If a table with the name does not exist, or the identifier is invalid.
         """
-        identifier_tuple = self._identifier_to_tuple_without_catalog(identifier)
-        database_name, table_name = self.identifier_to_database_and_table(identifier_tuple, NoSuchTableError)
+        database_name, table_name = self.identifier_to_database_and_table(identifier, NoSuchTableError)
         dynamo_table_item = self._get_iceberg_table_item(database_name=database_name, table_name=table_name)
         return self._convert_dynamo_table_item_to_iceberg_table(dynamo_table_item=dynamo_table_item)
 
@@ -258,8 +257,7 @@ class DynamoDbCatalog(MetastoreCatalog):
         Raises:
             NoSuchTableError: If a table with the name does not exist, or the identifier is invalid.
         """
-        identifier_tuple = self._identifier_to_tuple_without_catalog(identifier)
-        database_name, table_name = self.identifier_to_database_and_table(identifier_tuple, NoSuchTableError)
+        database_name, table_name = self.identifier_to_database_and_table(identifier, NoSuchTableError)
 
         try:
             self._delete_dynamo_item(
@@ -289,8 +287,7 @@ class DynamoDbCatalog(MetastoreCatalog):
             NoSuchPropertyException: When from table miss some required properties.
             NoSuchNamespaceError: When the destination namespace doesn't exist.
         """
-        from_identifier_tuple = self._identifier_to_tuple_without_catalog(from_identifier)
-        from_database_name, from_table_name = self.identifier_to_database_and_table(from_identifier_tuple, NoSuchTableError)
+        from_database_name, from_table_name = self.identifier_to_database_and_table(from_identifier, NoSuchTableError)
         to_database_name, to_table_name = self.identifier_to_database_and_table(to_identifier)
 
         from_table_item = self._get_iceberg_table_item(database_name=from_database_name, table_name=from_table_name)
@@ -321,7 +318,7 @@ class DynamoDbCatalog(MetastoreCatalog):
             raise TableAlreadyExistsError(f"Table {to_database_name}.{to_table_name} already exists") from e
 
         try:
-            self.drop_table(from_identifier_tuple)
+            self.drop_table(from_identifier)
         except (NoSuchTableError, GenericDynamoDbError) as e:
             log_message = f"Failed to drop old table {from_database_name}.{from_table_name}. "
 

--- a/pyiceberg/catalog/glue.py
+++ b/pyiceberg/catalog/glue.py
@@ -556,8 +556,7 @@ class GlueCatalog(MetastoreCatalog):
         Raises:
             NoSuchTableError: If a table with the name does not exist, or the identifier is invalid.
         """
-        identifier_tuple = self._identifier_to_tuple_without_catalog(identifier)
-        database_name, table_name = self.identifier_to_database_and_table(identifier_tuple, NoSuchTableError)
+        database_name, table_name = self.identifier_to_database_and_table(identifier, NoSuchTableError)
 
         return self._convert_glue_to_iceberg(self._get_glue_table(database_name=database_name, table_name=table_name))
 
@@ -570,8 +569,7 @@ class GlueCatalog(MetastoreCatalog):
         Raises:
             NoSuchTableError: If a table with the name does not exist, or the identifier is invalid.
         """
-        identifier_tuple = self._identifier_to_tuple_without_catalog(identifier)
-        database_name, table_name = self.identifier_to_database_and_table(identifier_tuple, NoSuchTableError)
+        database_name, table_name = self.identifier_to_database_and_table(identifier, NoSuchTableError)
         try:
             self.glue.delete_table(DatabaseName=database_name, Name=table_name)
         except self.glue.exceptions.EntityNotFoundException as e:
@@ -596,8 +594,7 @@ class GlueCatalog(MetastoreCatalog):
             NoSuchPropertyException: When from table miss some required properties.
             NoSuchNamespaceError: When the destination namespace doesn't exist.
         """
-        from_identifier_tuple = self._identifier_to_tuple_without_catalog(from_identifier)
-        from_database_name, from_table_name = self.identifier_to_database_and_table(from_identifier_tuple, NoSuchTableError)
+        from_database_name, from_table_name = self.identifier_to_database_and_table(from_identifier, NoSuchTableError)
         to_database_name, to_table_name = self.identifier_to_database_and_table(to_identifier)
         try:
             get_table_response = self.glue.get_table(DatabaseName=from_database_name, Name=from_table_name)

--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -531,8 +531,7 @@ class HiveCatalog(MetastoreCatalog):
         Raises:
             NoSuchTableError: If a table with the name does not exist, or the identifier is invalid.
         """
-        identifier_tuple = self._identifier_to_tuple_without_catalog(identifier)
-        database_name, table_name = self.identifier_to_database_and_table(identifier_tuple, NoSuchTableError)
+        database_name, table_name = self.identifier_to_database_and_table(identifier, NoSuchTableError)
 
         with self._client as open_client:
             hive_table = self._get_hive_table(open_client, database_name, table_name)
@@ -548,8 +547,7 @@ class HiveCatalog(MetastoreCatalog):
         Raises:
             NoSuchTableError: If a table with the name does not exist, or the identifier is invalid.
         """
-        identifier_tuple = self._identifier_to_tuple_without_catalog(identifier)
-        database_name, table_name = self.identifier_to_database_and_table(identifier_tuple, NoSuchTableError)
+        database_name, table_name = self.identifier_to_database_and_table(identifier, NoSuchTableError)
         try:
             with self._client as open_client:
                 open_client.drop_table(dbname=database_name, name=table_name, deleteData=False)
@@ -576,8 +574,7 @@ class HiveCatalog(MetastoreCatalog):
             NoSuchTableError: When a table with the name does not exist.
             NoSuchNamespaceError: When the destination namespace doesn't exist.
         """
-        from_identifier_tuple = self._identifier_to_tuple_without_catalog(from_identifier)
-        from_database_name, from_table_name = self.identifier_to_database_and_table(from_identifier_tuple, NoSuchTableError)
+        from_database_name, from_table_name = self.identifier_to_database_and_table(from_identifier, NoSuchTableError)
         to_database_name, to_table_name = self.identifier_to_database_and_table(to_identifier)
         try:
             with self._client as open_client:

--- a/pyiceberg/catalog/sql.py
+++ b/pyiceberg/catalog/sql.py
@@ -200,9 +200,8 @@ class SqlCatalog(MetastoreCatalog):
         """
         schema: Schema = self._convert_schema_if_needed(schema)  # type: ignore
 
-        identifier_nocatalog = self._identifier_to_tuple_without_catalog(identifier)
-        namespace_identifier = Catalog.namespace_from(identifier_nocatalog)
-        table_name = Catalog.table_name_from(identifier_nocatalog)
+        namespace_identifier = Catalog.namespace_from(identifier)
+        table_name = Catalog.table_name_from(identifier)
         if not self._namespace_exists(namespace_identifier):
             raise NoSuchNamespaceError(f"Namespace does not exist: {namespace_identifier}")
 
@@ -246,10 +245,9 @@ class SqlCatalog(MetastoreCatalog):
             TableAlreadyExistsError: If the table already exists
             NoSuchNamespaceError: If namespace does not exist
         """
-        identifier_tuple = self._identifier_to_tuple_without_catalog(identifier)
-        namespace_tuple = Catalog.namespace_from(identifier_tuple)
+        namespace_tuple = Catalog.namespace_from(identifier)
         namespace = Catalog.namespace_to_string(namespace_tuple)
-        table_name = Catalog.table_name_from(identifier_tuple)
+        table_name = Catalog.table_name_from(identifier)
         if not self._namespace_exists(namespace):
             raise NoSuchNamespaceError(f"Namespace does not exist: {namespace}")
 
@@ -285,10 +283,9 @@ class SqlCatalog(MetastoreCatalog):
         Raises:
             NoSuchTableError: If a table with the name does not exist.
         """
-        identifier_tuple = self._identifier_to_tuple_without_catalog(identifier)
-        namespace_tuple = Catalog.namespace_from(identifier_tuple)
+        namespace_tuple = Catalog.namespace_from(identifier)
         namespace = Catalog.namespace_to_string(namespace_tuple)
-        table_name = Catalog.table_name_from(identifier_tuple)
+        table_name = Catalog.table_name_from(identifier)
         with Session(self.engine) as session:
             stmt = select(IcebergTables).where(
                 IcebergTables.catalog_name == self.name,
@@ -309,10 +306,9 @@ class SqlCatalog(MetastoreCatalog):
         Raises:
             NoSuchTableError: If a table with the name does not exist.
         """
-        identifier_tuple = self._identifier_to_tuple_without_catalog(identifier)
-        namespace_tuple = Catalog.namespace_from(identifier_tuple)
+        namespace_tuple = Catalog.namespace_from(identifier)
         namespace = Catalog.namespace_to_string(namespace_tuple)
-        table_name = Catalog.table_name_from(identifier_tuple)
+        table_name = Catalog.table_name_from(identifier)
         with Session(self.engine) as session:
             if self.engine.dialect.supports_sane_rowcount:
                 res = session.execute(
@@ -356,14 +352,12 @@ class SqlCatalog(MetastoreCatalog):
             TableAlreadyExistsError: If a table with the new name already exist.
             NoSuchNamespaceError: If the target namespace does not exist.
         """
-        from_identifier_tuple = self._identifier_to_tuple_without_catalog(from_identifier)
-        to_identifier_tuple = self._identifier_to_tuple_without_catalog(to_identifier)
-        from_namespace_tuple = Catalog.namespace_from(from_identifier_tuple)
+        from_namespace_tuple = Catalog.namespace_from(from_identifier)
         from_namespace = Catalog.namespace_to_string(from_namespace_tuple)
-        from_table_name = Catalog.table_name_from(from_identifier_tuple)
-        to_namespace_tuple = Catalog.namespace_from(to_identifier_tuple)
+        from_table_name = Catalog.table_name_from(from_identifier)
+        to_namespace_tuple = Catalog.namespace_from(to_identifier)
         to_namespace = Catalog.namespace_to_string(to_namespace_tuple)
-        to_table_name = Catalog.table_name_from(to_identifier_tuple)
+        to_table_name = Catalog.table_name_from(to_identifier)
         if not self._namespace_exists(to_namespace):
             raise NoSuchNamespaceError(f"Namespace does not exist: {to_namespace}")
         with Session(self.engine) as session:

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -132,7 +132,8 @@ from pyiceberg.types import (
 )
 from pyiceberg.utils.concurrent import ExecutorFactory
 from pyiceberg.utils.config import Config
-from pyiceberg.utils.deprecated import deprecated, deprecation_message
+from pyiceberg.utils.deprecated import deprecated
+from pyiceberg.utils.deprecated import deprecation_message as deprecation_message
 from pyiceberg.utils.properties import property_as_bool
 
 if TYPE_CHECKING:

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -787,20 +787,6 @@ class Table:
         self.metadata_location = fresh.metadata_location
         return self
 
-    @property
-    def identifier(self) -> Identifier:
-        """Return the identifier of this table.
-
-        Returns:
-            An Identifier tuple of the table name
-        """
-        deprecation_message(
-            deprecated_in="0.8.0",
-            removed_in="0.9.0",
-            help_message="Table.identifier property is deprecated. Please use Table.name() function instead.",
-        )
-        return (self.catalog.name,) + self._identifier
-
     def name(self) -> Identifier:
         """Return the identifier of this table.
 

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -132,8 +132,7 @@ from pyiceberg.types import (
 )
 from pyiceberg.utils.concurrent import ExecutorFactory
 from pyiceberg.utils.config import Config
-from pyiceberg.utils.deprecated import deprecated
-from pyiceberg.utils.deprecated import deprecation_message as deprecation_message
+from pyiceberg.utils.deprecated import deprecated, deprecation_message
 from pyiceberg.utils.properties import property_as_bool
 
 if TYPE_CHECKING:

--- a/tests/catalog/test_base.py
+++ b/tests/catalog/test_base.py
@@ -156,15 +156,15 @@ class InMemoryCatalog(MetastoreCatalog):
         return CommitTableResponse(metadata=updated_metadata, metadata_location=new_metadata_location)
 
     def load_table(self, identifier: Union[str, Identifier]) -> Table:
-        identifier_tuple = self._identifier_to_tuple_without_catalog(identifier)
         try:
+            identifier_tuple = Catalog.identifier_to_tuple(identifier)
             return self.__tables[identifier_tuple]
         except KeyError as error:
             raise NoSuchTableError(f"Table does not exist: {identifier_tuple}") from error
 
     def drop_table(self, identifier: Union[str, Identifier]) -> None:
-        identifier_tuple = self._identifier_to_tuple_without_catalog(identifier)
         try:
+            identifier_tuple = Catalog.identifier_to_tuple(identifier)
             self.__tables.pop(identifier_tuple)
         except KeyError as error:
             raise NoSuchTableError(f"Table does not exist: {identifier_tuple}") from error
@@ -173,8 +173,8 @@ class InMemoryCatalog(MetastoreCatalog):
         self.drop_table(identifier)
 
     def rename_table(self, from_identifier: Union[str, Identifier], to_identifier: Union[str, Identifier]) -> Table:
-        identifier_tuple = self._identifier_to_tuple_without_catalog(from_identifier)
         try:
+            identifier_tuple = Catalog.identifier_to_tuple(from_identifier)
             table = self.__tables.pop(identifier_tuple)
         except KeyError as error:
             raise NoSuchTableError(f"Table does not exist: {identifier_tuple}") from error

--- a/tests/catalog/test_sql.py
+++ b/tests/catalog/test_sql.py
@@ -75,30 +75,12 @@ def fixture_random_table_identifier(warehouse: Path, database_name: str, table_n
     return database_name, table_name
 
 
-@pytest.fixture(name="random_table_identifier_with_catalog")
-def fixture_random_table_identifier_with_catalog(
-    warehouse: Path, catalog_name: str, database_name: str, table_name: str
-) -> Identifier:
-    os.makedirs(f"{warehouse}/{database_name}.db/{table_name}/metadata/", exist_ok=True)
-    return catalog_name, database_name, table_name
-
-
 @pytest.fixture(name="another_random_table_identifier")
 def fixture_another_random_table_identifier(warehouse: Path, database_name: str, table_name: str) -> Identifier:
     database_name = database_name + "_new"
     table_name = table_name + "_new"
     os.makedirs(f"{warehouse}/{database_name}.db/{table_name}/metadata/", exist_ok=True)
     return database_name, table_name
-
-
-@pytest.fixture(name="another_random_table_identifier_with_catalog")
-def fixture_another_random_table_identifier_with_catalog(
-    warehouse: Path, catalog_name: str, database_name: str, table_name: str
-) -> Identifier:
-    database_name = database_name + "_new"
-    table_name = table_name + "_new"
-    os.makedirs(f"{warehouse}/{database_name}.db/{table_name}/metadata/", exist_ok=True)
-    return catalog_name, database_name, table_name
 
 
 @pytest.fixture(name="random_hierarchical_identifier")
@@ -332,12 +314,10 @@ def test_create_tables_idempotency(catalog: SqlCatalog) -> None:
     [
         lazy_fixture("random_table_identifier"),
         lazy_fixture("random_hierarchical_identifier"),
-        lazy_fixture("random_table_identifier_with_catalog"),
     ],
 )
 def test_create_table_default_sort_order(catalog: SqlCatalog, table_schema_nested: Schema, table_identifier: Identifier) -> None:
-    table_identifier_nocatalog = catalog._identifier_to_tuple_without_catalog(table_identifier)
-    namespace = Catalog.namespace_from(table_identifier_nocatalog)
+    namespace = Catalog.namespace_from(table_identifier)
     catalog.create_namespace(namespace)
     table = catalog.create_table(table_identifier, table_schema_nested)
     assert table.sort_order().order_id == 0, "Order ID must match"
@@ -357,12 +337,10 @@ def test_create_table_default_sort_order(catalog: SqlCatalog, table_schema_neste
     [
         lazy_fixture("random_table_identifier"),
         lazy_fixture("random_hierarchical_identifier"),
-        lazy_fixture("random_table_identifier_with_catalog"),
     ],
 )
 def test_create_v1_table(catalog: SqlCatalog, table_schema_nested: Schema, table_identifier: Identifier) -> None:
-    table_identifier_nocatalog = catalog._identifier_to_tuple_without_catalog(table_identifier)
-    namespace = Catalog.namespace_from(table_identifier_nocatalog)
+    namespace = Catalog.namespace_from(table_identifier)
     catalog.create_namespace(namespace)
     table = catalog.create_table(table_identifier, table_schema_nested, properties={"format-version": "1"})
     assert table.sort_order().order_id == 0, "Order ID must match"
@@ -384,7 +362,6 @@ def test_create_v1_table(catalog: SqlCatalog, table_schema_nested: Schema, table
     [
         lazy_fixture("random_table_identifier"),
         lazy_fixture("random_hierarchical_identifier"),
-        lazy_fixture("random_table_identifier_with_catalog"),
     ],
 )
 def test_create_table_with_pyarrow_schema(
@@ -393,8 +370,7 @@ def test_create_table_with_pyarrow_schema(
     iceberg_table_schema_simple: Schema,
     table_identifier: Identifier,
 ) -> None:
-    table_identifier_nocatalog = catalog._identifier_to_tuple_without_catalog(table_identifier)
-    namespace = Catalog.namespace_from(table_identifier_nocatalog)
+    namespace = Catalog.namespace_from(table_identifier)
     catalog.create_namespace(namespace)
     table = catalog.create_table(table_identifier, pyarrow_schema_simple_without_ids)
     assert table.schema() == iceberg_table_schema_simple
@@ -413,7 +389,6 @@ def test_create_table_with_pyarrow_schema(
     [
         lazy_fixture("random_table_identifier"),
         lazy_fixture("random_hierarchical_identifier"),
-        lazy_fixture("random_table_identifier_with_catalog"),
     ],
 )
 def test_write_pyarrow_schema(catalog: SqlCatalog, table_identifier: Identifier) -> None:
@@ -433,8 +408,7 @@ def test_write_pyarrow_schema(catalog: SqlCatalog, table_identifier: Identifier)
             pa.field("large", pa.large_string(), nullable=True),
         ]),
     )
-    table_identifier_nocatalog = catalog._identifier_to_tuple_without_catalog(table_identifier)
-    namespace = Catalog.namespace_from(table_identifier_nocatalog)
+    namespace = Catalog.namespace_from(table_identifier)
     catalog.create_namespace(namespace)
     table = catalog.create_table(table_identifier, pyarrow_table.schema)
     table.append(pyarrow_table)
@@ -452,12 +426,10 @@ def test_write_pyarrow_schema(catalog: SqlCatalog, table_identifier: Identifier)
     [
         lazy_fixture("random_table_identifier"),
         lazy_fixture("random_hierarchical_identifier"),
-        lazy_fixture("random_table_identifier_with_catalog"),
     ],
 )
 def test_create_table_custom_sort_order(catalog: SqlCatalog, table_schema_nested: Schema, table_identifier: Identifier) -> None:
-    table_identifier_nocatalog = catalog._identifier_to_tuple_without_catalog(table_identifier)
-    namespace = Catalog.namespace_from(table_identifier_nocatalog)
+    namespace = Catalog.namespace_from(table_identifier)
     catalog.create_namespace(namespace)
     order = SortOrder(SortField(source_id=2, transform=IdentityTransform(), null_order=NullOrder.NULLS_FIRST))
     table = catalog.create_table(table_identifier, table_schema_nested, sort_order=order)
@@ -482,18 +454,17 @@ def test_create_table_custom_sort_order(catalog: SqlCatalog, table_schema_nested
     [
         lazy_fixture("random_table_identifier"),
         lazy_fixture("random_hierarchical_identifier"),
-        lazy_fixture("random_table_identifier_with_catalog"),
     ],
 )
 def test_create_table_with_default_warehouse_location(
     warehouse: Path, catalog: SqlCatalog, table_schema_nested: Schema, table_identifier: Identifier
 ) -> None:
-    table_identifier_nocatalog = catalog._identifier_to_tuple_without_catalog(table_identifier)
-    namespace = Catalog.namespace_from(table_identifier_nocatalog)
+    identifier_tuple = Catalog.identifier_to_tuple(table_identifier)
+    namespace = Catalog.namespace_from(table_identifier)
     catalog.create_namespace(namespace)
     catalog.create_table(table_identifier, table_schema_nested)
     table = catalog.load_table(table_identifier)
-    assert table.name() == table_identifier_nocatalog
+    assert table.name() == identifier_tuple
     assert table.metadata_location.startswith(f"file://{warehouse}")
     assert os.path.exists(table.metadata_location[len("file://") :])
     catalog.drop_table(table_identifier)
@@ -511,20 +482,19 @@ def test_create_table_with_default_warehouse_location(
     [
         lazy_fixture("random_table_identifier"),
         lazy_fixture("random_hierarchical_identifier"),
-        lazy_fixture("random_table_identifier_with_catalog"),
     ],
 )
 def test_create_table_with_given_location_removes_trailing_slash(
     warehouse: Path, catalog: SqlCatalog, table_schema_nested: Schema, table_identifier: Identifier
 ) -> None:
-    table_identifier_nocatalog = catalog._identifier_to_tuple_without_catalog(table_identifier)
-    namespace = Catalog.namespace_from(table_identifier_nocatalog)
-    table_name = Catalog.table_name_from(table_identifier_nocatalog)
+    identifier_tuple = Catalog.identifier_to_tuple(table_identifier)
+    namespace = Catalog.namespace_from(table_identifier)
+    table_name = Catalog.table_name_from(identifier_tuple)
     location = f"file://{warehouse}/{catalog.name}.db/{table_name}-given"
     catalog.create_namespace(namespace)
     catalog.create_table(table_identifier, table_schema_nested, location=f"{location}/")
     table = catalog.load_table(table_identifier)
-    assert table.name() == table_identifier_nocatalog
+    assert table.name() == identifier_tuple
     assert table.metadata_location.startswith(f"file://{warehouse}")
     assert os.path.exists(table.metadata_location[len("file://") :])
     assert table.location() == location
@@ -543,12 +513,10 @@ def test_create_table_with_given_location_removes_trailing_slash(
     [
         lazy_fixture("random_table_identifier"),
         lazy_fixture("random_hierarchical_identifier"),
-        lazy_fixture("random_table_identifier_with_catalog"),
     ],
 )
 def test_create_duplicated_table(catalog: SqlCatalog, table_schema_nested: Schema, table_identifier: Identifier) -> None:
-    table_identifier_nocatalog = catalog._identifier_to_tuple_without_catalog(table_identifier)
-    namespace = Catalog.namespace_from(table_identifier_nocatalog)
+    namespace = Catalog.namespace_from(table_identifier)
     catalog.create_namespace(namespace)
     catalog.create_table(table_identifier, table_schema_nested)
     with pytest.raises(TableAlreadyExistsError):
@@ -567,14 +535,12 @@ def test_create_duplicated_table(catalog: SqlCatalog, table_schema_nested: Schem
     [
         lazy_fixture("random_table_identifier"),
         lazy_fixture("random_hierarchical_identifier"),
-        lazy_fixture("random_table_identifier_with_catalog"),
     ],
 )
 def test_create_table_if_not_exists_duplicated_table(
     catalog: SqlCatalog, table_schema_nested: Schema, table_identifier: Identifier
 ) -> None:
-    table_identifier_nocatalog = catalog._identifier_to_tuple_without_catalog(table_identifier)
-    namespace = Catalog.namespace_from(table_identifier_nocatalog)
+    namespace = Catalog.namespace_from(table_identifier)
     catalog.create_namespace(namespace)
     table1 = catalog.create_table(table_identifier, table_schema_nested)
     table2 = catalog.create_table_if_not_exists(table_identifier, table_schema_nested)
@@ -618,15 +584,14 @@ def test_create_table_without_namespace(catalog: SqlCatalog, table_schema_nested
     [
         lazy_fixture("random_table_identifier"),
         lazy_fixture("random_hierarchical_identifier"),
-        lazy_fixture("random_table_identifier_with_catalog"),
     ],
 )
 def test_register_table(catalog: SqlCatalog, table_identifier: Identifier, metadata_location: str) -> None:
-    table_identifier_nocatalog = catalog._identifier_to_tuple_without_catalog(table_identifier)
-    namespace = Catalog.namespace_from(table_identifier_nocatalog)
+    identifier_tuple = Catalog.identifier_to_tuple(table_identifier)
+    namespace = Catalog.namespace_from(table_identifier)
     catalog.create_namespace(namespace)
     table = catalog.register_table(table_identifier, metadata_location)
-    assert table.name() == table_identifier_nocatalog
+    assert table.name() == identifier_tuple
     assert table.metadata_location == metadata_location
     assert os.path.exists(metadata_location)
     catalog.drop_table(table_identifier)
@@ -644,12 +609,10 @@ def test_register_table(catalog: SqlCatalog, table_identifier: Identifier, metad
     [
         lazy_fixture("random_table_identifier"),
         lazy_fixture("random_hierarchical_identifier"),
-        lazy_fixture("random_table_identifier_with_catalog"),
     ],
 )
 def test_register_existing_table(catalog: SqlCatalog, table_identifier: Identifier, metadata_location: str) -> None:
-    table_identifier_nocatalog = catalog._identifier_to_tuple_without_catalog(table_identifier)
-    namespace = Catalog.namespace_from(table_identifier_nocatalog)
+    namespace = Catalog.namespace_from(table_identifier)
     catalog.create_namespace(namespace)
     catalog.register_table(table_identifier, metadata_location)
     with pytest.raises(TableAlreadyExistsError):
@@ -693,12 +656,10 @@ def test_register_table_without_namespace(catalog: SqlCatalog, metadata_location
     [
         lazy_fixture("random_table_identifier"),
         lazy_fixture("random_hierarchical_identifier"),
-        lazy_fixture("random_table_identifier_with_catalog"),
     ],
 )
 def test_load_table(catalog: SqlCatalog, table_schema_nested: Schema, table_identifier: Identifier) -> None:
-    table_identifier_nocatalog = catalog._identifier_to_tuple_without_catalog(table_identifier)
-    namespace = Catalog.namespace_from(table_identifier_nocatalog)
+    namespace = Catalog.namespace_from(table_identifier)
     catalog.create_namespace(namespace)
     table = catalog.create_table(table_identifier, table_schema_nested)
     loaded_table = catalog.load_table(table_identifier)
@@ -719,16 +680,15 @@ def test_load_table(catalog: SqlCatalog, table_schema_nested: Schema, table_iden
     [
         lazy_fixture("random_table_identifier"),
         lazy_fixture("random_hierarchical_identifier"),
-        lazy_fixture("random_table_identifier_with_catalog"),
     ],
 )
 def test_load_table_from_self_identifier(catalog: SqlCatalog, table_schema_nested: Schema, table_identifier: Identifier) -> None:
-    table_identifier_nocatalog = catalog._identifier_to_tuple_without_catalog(table_identifier)
-    namespace = Catalog.namespace_from(table_identifier_nocatalog)
+    identifier_tuple = Catalog.identifier_to_tuple(table_identifier)
+    namespace = Catalog.namespace_from(table_identifier)
     catalog.create_namespace(namespace)
     table = catalog.create_table(table_identifier, table_schema_nested)
     intermediate = catalog.load_table(table_identifier)
-    assert intermediate.name() == table_identifier_nocatalog
+    assert intermediate.name() == identifier_tuple
     loaded_table = catalog.load_table(intermediate.name())
     assert table.name() == loaded_table.name()
     assert table.metadata_location == loaded_table.metadata_location
@@ -748,15 +708,14 @@ def test_load_table_from_self_identifier(catalog: SqlCatalog, table_schema_neste
     [
         lazy_fixture("random_table_identifier"),
         lazy_fixture("random_hierarchical_identifier"),
-        lazy_fixture("random_table_identifier_with_catalog"),
     ],
 )
 def test_drop_table(catalog: SqlCatalog, table_schema_nested: Schema, table_identifier: Identifier) -> None:
-    table_identifier_nocatalog = catalog._identifier_to_tuple_without_catalog(table_identifier)
-    namespace = Catalog.namespace_from(table_identifier_nocatalog)
+    identifier_tuple = Catalog.identifier_to_tuple(table_identifier)
+    namespace = Catalog.namespace_from(table_identifier)
     catalog.create_namespace(namespace)
     table = catalog.create_table(table_identifier, table_schema_nested)
-    assert table.name() == table_identifier_nocatalog
+    assert table.name() == identifier_tuple
     catalog.drop_table(table_identifier)
     with pytest.raises(NoSuchTableError):
         catalog.load_table(table_identifier)
@@ -775,15 +734,14 @@ def test_drop_table(catalog: SqlCatalog, table_schema_nested: Schema, table_iden
     [
         lazy_fixture("random_table_identifier"),
         lazy_fixture("random_hierarchical_identifier"),
-        lazy_fixture("random_table_identifier_with_catalog"),
     ],
 )
 def test_drop_table_from_self_identifier(catalog: SqlCatalog, table_schema_nested: Schema, table_identifier: Identifier) -> None:
-    table_identifier_nocatalog = catalog._identifier_to_tuple_without_catalog(table_identifier)
-    namespace = Catalog.namespace_from(table_identifier_nocatalog)
+    identifier_tuple = Catalog.identifier_to_tuple(table_identifier)
+    namespace = Catalog.namespace_from(table_identifier)
     catalog.create_namespace(namespace)
     table = catalog.create_table(table_identifier, table_schema_nested)
-    assert table.name() == table_identifier_nocatalog
+    assert table.name() == identifier_tuple
     catalog.drop_table(table.name())
     with pytest.raises(NoSuchTableError):
         catalog.load_table(table.name())
@@ -804,7 +762,6 @@ def test_drop_table_from_self_identifier(catalog: SqlCatalog, table_schema_neste
     [
         lazy_fixture("random_table_identifier"),
         lazy_fixture("random_hierarchical_identifier"),
-        lazy_fixture("random_table_identifier_with_catalog"),
     ],
 )
 def test_drop_table_that_does_not_exist(catalog: SqlCatalog, table_identifier: Identifier) -> None:
@@ -825,7 +782,6 @@ def test_drop_table_that_does_not_exist(catalog: SqlCatalog, table_identifier: I
     [
         lazy_fixture("random_table_identifier"),
         lazy_fixture("random_hierarchical_identifier"),
-        lazy_fixture("random_table_identifier_with_catalog"),
     ],
 )
 @pytest.mark.parametrize(
@@ -833,23 +789,20 @@ def test_drop_table_that_does_not_exist(catalog: SqlCatalog, table_identifier: I
     [
         lazy_fixture("another_random_table_identifier"),
         lazy_fixture("another_random_hierarchical_identifier"),
-        lazy_fixture("another_random_table_identifier_with_catalog"),
     ],
 )
 def test_rename_table(
     catalog: SqlCatalog, table_schema_nested: Schema, from_table_identifier: Identifier, to_table_identifier: Identifier
 ) -> None:
-    from_table_identifier_nocatalog = catalog._identifier_to_tuple_without_catalog(from_table_identifier)
-    to_table_identifier_nocatalog = catalog._identifier_to_tuple_without_catalog(to_table_identifier)
-    from_namespace = Catalog.namespace_from(from_table_identifier_nocatalog)
-    to_namespace = Catalog.namespace_from(to_table_identifier_nocatalog)
+    from_namespace = Catalog.namespace_from(from_table_identifier)
+    to_namespace = Catalog.namespace_from(to_table_identifier)
     catalog.create_namespace(from_namespace)
     catalog.create_namespace(to_namespace)
     table = catalog.create_table(from_table_identifier, table_schema_nested)
-    assert table.name() == from_table_identifier_nocatalog
+    assert table.name() == from_table_identifier
     catalog.rename_table(from_table_identifier, to_table_identifier)
     new_table = catalog.load_table(to_table_identifier)
-    assert new_table.name() == to_table_identifier_nocatalog
+    assert new_table.name() == to_table_identifier
     assert new_table.metadata_location == table.metadata_location
     with pytest.raises(NoSuchTableError):
         catalog.load_table(from_table_identifier)
@@ -868,7 +821,6 @@ def test_rename_table(
     [
         lazy_fixture("random_table_identifier"),
         lazy_fixture("random_hierarchical_identifier"),
-        lazy_fixture("random_table_identifier_with_catalog"),
     ],
 )
 @pytest.mark.parametrize(
@@ -876,23 +828,20 @@ def test_rename_table(
     [
         lazy_fixture("another_random_table_identifier"),
         lazy_fixture("another_random_hierarchical_identifier"),
-        lazy_fixture("another_random_table_identifier_with_catalog"),
     ],
 )
 def test_rename_table_from_self_identifier(
     catalog: SqlCatalog, table_schema_nested: Schema, from_table_identifier: Identifier, to_table_identifier: Identifier
 ) -> None:
-    from_table_identifier_nocatalog = catalog._identifier_to_tuple_without_catalog(from_table_identifier)
-    to_table_identifier_nocatalog = catalog._identifier_to_tuple_without_catalog(to_table_identifier)
-    from_namespace = Catalog.namespace_from(from_table_identifier_nocatalog)
-    to_namespace = Catalog.namespace_from(to_table_identifier_nocatalog)
+    from_namespace = Catalog.namespace_from(from_table_identifier)
+    to_namespace = Catalog.namespace_from(to_table_identifier)
     catalog.create_namespace(from_namespace)
     catalog.create_namespace(to_namespace)
     table = catalog.create_table(from_table_identifier, table_schema_nested)
-    assert table.name() == from_table_identifier_nocatalog
+    assert table.name() == from_table_identifier
     catalog.rename_table(table.name(), to_table_identifier)
     new_table = catalog.load_table(to_table_identifier)
-    assert new_table.name() == to_table_identifier_nocatalog
+    assert new_table.name() == to_table_identifier
     assert new_table.metadata_location == table.metadata_location
     with pytest.raises(NoSuchTableError):
         catalog.load_table(table.name())
@@ -913,7 +862,6 @@ def test_rename_table_from_self_identifier(
     [
         lazy_fixture("random_table_identifier"),
         lazy_fixture("random_hierarchical_identifier"),
-        lazy_fixture("random_table_identifier_with_catalog"),
     ],
 )
 @pytest.mark.parametrize(
@@ -921,22 +869,19 @@ def test_rename_table_from_self_identifier(
     [
         lazy_fixture("another_random_table_identifier"),
         lazy_fixture("another_random_hierarchical_identifier"),
-        lazy_fixture("another_random_table_identifier_with_catalog"),
     ],
 )
 def test_rename_table_to_existing_one(
     catalog: SqlCatalog, table_schema_nested: Schema, from_table_identifier: Identifier, to_table_identifier: Identifier
 ) -> None:
-    from_table_identifier_nocatalog = catalog._identifier_to_tuple_without_catalog(from_table_identifier)
-    to_table_identifier_nocatalog = catalog._identifier_to_tuple_without_catalog(to_table_identifier)
-    from_namespace = Catalog.namespace_from(from_table_identifier_nocatalog)
-    to_namespace = Catalog.namespace_from(to_table_identifier_nocatalog)
+    from_namespace = Catalog.namespace_from(from_table_identifier)
+    to_namespace = Catalog.namespace_from(to_table_identifier)
     catalog.create_namespace(from_namespace)
     catalog.create_namespace(to_namespace)
     table = catalog.create_table(from_table_identifier, table_schema_nested)
-    assert table.name() == from_table_identifier_nocatalog
+    assert table.name() == from_table_identifier
     new_table = catalog.create_table(to_table_identifier, table_schema_nested)
-    assert new_table.name() == to_table_identifier_nocatalog
+    assert new_table.name() == to_table_identifier
     with pytest.raises(TableAlreadyExistsError):
         catalog.rename_table(from_table_identifier, to_table_identifier)
 
@@ -954,7 +899,6 @@ def test_rename_table_to_existing_one(
     [
         lazy_fixture("random_table_identifier"),
         lazy_fixture("random_hierarchical_identifier"),
-        lazy_fixture("random_table_identifier_with_catalog"),
     ],
 )
 @pytest.mark.parametrize(
@@ -962,12 +906,10 @@ def test_rename_table_to_existing_one(
     [
         lazy_fixture("another_random_table_identifier"),
         lazy_fixture("another_random_hierarchical_identifier"),
-        lazy_fixture("another_random_table_identifier_with_catalog"),
     ],
 )
 def test_rename_missing_table(catalog: SqlCatalog, from_table_identifier: Identifier, to_table_identifier: Identifier) -> None:
-    to_table_identifier_nocatalog = catalog._identifier_to_tuple_without_catalog(to_table_identifier)
-    to_namespace = Catalog.namespace_from(to_table_identifier_nocatalog)
+    to_namespace = Catalog.namespace_from(to_table_identifier)
     catalog.create_namespace(to_namespace)
     with pytest.raises(NoSuchTableError):
         catalog.rename_table(from_table_identifier, to_table_identifier)
@@ -986,7 +928,6 @@ def test_rename_missing_table(catalog: SqlCatalog, from_table_identifier: Identi
     [
         lazy_fixture("random_table_identifier"),
         lazy_fixture("random_hierarchical_identifier"),
-        lazy_fixture("random_table_identifier_with_catalog"),
     ],
 )
 @pytest.mark.parametrize(
@@ -994,17 +935,15 @@ def test_rename_missing_table(catalog: SqlCatalog, from_table_identifier: Identi
     [
         lazy_fixture("another_random_table_identifier"),
         lazy_fixture("another_random_hierarchical_identifier"),
-        lazy_fixture("another_random_table_identifier_with_catalog"),
     ],
 )
 def test_rename_table_to_missing_namespace(
     catalog: SqlCatalog, table_schema_nested: Schema, from_table_identifier: Identifier, to_table_identifier: Identifier
 ) -> None:
-    from_table_identifier_nocatalog = catalog._identifier_to_tuple_without_catalog(from_table_identifier)
-    from_namespace = Catalog.namespace_from(from_table_identifier_nocatalog)
+    from_namespace = Catalog.namespace_from(from_table_identifier)
     catalog.create_namespace(from_namespace)
     table = catalog.create_table(from_table_identifier, table_schema_nested)
-    assert table.name() == from_table_identifier_nocatalog
+    assert table.name() == from_table_identifier
     with pytest.raises(NoSuchNamespaceError):
         catalog.rename_table(from_table_identifier, to_table_identifier)
 
@@ -1021,7 +960,6 @@ def test_rename_table_to_missing_namespace(
     [
         lazy_fixture("random_table_identifier"),
         lazy_fixture("random_hierarchical_identifier"),
-        lazy_fixture("random_table_identifier_with_catalog"),
     ],
 )
 @pytest.mark.parametrize(
@@ -1029,27 +967,24 @@ def test_rename_table_to_missing_namespace(
     [
         lazy_fixture("another_random_table_identifier"),
         lazy_fixture("another_random_hierarchical_identifier"),
-        lazy_fixture("another_random_table_identifier_with_catalog"),
     ],
 )
 def test_list_tables(
     catalog: SqlCatalog, table_schema_nested: Schema, table_identifier_1: Identifier, table_identifier_2: Identifier
 ) -> None:
-    table_identifier_1_nocatalog = catalog._identifier_to_tuple_without_catalog(table_identifier_1)
-    table_identifier_2_nocatalog = catalog._identifier_to_tuple_without_catalog(table_identifier_2)
-    namespace_1 = Catalog.namespace_from(table_identifier_1_nocatalog)
-    namespace_2 = Catalog.namespace_from(table_identifier_2_nocatalog)
+    namespace_1 = Catalog.namespace_from(table_identifier_1)
+    namespace_2 = Catalog.namespace_from(table_identifier_2)
     catalog.create_namespace(namespace_1)
     catalog.create_namespace(namespace_2)
     catalog.create_table(table_identifier_1, table_schema_nested)
     catalog.create_table(table_identifier_2, table_schema_nested)
     identifier_list = catalog.list_tables(namespace_1)
     assert len(identifier_list) == 1
-    assert table_identifier_1_nocatalog in identifier_list
+    assert table_identifier_1 in identifier_list
 
     identifier_list = catalog.list_tables(namespace_2)
     assert len(identifier_list) == 1
-    assert table_identifier_2_nocatalog in identifier_list
+    assert table_identifier_2 in identifier_list
 
 
 @pytest.mark.parametrize(
@@ -1216,12 +1151,10 @@ def test_list_non_existing_namespaces(catalog: SqlCatalog) -> None:
     [
         lazy_fixture("random_table_identifier"),
         lazy_fixture("random_hierarchical_identifier"),
-        lazy_fixture("random_table_identifier_with_catalog"),
     ],
 )
 def test_drop_namespace(catalog: SqlCatalog, table_schema_nested: Schema, table_identifier: Identifier) -> None:
-    table_identifier_nocatalog = catalog._identifier_to_tuple_without_catalog(table_identifier)
-    namespace = Catalog.namespace_from(table_identifier_nocatalog)
+    namespace = Catalog.namespace_from(table_identifier)
     catalog.create_namespace(namespace)
     assert namespace in catalog.list_namespaces()
     catalog.create_table(table_identifier, table_schema_nested)
@@ -1344,12 +1277,10 @@ def test_update_namespace_properties(catalog: SqlCatalog, namespace: str) -> Non
     [
         lazy_fixture("random_table_identifier"),
         lazy_fixture("random_hierarchical_identifier"),
-        lazy_fixture("random_table_identifier_with_catalog"),
     ],
 )
 def test_commit_table(catalog: SqlCatalog, table_schema_nested: Schema, table_identifier: Identifier) -> None:
-    table_identifier_nocatalog = catalog._identifier_to_tuple_without_catalog(table_identifier)
-    namespace = Catalog.namespace_from(table_identifier_nocatalog)
+    namespace = Catalog.namespace_from(table_identifier)
     catalog.create_namespace(namespace)
     table = catalog.create_table(table_identifier, table_schema_nested)
     last_updated_ms = table.metadata.last_updated_ms
@@ -1394,12 +1325,10 @@ def test_commit_table(catalog: SqlCatalog, table_schema_nested: Schema, table_id
     [
         lazy_fixture("random_table_identifier"),
         lazy_fixture("random_hierarchical_identifier"),
-        lazy_fixture("random_table_identifier_with_catalog"),
     ],
 )
 def test_append_table(catalog: SqlCatalog, table_schema_simple: Schema, table_identifier: Identifier) -> None:
-    table_identifier_nocatalog = catalog._identifier_to_tuple_without_catalog(table_identifier)
-    namespace = Catalog.namespace_from(table_identifier_nocatalog)
+    namespace = Catalog.namespace_from(table_identifier)
     catalog.create_namespace(namespace)
     table = catalog.create_table(table_identifier, table_schema_simple)
 
@@ -1444,12 +1373,10 @@ def test_append_table(catalog: SqlCatalog, table_schema_simple: Schema, table_id
     [
         lazy_fixture("random_table_identifier"),
         lazy_fixture("random_hierarchical_identifier"),
-        lazy_fixture("random_table_identifier_with_catalog"),
     ],
 )
 def test_concurrent_commit_table(catalog: SqlCatalog, table_schema_simple: Schema, table_identifier: Identifier) -> None:
-    table_identifier_nocatalog = catalog._identifier_to_tuple_without_catalog(table_identifier)
-    namespace = Catalog.namespace_from(table_identifier_nocatalog)
+    namespace = Catalog.namespace_from(table_identifier)
     catalog.create_namespace(namespace)
     table_a = catalog.create_table(table_identifier, table_schema_simple)
     table_b = catalog.load_table(table_identifier)
@@ -1587,13 +1514,11 @@ def test_create_table_transaction(catalog: SqlCatalog, format_version: int) -> N
     [
         lazy_fixture("random_table_identifier"),
         lazy_fixture("random_hierarchical_identifier"),
-        lazy_fixture("random_table_identifier_with_catalog"),
     ],
 )
 def test_table_properties_int_value(catalog: SqlCatalog, table_schema_simple: Schema, table_identifier: Identifier) -> None:
     # table properties can be set to int, but still serialized to string
-    table_identifier_nocatalog = catalog._identifier_to_tuple_without_catalog(table_identifier)
-    namespace = Catalog.namespace_from(table_identifier_nocatalog)
+    namespace = Catalog.namespace_from(table_identifier)
     catalog.create_namespace(namespace)
     property_with_int = {"property_name": 42}
     table = catalog.create_table(table_identifier, table_schema_simple, properties=property_with_int)
@@ -1613,14 +1538,12 @@ def test_table_properties_int_value(catalog: SqlCatalog, table_schema_simple: Sc
     [
         lazy_fixture("random_table_identifier"),
         lazy_fixture("random_hierarchical_identifier"),
-        lazy_fixture("random_table_identifier_with_catalog"),
     ],
 )
 def test_table_properties_raise_for_none_value(
     catalog: SqlCatalog, table_schema_simple: Schema, table_identifier: Identifier
 ) -> None:
-    table_identifier_nocatalog = catalog._identifier_to_tuple_without_catalog(table_identifier)
-    namespace = Catalog.namespace_from(table_identifier_nocatalog)
+    namespace = Catalog.namespace_from(table_identifier)
     catalog.create_namespace(namespace)
     property_with_none = {"property_name": None}
     with pytest.raises(ValidationError) as exc_info:
@@ -1640,12 +1563,10 @@ def test_table_properties_raise_for_none_value(
     [
         lazy_fixture("random_table_identifier"),
         lazy_fixture("random_hierarchical_identifier"),
-        lazy_fixture("random_table_identifier_with_catalog"),
     ],
 )
 def test_table_exists(catalog: SqlCatalog, table_schema_simple: Schema, table_identifier: Identifier) -> None:
-    table_identifier_nocatalog = catalog._identifier_to_tuple_without_catalog(table_identifier)
-    namespace = Catalog.namespace_from(table_identifier_nocatalog)
+    namespace = Catalog.namespace_from(table_identifier)
     catalog.create_namespace(namespace)
     catalog.create_table(table_identifier, table_schema_simple, properties={"format-version": "2"})
     existing_table = table_identifier


### PR DESCRIPTION
Currently, we optionally support catalog names being specified in the identifier string. In other words, this means that we currently support identifier names that look like `catalog_name.table_namespace.table_name` or `table_namespace.table_name` being passed into `catalog.load_table()` method.

This PR proposes to remove this optional support, and change the `Table` class's identifier to be `(table_namespace, table_name)` instead of `(catalog_name, table_namespace, table_name)`. The reasons are as follows:
1. The Identifier is specified as namespace + table_name according to the [REST Catalog Open API Spec](https://github.com/apache/iceberg/blob/3495d9edaee30c1714a810eb35635f8be20fc106/open-api/rest-catalog-open-api.yaml#L1657)
2. `Table` has the attribute `catalog` - a Table is always instantiated with a Catalog instance. Hence the catalog name is accessible as: `tbl.catalog.name`, and I feel that prepending the catalog name to the identifier is redundant. If there is value in keeping a long identifier including the catalog name, it may be better to leave the `identifier` field as namespace + name pair, and update the `name` attribute to be `self.catalog.name` + `self.identifier` instead.
3. `identifier_to_tuple_without_catalog` is called in all `catalog` implementations, and is currently crucial in allowing `Table` to use the long identifier including the catalog_name. However, this function is imperfect, and will result in errors if the the table_namespace uses a hierarchical name that is repeats the catalog name. For example, namespace: `default.lower` and catalog_name: `default`. When we pass `default.lower.table_name` to refer to the table `table_name` in namespace `default.lower` on the catalog `default`, we will run into an unexpected exception as it will remove the first hierarchy of the namespace, and look for `lower.table_name`.
4. Fixes: https://github.com/apache/iceberg-python/issues/742

Thankfully, we have not explicitly documented that we support catalog_name in the identifier string in our API documentation, and other engine partners do not seem to be relying on this feature as well (checking one example of [Daft](https://github.com/Eventual-Inc/Daft/blob/764d2df9e7c6916b3cfda3e6be682af6430bc90b/tests/integration/iceberg/conftest.py#L54))

It would be great to get this change in for 0.7.0 release as certain rest catalog implementations are having issues with the current approach: https://github.com/hansetag/iceberg-catalog/issues/18

However this is backward incompatible change that takes away an optional feature, so I would like to put this PR up as a first step in facilitating the discussion.