### PR TITLE
Bug Fix: Position Deletes + row_filter yields less data when the DataFile is large

### DIFF
--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -1243,6 +1243,7 @@ def _task_to_record_batches(
                 # Create the mask of indices that we're interested in
                 indices = _combine_positional_deletes(positional_deletes, current_index, current_index + len(batch))
                 batch = batch.take(indices)
+                output_batches = iter([batch])
 
                 # Apply the user filter
                 if pyarrow_filter is not None:
@@ -1254,8 +1255,6 @@ def _task_to_record_batches(
                     if len(arrow_table) == 0:
                         continue
                     output_batches = arrow_table.to_batches()
-                else:
-                    output_batches = iter([batch])
             for output_batch in output_batches:
                 yield _to_requested_schema(
                     projected_schema,

--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -1238,10 +1238,12 @@ def _task_to_record_batches(
         for batch in batches:
             next_index = next_index + len(batch)
             current_index = next_index - len(batch)
+            output_batches = iter([batch])
             if positional_deletes:
                 # Create the mask of indices that we're interested in
                 indices = _combine_positional_deletes(positional_deletes, current_index, current_index + len(batch))
                 batch = batch.take(indices)
+
                 # Apply the user filter
                 if pyarrow_filter is not None:
                     # we need to switch back and forth between RecordBatch and Table
@@ -1251,10 +1253,17 @@ def _task_to_record_batches(
                     arrow_table = arrow_table.filter(pyarrow_filter)
                     if len(arrow_table) == 0:
                         continue
-                    batch = arrow_table.to_batches()[0]
-            yield _to_requested_schema(
-                projected_schema, file_project_schema, batch, downcast_ns_timestamp_to_us=True, use_large_types=use_large_types
-            )
+                    output_batches = arrow_table.to_batches()
+                else:
+                    output_batches = iter([batch])
+            for output_batch in output_batches:
+                yield _to_requested_schema(
+                    projected_schema,
+                    file_project_schema,
+                    output_batch,
+                    downcast_ns_timestamp_to_us=True,
+                    use_large_types=use_large_types,
+                )
 
 
 def _task_to_table(

--- a/tests/integration/test_deletes.py
+++ b/tests/integration/test_deletes.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint:disable=redefined-outer-name
+import random
 from datetime import datetime
 from typing import List
 
@@ -295,6 +296,9 @@ def test_delete_partitioned_table_positional_deletes_empty_batch(spark: SparkSes
 @pytest.mark.integration
 @pytest.mark.filterwarnings("ignore:Merge on read is not yet supported, falling back to copy-on-write")
 def test_read_table_with_multiple_files_with_position_deletes(spark: SparkSession, session_catalog: RestCatalog) -> None:
+    # reproducible random sample
+    random.seed(42)
+
     identifier = "default.test_read_table_with_multiple_files_with_position_deletes"
 
     run_spark_commands(
@@ -303,6 +307,7 @@ def test_read_table_with_multiple_files_with_position_deletes(spark: SparkSessio
             f"DROP TABLE IF EXISTS {identifier}",
             f"""
             CREATE TABLE {identifier} (
+                id                  int,
                 number              int
             )
             USING iceberg
@@ -319,44 +324,44 @@ def test_read_table_with_multiple_files_with_position_deletes(spark: SparkSessio
 
     tbl = session_catalog.load_table(identifier)
 
-    arrow_table = pa.Table.from_arrays(
-        [
-            pa.array(list(range(100))),
-        ],
-        schema=pa.schema([pa.field("number", pa.int32())]),
-    )
+    # repeat adds and positional deletes few times, checking the filtered count each time
+    for _ in range(3):
+        arrow_table = pa.Table.from_arrays(
+            [
+                pa.array(list(range(1, 101))),
+                pa.array(random.sample(range(1, 101), 100)),
+            ],
+            schema=pa.schema([pa.field("id", pa.int32()), pa.field("number", pa.int32())]),
+        )
 
-    # commit 10 times
-    for _ in range(10):
-        tbl.append(arrow_table)
+        # commit 5 times
+        for _ in range(5):
+            tbl.append(arrow_table)
 
-    assert len(tbl.scan().to_arrow()) == 10 * 100
+        run_spark_commands(
+            spark,
+            [
+                # Generate positional deletes
+                f"""
+                DELETE FROM {identifier} WHERE number in (10, 5, 99)
+            """,
+                f"""
+                DELETE FROM {identifier} WHERE number in (9, 60)
+            """,
+            ],
+        )
 
-    run_spark_commands(
-        spark,
-        [
-            # Generate a positional delete
-            f"""
-            DELETE FROM {identifier} WHERE number = 10
-        """,
-        ],
-    )
-    # Assert that there is just a single Parquet file, that has one merge on read file
-    tbl = tbl.refresh()
+        tbl = tbl.refresh()
 
-    files = list(tbl.scan().plan_files())
-    assert len(files) == 10
-    assert len(files[0].delete_files) == 1
+        total_count = spark.sql(f"SELECT count(1) as total_count from {identifier}").first()[0]
+        assert len(tbl.scan().to_arrow()) == total_count
 
-    assert len(tbl.scan().to_arrow()) == 10 * 99
+        assert len(tbl.scan(row_filter="number == 10").to_arrow()) == 0
 
-    assert len(tbl.scan(row_filter="number == 10").to_arrow()) == 0
-
-    assert len(tbl.scan(row_filter="number == 1").to_arrow()) == 10
-
-    reader = tbl.scan(row_filter="number == 1").to_arrow_batch_reader()
-    assert isinstance(reader, pa.RecordBatchReader)
-    assert len(reader.read_all()) == 10
+        filtered_count = spark.sql(f"SELECT count(1) as total_count from {identifier} WHERE number < 11").first()[0]
+        reader = tbl.scan(row_filter="number < 40").to_arrow_batch_reader()
+        assert isinstance(reader, pa.RecordBatchReader)
+        assert len(reader.read_all()) == filtered_count
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Fixes: #1132 

Culprit was the awkward zero-copy pass back and forth between RecordBatch and Table to filter by pyarrow_filter.

https://github.com/apache/iceberg-python/blob/0dc54080aa287dc8e920da128d7f4b335965f1df/pyiceberg/io/pyarrow.py#L1246-L1254

As noted, this is necessary because passing an expression filter to a RecordBatch hasn't yet been exposed (it is now in 17.0.0, but that would raise the lower limit of PyArrow dependency that much higher).

In cases where a single RecordBatch -> a Table -> multiple RecordBatches because of how Arrow automatically chunks a Table into multiple RecordBatches, we would lose the remaining RecordBatches in the returned output. Essentially, there's no guarantee that a single RecordBatch will remain a single one in a round trip conversion to Arrow Table, and back.

The new test covers a case where the amount of data within a DataFile is large enough for the arrow Table yields multiple RecordBatch