### PR TITLE
fix: Invert `case_sensitive` logic in StructType

### DIFF
--- a/pyiceberg/types.py
+++ b/pyiceberg/types.py
@@ -377,13 +377,13 @@ class StructType(IcebergType):
 
     def field_by_name(self, name: str, case_sensitive: bool = True) -> Optional[NestedField]:
         if case_sensitive:
+            for field in self.fields:
+                if field.name == name:
+                    return field
+        else:
             name_lower = name.lower()
             for field in self.fields:
                 if field.name.lower() == name_lower:
-                    return field
-        else:
-            for field in self.fields:
-                if field.name == name:
                     return field
         return None
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -148,6 +148,18 @@ def test_struct_type() -> None:
     assert type_var != StructType(NestedField(1, "optional_field", IntegerType(), required=True))
     assert type_var == pickle.loads(pickle.dumps(type_var))
 
+def test_struct_field_by_name() -> None:
+    lower_field = NestedField(1, "lower_case_field", IntegerType(), required=True),
+    upper_field = NestedField(2, "UPPER_CASE_FIELD", IntegerType(), required=True),
+    type_var = StructType(lower_field, upper_field, mixed_field)
+
+    assert type_var.field_by_name("lower_case_field", case_sensitive=False) == lower_field
+    assert type_var.field_by_name("upper_case_field", case_sensitive=False) == upper_field
+    assert type_var.field_by_name("nonexistent_field", case_sensitive=False) is None
+
+    assert type_var.field_by_name("lower_case_field", case_sensitive=True) == lower_field
+    assert type_var.field_by_name("upper_case_field", case_sensitive=True) is None
+    assert type_var.field_by_name("nonexistent_field", case_sensitive=True) is None
 
 def test_list_type() -> None:
     type_var = ListType(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -148,9 +148,10 @@ def test_struct_type() -> None:
     assert type_var != StructType(NestedField(1, "optional_field", IntegerType(), required=True))
     assert type_var == pickle.loads(pickle.dumps(type_var))
 
+
 def test_struct_field_by_name() -> None:
-    lower_field = NestedField(1, "lower_case_field", IntegerType(), required=True),
-    upper_field = NestedField(2, "UPPER_CASE_FIELD", IntegerType(), required=True),
+    lower_field = NestedField(1, "lower_case_field", IntegerType(), required=True)
+    upper_field = NestedField(2, "UPPER_CASE_FIELD", IntegerType(), required=True)
     type_var = StructType(lower_field, upper_field)
 
     assert type_var.field_by_name("lower_case_field", case_sensitive=False) == lower_field
@@ -160,6 +161,7 @@ def test_struct_field_by_name() -> None:
     assert type_var.field_by_name("lower_case_field", case_sensitive=True) == lower_field
     assert type_var.field_by_name("upper_case_field", case_sensitive=True) is None
     assert type_var.field_by_name("nonexistent_field", case_sensitive=True) is None
+
 
 def test_list_type() -> None:
     type_var = ListType(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -151,7 +151,7 @@ def test_struct_type() -> None:
 def test_struct_field_by_name() -> None:
     lower_field = NestedField(1, "lower_case_field", IntegerType(), required=True),
     upper_field = NestedField(2, "UPPER_CASE_FIELD", IntegerType(), required=True),
-    type_var = StructType(lower_field, upper_field, mixed_field)
+    type_var = StructType(lower_field, upper_field)
 
     assert type_var.field_by_name("lower_case_field", case_sensitive=False) == lower_field
     assert type_var.field_by_name("upper_case_field", case_sensitive=False) == upper_field


### PR DESCRIPTION
The `field_by_name` method in `StructType` seems to have inverted logic on the `case_sensitive` parameter.