### PR TITLE
fix: remove old, incorrect docstring

### DIFF
--- a/pyiceberg/catalog/__init__.py
+++ b/pyiceberg/catalog/__init__.py
@@ -564,8 +564,6 @@ class Catalog(ABC):
     def list_tables(self, namespace: Union[str, Identifier]) -> List[Identifier]:
         """List tables under the given namespace in the catalog.
 
-        If namespace not provided, will list all tables in the catalog.
-
         Args:
             namespace (str | Identifier): Namespace identifier to search.
 


### PR DESCRIPTION
resolves: #1163

remove this line. no additions necessary as other `Catalog` method's don't have additional context in the docstring beyond docmenting the signature