### PR TITLE
Update create table doc to clarify ID re-assignment

### DIFF
--- a/mkdocs/docs/api.md
+++ b/mkdocs/docs/api.md
@@ -146,6 +146,8 @@ catalog.create_table(
 )
 ```
 
+When the table is created, all IDs in the schema are re-assigned to ensure uniqueness.
+
 To create a table using a pyarrow schema:
 
 ```python


### PR DESCRIPTION
Copying over a similar sentence from the Java docs: https://iceberg.apache.org/docs/1.5.1/java-api-quickstart/#create-a-schema. Based on my reading of the catalog code, this is true as all the `create_table` implementations end up calling `assign_fresh_schema_ids`, `assign_fresh_partition_spec_ids`, and `assign_fresh_sort_order_ids`.

This is useful to understand so newcomers don't have to worry about ID management in any new schemas they are sending into `create_table`.