### PR TITLE
Fix `table_exists` behavior in REST catalog

### DIFF
--- a/pyiceberg/catalog/rest.py
+++ b/pyiceberg/catalog/rest.py
@@ -834,4 +834,15 @@ class RestCatalog(Catalog):
         response = self._session.head(
             self.url(Endpoints.load_table, prefixed=True, **self._split_identifier_for_path(identifier_tuple))
         )
-        return response.status_code in (200, 204)
+
+        if response.status_code == 404:
+            return False
+        elif response.status_code == 204:
+            return True
+
+        try:
+            response.raise_for_status()
+        except HTTPError as exc:
+            self._handle_non_200_response(exc, {})
+
+        return False


### PR DESCRIPTION
I understand that it might seem odd to return false for a 200 status code, but according to the [specification](https://github.com/apache/iceberg/blob/97e034b2cec9408a6f792c410a8eb8dddb452e14/open-api/rest-catalog-open-api.yaml#L833-L864), success should only be indicated by a 204 status code. Additionally, it doesn’t make sense to throw an exception for a 404 status code since a table_exists method is expected to return True or False, not just True or an exception.

If a user needs to handle exceptions, they can use the load_table method, which will return an exception if the table does not exist.

Solves: #1018 