### PR TITLE
Fix Install Issues with `docutils = 0.21.post1` and exclude 3.12 from supported python dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3058,10 +3058,7 @@ files = [
 [package.dependencies]
 annotated-types = ">=0.4.0"
 pydantic-core = "2.20.1"
-typing-extensions = [
-    {version = ">=4.6.1", markers = "python_version < \"3.13\""},
-    {version = ">=4.12.2", markers = "python_version >= \"3.13\""},
-]
+typing-extensions = {version = ">=4.6.1", markers = "python_version < \"3.13\""}
 
 [package.extras]
 email = ["email-validator (>=2.0.0)"]
@@ -4578,5 +4575,5 @@ zstandard = ["zstandard"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.8, <4.0, !=3.9.7"
-content-hash = "dd6a632537362646d6836d6df3b760263a6882ec9a11cae75e61c8386d34994d"
+python-versions = ">=3.8, <3.12, !=3.9.7"
+content-hash = "4cdc5aec21e4d18b1934406a3a8857555ba6b0d723681216423c74049630fd96"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.8, <4.0, !=3.9.7"
+python = ">=3.8, <3.12, !=3.9.7"
 mmh3 = ">=4.0.0,<5.0.0"
 requests = ">=2.20.0,<3.0.0"
 click = ">=7.1.1,<9.0.0"
@@ -94,7 +94,7 @@ pytest-mock = "3.14.0"
 pyspark = "3.5.2"
 cython = "3.0.11"
 deptry = ">=0.14,<0.20"
-docutils = "!=0.21"
+docutils = "!=0.21.post1"   # https://github.com/python-poetry/poetry/issues/9248#issuecomment-2026240520
 
 [[tool.mypy.overrides]]
 module = "pytest_mock.*"


### PR DESCRIPTION
Currently, when users try to install using poetry with python3.12, they run into the following error:

```
  - Installing numpy (1.24.4): Failed

  ChefBuildError

  Backend 'setuptools.build_meta:__legacy__' is not available.

  Cannot import 'setuptools.build_meta'

  at venv/lib/python3.12/site-packages/poetry/installation/chef.py:164 in _prepare
      160│
      161│                 error = ChefBuildError("\n\n".join(message_parts))
      162│
      163│             if error is not None:
    → 164│                 raise error from None
      165│
      166│             return path
      167│
      168│     def _prepare_sdist(self, archive: Path, destination: Path | None = None) -> Path:

Note: This error originates from the build backend, and is likely not a problem with poetry but with numpy (1.24.4) not supporting PEP 517 builds. You can verify this by running 'pip wheel --no-cache-dir --use-pep517 "numpy (==1.24.4)"'.
```

The proposed solution excludes 3.12 from the supported versions in the dependencies, so that poetry will attempt to find a compatible python version to install the dependencies instead.
```
The currently activated Python version 3.12.4 is not supported by the project (>=3.8, <3.12, !=3.9.7).
Trying to find and use a compatible version. 
Using python3.8 (3.8.19)
```
