### PR TITLE
Coverage Run unit tests first before docker containers are set up

### DIFF
--- a/tests/integration/test_reads.py
+++ b/tests/integration/test_reads.py
@@ -753,6 +753,7 @@ def test_configure_row_group_batch_size(session_catalog: Catalog) -> None:
     assert len(batches) == entries
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize("catalog", [pytest.lazy_fixture("session_catalog_hive"), pytest.lazy_fixture("session_catalog")])
 def test_table_scan_default_to_large_types(catalog: Catalog) -> None:
     identifier = "default.test_table_scan_default_to_large_types"


### PR DESCRIPTION
This PR implements:
- Run unit tests as part of the CI
- Add a missing integration mark to one of the integration tests

Should close #1051 