### PR TITLE
prevent adding duplicate files 

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -1648,7 +1648,9 @@ class Table:
         with self.transaction() as tx:
             tx.delete(delete_filter=delete_filter, snapshot_properties=snapshot_properties)
 
-    def add_files(self, file_paths: List[str], snapshot_properties: Dict[str, str] = EMPTY_DICT) -> None:
+    def add_files(
+        self, file_paths: List[str], snapshot_properties: Dict[str, str] = EMPTY_DICT, check_duplicate_files: bool = True
+    ) -> None:
         """
         Shorthand API for adding files as data files to the table.
 
@@ -1659,7 +1661,9 @@ class Table:
             FileNotFoundError: If the file does not exist.
         """
         with self.transaction() as tx:
-            tx.add_files(file_paths=file_paths, snapshot_properties=snapshot_properties)
+            tx.add_files(
+                file_paths=file_paths, snapshot_properties=snapshot_properties, check_duplicate_files=check_duplicate_files
+            )
 
     def update_spec(self, case_sensitive: bool = True) -> UpdateSpec:
         return UpdateSpec(Transaction(self, autocommit=True), case_sensitive=case_sensitive)

--- a/tests/integration/test_add_files.py
+++ b/tests/integration/test_add_files.py
@@ -776,3 +776,33 @@ def test_add_files_that_referenced_by_current_snapshot(
     with pytest.raises(ValueError) as exc_info:
         tbl.add_files(file_paths=[referenced_file])
     assert f"Cannot add files that are already referenced by table, files: {referenced_file}" in str(exc_info.value)
+
+
+@pytest.mark.integration
+def test_add_files_that_referenced_by_current_snapshot_with_check_duplicate_files_false(
+    spark: SparkSession, session_catalog: Catalog, format_version: int
+) -> None:
+    identifier = f"default.test_table_add_referenced_file_v{format_version}"
+    tbl = _create_table(session_catalog, identifier, format_version)
+
+    file_paths = [f"s3://warehouse/default/unpartitioned/v{format_version}/test-{i}.parquet" for i in range(5)]
+    referenced_file = f"s3://warehouse/default/unpartitioned/v{format_version}/test-1.parquet"
+    # write parquet files
+    for file_path in file_paths:
+        fo = tbl.io.new_output(file_path)
+        with fo.create(overwrite=True) as fos:
+            with pq.ParquetWriter(fos, schema=ARROW_SCHEMA) as writer:
+                writer.write_table(ARROW_TABLE)
+
+    # add the parquet files as data files
+    tbl.add_files(file_paths=file_paths)
+    tbl.add_files(file_paths=[referenced_file], check_duplicate_files=False)
+    rows = spark.sql(
+        f"""
+        SELECT added_data_files_count, existing_data_files_count, deleted_data_files_count
+        FROM {identifier}.all_manifests
+    """
+    ).collect()
+
+    assert [row.added_data_files_count for row in rows] == [5, 1, 5]
+

--- a/tests/integration/test_add_files.py
+++ b/tests/integration/test_add_files.py
@@ -735,18 +735,12 @@ def test_add_files_subset_of_schema(spark: SparkSession, session_catalog: Catalo
 
 
 @pytest.mark.integration
+@pytest.mark.parametrize("format_version", [1, 2])
 def test_add_files_with_duplicate_files_in_file_paths(spark: SparkSession, session_catalog: Catalog, format_version: int) -> None:
     identifier = f"default.test_table_duplicate_add_files_v{format_version}"
     tbl = _create_table(session_catalog, identifier, format_version)
-
-    file_paths = [f"s3://warehouse/default/unpartitioned/v{format_version}/test-{i}.parquet" for i in range(5)]
-    file_paths.append(f"s3://warehouse/default/unpartitioned/v{format_version}/test-1.parquet")
-    # write parquet files
-    for file_path in file_paths:
-        fo = tbl.io.new_output(file_path)
-        with fo.create(overwrite=True) as fos:
-            with pq.ParquetWriter(fos, schema=ARROW_SCHEMA) as writer:
-                writer.write_table(ARROW_TABLE)
+    file_path = "s3://warehouse/default/unpartitioned/v{format_version}/test-1.parquet"
+    file_paths = [file_path, file_path]
 
     # add the parquet files as data files
     with pytest.raises(ValueError) as exc_info:
@@ -755,6 +749,7 @@ def test_add_files_with_duplicate_files_in_file_paths(spark: SparkSession, sessi
 
 
 @pytest.mark.integration
+@pytest.mark.parametrize("format_version", [1, 2])
 def test_add_files_that_referenced_by_current_snapshot(
     spark: SparkSession, session_catalog: Catalog, format_version: int
 ) -> None:
@@ -762,7 +757,7 @@ def test_add_files_that_referenced_by_current_snapshot(
     tbl = _create_table(session_catalog, identifier, format_version)
 
     file_paths = [f"s3://warehouse/default/unpartitioned/v{format_version}/test-{i}.parquet" for i in range(5)]
-    referenced_file = f"s3://warehouse/default/unpartitioned/v{format_version}/test-1.parquet"
+
     # write parquet files
     for file_path in file_paths:
         fo = tbl.io.new_output(file_path)
@@ -772,13 +767,15 @@ def test_add_files_that_referenced_by_current_snapshot(
 
     # add the parquet files as data files
     tbl.add_files(file_paths=file_paths)
+    existing_files_in_table = tbl.inspect.files().to_pylist().pop()["file_path"]
 
     with pytest.raises(ValueError) as exc_info:
-        tbl.add_files(file_paths=[referenced_file])
-    assert f"Cannot add files that are already referenced by table, files: {referenced_file}" in str(exc_info.value)
+        tbl.add_files(file_paths=[existing_files_in_table])
+    assert f"Cannot add files that are already referenced by table, files: {existing_files_in_table}" in str(exc_info.value)
 
 
 @pytest.mark.integration
+@pytest.mark.parametrize("format_version", [1, 2])
 def test_add_files_that_referenced_by_current_snapshot_with_check_duplicate_files_false(
     spark: SparkSession, session_catalog: Catalog, format_version: int
 ) -> None:
@@ -786,7 +783,6 @@ def test_add_files_that_referenced_by_current_snapshot_with_check_duplicate_file
     tbl = _create_table(session_catalog, identifier, format_version)
 
     file_paths = [f"s3://warehouse/default/unpartitioned/v{format_version}/test-{i}.parquet" for i in range(5)]
-    referenced_file = f"s3://warehouse/default/unpartitioned/v{format_version}/test-1.parquet"
     # write parquet files
     for file_path in file_paths:
         fo = tbl.io.new_output(file_path)
@@ -796,12 +792,38 @@ def test_add_files_that_referenced_by_current_snapshot_with_check_duplicate_file
 
     # add the parquet files as data files
     tbl.add_files(file_paths=file_paths)
-    tbl.add_files(file_paths=[referenced_file], check_duplicate_files=False)
+    existing_files_in_table = tbl.inspect.files().to_pylist().pop()["file_path"]
+    tbl.add_files(file_paths=[existing_files_in_table], check_duplicate_files=False)
     rows = spark.sql(
         f"""
         SELECT added_data_files_count, existing_data_files_count, deleted_data_files_count
         FROM {identifier}.all_manifests
     """
     ).collect()
+    assert [row.added_data_files_count for row in rows] == [5,1,5]
+    assert [row.existing_data_files_count for row in rows] == [0,0,0]
+    assert [row.deleted_data_files_count for row in rows] == [0,0,0]
 
-    assert [row.added_data_files_count for row in rows] == [5, 1, 5]
+
+@pytest.mark.integration
+@pytest.mark.parametrize("format_version", [1, 2])
+def test_add_files_that_referenced_by_current_snapshot_with_check_duplicate_files_true(
+    spark: SparkSession, session_catalog: Catalog, format_version: int
+) -> None:
+    identifier = f"default.test_table_add_referenced_file_v{format_version}"
+    tbl = _create_table(session_catalog, identifier, format_version)
+
+    file_paths = [f"s3://warehouse/default/unpartitioned/v{format_version}/test-{i}.parquet" for i in range(5)]
+    # write parquet files
+    for file_path in file_paths:
+        fo = tbl.io.new_output(file_path)
+        with fo.create(overwrite=True) as fos:
+            with pq.ParquetWriter(fos, schema=ARROW_SCHEMA) as writer:
+                writer.write_table(ARROW_TABLE)
+
+    # add the parquet files as data files
+    tbl.add_files(file_paths=file_paths)
+    existing_files_in_table = tbl.inspect.files().to_pylist().pop()["file_path"]
+    with pytest.raises(ValueError) as exc_info:
+        tbl.add_files(file_paths=[existing_files_in_table], check_duplicate_files=True)
+    assert f"Cannot add files that are already referenced by table, files: {existing_files_in_table}" in str(exc_info.value)

--- a/tests/integration/test_add_files.py
+++ b/tests/integration/test_add_files.py
@@ -800,9 +800,9 @@ def test_add_files_that_referenced_by_current_snapshot_with_check_duplicate_file
         FROM {identifier}.all_manifests
     """
     ).collect()
-    assert [row.added_data_files_count for row in rows] == [5,1,5]
-    assert [row.existing_data_files_count for row in rows] == [0,0,0]
-    assert [row.deleted_data_files_count for row in rows] == [0,0,0]
+    assert [row.added_data_files_count for row in rows] == [5, 1, 5]
+    assert [row.existing_data_files_count for row in rows] == [0, 0, 0]
+    assert [row.deleted_data_files_count for row in rows] == [0, 0, 0]
 
 
 @pytest.mark.integration

--- a/tests/integration/test_add_files.py
+++ b/tests/integration/test_add_files.py
@@ -732,3 +732,47 @@ def test_add_files_subset_of_schema(spark: SparkSession, session_catalog: Catalo
     for column in written_arrow_table.column_names:
         for left, right in zip(lhs[column].to_list(), rhs[column].to_list()):
             assert left == right
+
+
+@pytest.mark.integration
+def test_add_files_with_duplicate_files_in_file_paths(spark: SparkSession, session_catalog: Catalog, format_version: int) -> None:
+    identifier = f"default.test_table_duplicate_add_files_v{format_version}"
+    tbl = _create_table(session_catalog, identifier, format_version)
+
+    file_paths = [f"s3://warehouse/default/unpartitioned/v{format_version}/test-{i}.parquet" for i in range(5)]
+    file_paths.append(f"s3://warehouse/default/unpartitioned/v{format_version}/test-1.parquet")
+    # write parquet files
+    for file_path in file_paths:
+        fo = tbl.io.new_output(file_path)
+        with fo.create(overwrite=True) as fos:
+            with pq.ParquetWriter(fos, schema=ARROW_SCHEMA) as writer:
+                writer.write_table(ARROW_TABLE)
+
+    # add the parquet files as data files
+    with pytest.raises(ValueError) as exc_info:
+        tbl.add_files(file_paths=file_paths)
+    assert "File paths must be unique" in str(exc_info.value)
+
+
+@pytest.mark.integration
+def test_add_files_that_referenced_by_current_snapshot(
+    spark: SparkSession, session_catalog: Catalog, format_version: int
+) -> None:
+    identifier = f"default.test_table_add_referenced_file_v{format_version}"
+    tbl = _create_table(session_catalog, identifier, format_version)
+
+    file_paths = [f"s3://warehouse/default/unpartitioned/v{format_version}/test-{i}.parquet" for i in range(5)]
+    referenced_file = f"s3://warehouse/default/unpartitioned/v{format_version}/test-1.parquet"
+    # write parquet files
+    for file_path in file_paths:
+        fo = tbl.io.new_output(file_path)
+        with fo.create(overwrite=True) as fos:
+            with pq.ParquetWriter(fos, schema=ARROW_SCHEMA) as writer:
+                writer.write_table(ARROW_TABLE)
+
+    # add the parquet files as data files
+    tbl.add_files(file_paths=file_paths)
+
+    with pytest.raises(ValueError) as exc_info:
+        tbl.add_files(file_paths=[referenced_file])
+    assert f"Cannot add files that are already referenced by table, files: {referenced_file}" in str(exc_info.value)

--- a/tests/integration/test_add_files.py
+++ b/tests/integration/test_add_files.py
@@ -805,4 +805,3 @@ def test_add_files_that_referenced_by_current_snapshot_with_check_duplicate_file
     ).collect()
 
     assert [row.added_data_files_count for row in rows] == [5, 1, 5]
-


### PR DESCRIPTION
This resolves #998 , where duplicate files are added  with add_files method, handles 2 cases:

1. Files list is not unique 
2. One of the files added is already referenced by current snapshot