### PR TITLE
Preserve Backward compatibility in 0.8.0 for #1144

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -106,8 +106,15 @@ from pyiceberg.table.update import (
     UpgradeFormatVersionUpdate,
     update_table_metadata,
 )
-from pyiceberg.table.update.schema import UpdateSchema
-from pyiceberg.table.update.snapshot import ManageSnapshots, UpdateSnapshot
+from pyiceberg.table.update.schema import UpdateSchema, _Move, _MoveOperation
+from pyiceberg.table.update.snapshot import (
+    ManageSnapshots,
+    UpdateSnapshot,
+    _DeleteFiles,
+    _FastAppendFiles,
+    _MergeAppendFiles,
+    _OverwriteFiles,
+)
 from pyiceberg.table.update.spec import UpdateSpec
 from pyiceberg.typedef import (
     EMPTY_DICT,
@@ -1464,3 +1471,57 @@ def _parquet_files_to_data_files(table_metadata: TableMetadata, file_paths: List
     from pyiceberg.io.pyarrow import parquet_files_to_data_files
 
     yield from parquet_files_to_data_files(io=io, table_metadata=table_metadata, file_paths=iter(file_paths))
+
+
+@deprecated(
+    deprecated_in="0.8.0",
+    removed_in="0.9.0",
+    help_message="pyiceberg.table.Move has been changed to private class pyiceberg.table.update.schema._Move",
+)
+def Move(*args: Any, **kwargs: Any) -> _Move:
+    return _Move(*args, **kwargs)
+
+
+@deprecated(
+    deprecated_in="0.8.0",
+    removed_in="0.9.0",
+    help_message="pyiceberg.table.MoveOperation has been changed to private class pyiceberg.table.update.schema._MoveOperation",
+)
+def MoveOperation(*args: Any, **kwargs: Any) -> _MoveOperation:
+    return _MoveOperation(*args, **kwargs)
+
+
+@deprecated(
+    deprecated_in="0.8.0",
+    removed_in="0.9.0",
+    help_message="pyiceberg.table.DeleteFiles has been changed to private class pyiceberg.table.update.snapshot._DeleteFiles",
+)
+def DeleteFiles(*args: Any, **kwargs: Any) -> _DeleteFiles:
+    return _DeleteFiles(*args, **kwargs)
+
+
+@deprecated(
+    deprecated_in="0.8.0",
+    removed_in="0.9.0",
+    help_message="pyiceberg.table.FastAppendFiles has been changed to private class pyiceberg.table.update.snapshot._FastAppendFiles",
+)
+def FastAppendFiles(*args: Any, **kwargs: Any) -> _FastAppendFiles:
+    return _FastAppendFiles(*args, **kwargs)
+
+
+@deprecated(
+    deprecated_in="0.8.0",
+    removed_in="0.9.0",
+    help_message="pyiceberg.table.MergeAppendFiles has been changed to private class pyiceberg.table.update.snapshot._MergeAppendFiles",
+)
+def MergeAppendFiles(*args: Any, **kwargs: Any) -> _MergeAppendFiles:
+    return _MergeAppendFiles(*args, **kwargs)
+
+
+@deprecated(
+    deprecated_in="0.8.0",
+    removed_in="0.9.0",
+    help_message="pyiceberg.table.OverwriteFiles has been changed to private class pyiceberg.table.update.snapshot._OverwriteFiles",
+)
+def OverwriteFiles(*args: Any, **kwargs: Any) -> _OverwriteFiles:
+    return _OverwriteFiles(*args, **kwargs)

--- a/tests/table/test_init.py
+++ b/tests/table/test_init.py
@@ -1243,3 +1243,18 @@ def test_update_metadata_log_overflow(table_v2: Table) -> None:
         table_v2.metadata_location,
     )
     assert len(new_metadata.metadata_log) == 1
+
+
+def test_table_module_refactoring_backward_compatibility() -> None:
+    # TODO: Remove this in 0.9.0
+    try:
+        from pyiceberg.table import (  # noqa: F401
+            DeleteFiles,
+            FastAppendFiles,
+            MergeAppendFiles,
+            Move,
+            MoveOperation,
+            OverwriteFiles,
+        )
+    except Exception as exc:
+        raise pytest.fail("Importing moved modules should not raise an exception") from exc


### PR DESCRIPTION
In #1144, we moved 'public' classes and functions to submodules.

Although 'public' by naming convention, these classes and functions are meant for internal use. The current lack of explicit external API declarations makes it difficult to communicate with our end-users, which classes and functions we are intending to support for external use. (https://github.com/apache/iceberg-python/issues/1099)

The classes that were moved and are not referenced as an import in `pyiceberg.table` module are as follows:
- Move
- MoveOperation
- DeleteFiles
- FastAppendFiles
- MergeAppendFiles
- OverwriteFiles
- UpdateTableMetadata

UpdateTableMetadata is an abstract base class, and hence cannot be used directly.

This PR proposed to rename these as 'private' classes with single underscore prefix, and introduces functions that return these classes with a deprecation warning. This will allow users who are for some reason using these classes to see the warnings and update their code to not use these classes anymore.

Thanks @kevinjqliu for flagging this as a potential issue for backward compatibility.