### PR TITLE
Revert "Cache Manifest files"

### DIFF
--- a/pyiceberg/table/snapshots.py
+++ b/pyiceberg/table/snapshots.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import time
 from collections import defaultdict
 from enum import Enum
-from functools import lru_cache
 from typing import TYPE_CHECKING, Any, DefaultDict, Dict, Iterable, List, Mapping, Optional
 
 from pydantic import Field, PrivateAttr, model_serializer
@@ -231,13 +230,6 @@ class Summary(IcebergBaseModel, Mapping[str, str]):
         )
 
 
-@lru_cache
-def _manifests(io: FileIO, manifest_list: str) -> List[ManifestFile]:
-    """Return the manifests from the manifest list."""
-    file = io.new_input(manifest_list)
-    return list(read_manifest_list(file))
-
-
 class Snapshot(IcebergBaseModel):
     snapshot_id: int = Field(alias="snapshot-id")
     parent_snapshot_id: Optional[int] = Field(alias="parent-snapshot-id", default=None)
@@ -258,9 +250,9 @@ class Snapshot(IcebergBaseModel):
         return result_str
 
     def manifests(self, io: FileIO) -> List[ManifestFile]:
-        """Return the manifests for the given snapshot."""
-        if self.manifest_list:
-            return _manifests(io, self.manifest_list)
+        if self.manifest_list is not None:
+            file = io.new_input(self.manifest_list)
+            return list(read_manifest_list(file))
         return []
 
 


### PR DESCRIPTION
Reverts #787
Closes #1162

Integration tests (`make test-integration`) fail when this commit, but only for M1 Mac. 
* See #1162. Another user reported issue when running with M1 Mac.
* [kevinjqliu/iceberg-python/#5](https://github.com/kevinjqliu/iceberg-python/pull/5) ran integration test against none M1 macs (Github Action `macos-12, macos-13`) and test succeeded.

Integration tests pass 100% with the commit reverted

Error log: 
* https://gist.github.com/kevinjqliu/c8310b6253beab52cce93391df03bfe4
* https://gist.github.com/kevinjqliu/a0e8e2199bd8064757eb2b40409e0794

