### PR TITLE
Fix list namespace response in rest catalog

### DIFF
--- a/pyiceberg/catalog/rest.py
+++ b/pyiceberg/catalog/rest.py
@@ -758,8 +758,7 @@ class RestCatalog(Catalog):
         except HTTPError as exc:
             self._handle_non_200_response(exc, {})
 
-        namespaces = ListNamespaceResponse(**response.json())
-        return [namespace_tuple + child_namespace for child_namespace in namespaces.namespaces]
+        return ListNamespaceResponse(**response.json()).namespaces
 
     @retry(**_RETRY_ARGS)
     def load_namespace_properties(self, namespace: Union[str, Identifier]) -> Properties:

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -419,7 +419,7 @@ def test_list_namespaces_200(rest_mock: Mocker) -> None:
 def test_list_namespace_with_parent_200(rest_mock: Mocker) -> None:
     rest_mock.get(
         f"{TEST_URI}v1/namespaces?parent=accounting",
-        json={"namespaces": [["tax"]]},
+        json={"namespaces": [["accounting", "tax"]]},
         status_code=200,
         request_headers=TEST_HEADERS,
     )


### PR DESCRIPTION
While testing PyIceberg with Polaris and multi-level namespacing, I noticed a behavior that doesn't [align with the REST catalog specification](https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml#L210-L215). The expected response should be the fully qualified namespace.