### PR TITLE
[CI] Run on different platforms (ubuntu/windows/mac/mac m1)

### DIFF
--- a/.github/workflows/python-integration.yml
+++ b/.github/workflows/python-integration.yml
@@ -42,6 +42,7 @@ jobs:
       with:
         fetch-depth: 2
     - name: Setup Docker on macOS
+      if: startsWith(matrix.os, 'macos')
       uses: douglascamata/setup-docker-macos-action@v1-alpha
     - name: Install
       run: make install

--- a/.github/workflows/python-integration.yml
+++ b/.github/workflows/python-integration.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-22.04, windows-2022, macos-12, macos-13 ]
+        os: [ ubuntu-22.04, macos-12, macos-13 ]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-integration.yml
+++ b/.github/workflows/python-integration.yml
@@ -41,6 +41,8 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 2
+    - name: Setup Docker on macOS
+      uses: douglascamata/setup-docker-macos-action@v1-alpha
     - name: Install
       run: make install
     - name: Run integration tests

--- a/.github/workflows/python-integration.yml
+++ b/.github/workflows/python-integration.yml
@@ -31,7 +31,11 @@ concurrency:
 
 jobs:
   integration-test:
-    runs-on: ubuntu-20.04
+    name: Run integration test on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-22.04, windows-2022, macos-12, macos-13, macos-14 ]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-integration.yml
+++ b/.github/workflows/python-integration.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-22.04, windows-2022, macos-12, macos-13, macos-14 ]
+        os: [ ubuntu-22.04, windows-2022, macos-12, macos-13 ]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
[Types of VM on Github Actions](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#standard-github-hosted-runners-for-public-repositories)

Github Marketplace Action for "docker on macos", [Setup Docker on macOS](https://github.com/marketplace/actions/setup-docker-on-macos)
* Does not currently work on `macos-14` / M-series mac
* [Cannot run on the apache repo](https://github.com/apache/iceberg-python/actions/runs/10843722745) since the action is [not "verified"](https://github.com/douglascamata/setup-docker-macos-action/issues/36). Needs to be allowlisted to use. Can run in private fork (https://github.com/kevinjqliu/iceberg-python/pull/5).



