### PR TITLE
Update "verify release" instruction

### DIFF
--- a/mkdocs/docs/verify-release.md
+++ b/mkdocs/docs/verify-release.md
@@ -105,7 +105,7 @@ First step is to install the package:
 make install
 ```
 
-To run the full test coverage, with run both unit tests and integration tests:
+To run the full test coverage, with both unit tests and integration tests:
 
 ```sh
 make test-coverage

--- a/mkdocs/docs/verify-release.md
+++ b/mkdocs/docs/verify-release.md
@@ -105,13 +105,7 @@ First step is to install the package:
 make install
 ```
 
-And then run the tests:
-
-```sh
-make test
-```
-
-To run the full test coverage:
+To run the full test coverage, with run both unit tests and integration tests:
 
 ```sh
 make test-coverage


### PR DESCRIPTION
Now that `make test-coverage` includes both unit and integration tests (thanks to #1055) 

We no longer need to specify`make test` individually