### PR TITLE
fix: support MonthTransform for partitioning

### DIFF
--- a/pyiceberg/partitioning.py
+++ b/pyiceberg/partitioning.py
@@ -46,6 +46,7 @@ from pyiceberg.transforms import (
     DayTransform,
     HourTransform,
     IdentityTransform,
+    MonthTransform,
     Transform,
     TruncateTransform,
     UnknownTransform,
@@ -359,6 +360,8 @@ def _visit_partition_field(schema: Schema, field: PartitionField, visitor: Parti
         return visitor.day(field.field_id, source_name, field.source_id)
     elif isinstance(transform, HourTransform):
         return visitor.hour(field.field_id, source_name, field.source_id)
+    elif isinstance(transform, MonthTransform):
+        return visitor.month(field.field_id, source_name, field.source_id)
     elif isinstance(transform, YearTransform):
         return visitor.year(field.field_id, source_name, field.source_id)
     elif isinstance(transform, VoidTransform):

--- a/tests/integration/test_partition_evolution.py
+++ b/tests/integration/test_partition_evolution.py
@@ -115,6 +115,7 @@ def test_add_month_generates_default_name(catalog: Catalog) -> None:
     table.update_spec().add_field("event_ts", MonthTransform()).commit()
     _validate_new_partition_fields(table, 1000, 1, 1000, PartitionField(2, 1000, MonthTransform(), "event_ts_month"))
 
+
 @pytest.mark.integration
 @pytest.mark.parametrize("catalog", [pytest.lazy_fixture("session_catalog_hive"), pytest.lazy_fixture("session_catalog")])
 def test_add_day(catalog: Catalog) -> None:
@@ -178,9 +179,7 @@ def test_add_truncate(catalog: Catalog, table_schema_simple: Schema) -> None:
 def test_add_truncate_generates_default_name(catalog: Catalog, table_schema_simple: Schema) -> None:
     simple_table = _create_table_with_schema(catalog, table_schema_simple, "1")
     simple_table.update_spec().add_field("foo", TruncateTransform(1)).commit()
-    _validate_new_partition_fields(
-        simple_table, 1000, 1, 1000, PartitionField(1, 1000, TruncateTransform(1), "foo_trunc_1")
-    )
+    _validate_new_partition_fields(simple_table, 1000, 1, 1000, PartitionField(1, 1000, TruncateTransform(1), "foo_trunc_1"))
 
 
 @pytest.mark.integration
@@ -206,9 +205,7 @@ def test_multiple_adds(catalog: Catalog) -> None:
 def test_add_void(catalog: Catalog, table_schema_simple: Schema) -> None:
     simple_table = _create_table_with_schema(catalog, table_schema_simple, "1")
     simple_table.update_spec().add_field("foo", VoidTransform(), "void_transform").commit()
-    _validate_new_partition_fields(
-        simple_table, 1000, 1, 1000, PartitionField(1, 1000, VoidTransform(), "void_transform")
-    )
+    _validate_new_partition_fields(simple_table, 1000, 1, 1000, PartitionField(1, 1000, VoidTransform(), "void_transform"))
 
 
 @pytest.mark.integration
@@ -216,9 +213,7 @@ def test_add_void(catalog: Catalog, table_schema_simple: Schema) -> None:
 def test_add_void_generates_default_name(catalog: Catalog, table_schema_simple: Schema) -> None:
     simple_table = _create_table_with_schema(catalog, table_schema_simple, "1")
     simple_table.update_spec().add_field("foo", VoidTransform()).commit()
-    _validate_new_partition_fields(
-        simple_table, 1000, 1, 1000, PartitionField(1, 1000, VoidTransform(), "foo_null")
-    )
+    _validate_new_partition_fields(simple_table, 1000, 1, 1000, PartitionField(1, 1000, VoidTransform(), "foo_null"))
 
 
 @pytest.mark.integration

--- a/tests/integration/test_partition_evolution.py
+++ b/tests/integration/test_partition_evolution.py
@@ -223,16 +223,6 @@ def test_add_void_generates_default_name(catalog: Catalog, table_schema_simple: 
 
 @pytest.mark.integration
 @pytest.mark.parametrize("catalog", [pytest.lazy_fixture("session_catalog_hive"), pytest.lazy_fixture("session_catalog")])
-def test_add_truncate_generates_default_name(catalog: Catalog, table_schema_simple: Schema) -> None:
-    simple_table = _create_table_with_schema(catalog, table_schema_simple, "1")
-    simple_table.update_spec().add_field("foo", TruncateTransform(1)).commit()
-    _validate_new_partition_fields(
-        simple_table, 1000, 1, 1000, PartitionField(1, 1000, TruncateTransform(1), "foo_trunc_1")
-    )
-
-
-@pytest.mark.integration
-@pytest.mark.parametrize("catalog", [pytest.lazy_fixture("session_catalog_hive"), pytest.lazy_fixture("session_catalog")])
 def test_add_hour_to_day(catalog: Catalog) -> None:
     table = _table(catalog)
     table.update_spec().add_field("event_ts", DayTransform(), "daily_partitioned").commit()

--- a/tests/integration/test_partition_evolution.py
+++ b/tests/integration/test_partition_evolution.py
@@ -94,6 +94,14 @@ def test_add_year(catalog: Catalog) -> None:
 
 @pytest.mark.integration
 @pytest.mark.parametrize("catalog", [pytest.lazy_fixture("session_catalog_hive"), pytest.lazy_fixture("session_catalog")])
+def test_add_year_generates_default_name(catalog: Catalog) -> None:
+    table = _table(catalog)
+    table.update_spec().add_field("event_ts", YearTransform()).commit()
+    _validate_new_partition_fields(table, 1000, 1, 1000, PartitionField(2, 1000, YearTransform(), "event_ts_year"))
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("catalog", [pytest.lazy_fixture("session_catalog_hive"), pytest.lazy_fixture("session_catalog")])
 def test_add_month(catalog: Catalog) -> None:
     table = _table(catalog)
     table.update_spec().add_field("event_ts", MonthTransform(), "month_transform").commit()
@@ -117,10 +125,26 @@ def test_add_day(catalog: Catalog) -> None:
 
 @pytest.mark.integration
 @pytest.mark.parametrize("catalog", [pytest.lazy_fixture("session_catalog_hive"), pytest.lazy_fixture("session_catalog")])
+def test_add_day_generates_default_name(catalog: Catalog) -> None:
+    table = _table(catalog)
+    table.update_spec().add_field("event_ts", DayTransform()).commit()
+    _validate_new_partition_fields(table, 1000, 1, 1000, PartitionField(2, 1000, DayTransform(), "event_ts_day"))
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("catalog", [pytest.lazy_fixture("session_catalog_hive"), pytest.lazy_fixture("session_catalog")])
 def test_add_hour(catalog: Catalog) -> None:
     table = _table(catalog)
     table.update_spec().add_field("event_ts", HourTransform(), "hour_transform").commit()
     _validate_new_partition_fields(table, 1000, 1, 1000, PartitionField(2, 1000, HourTransform(), "hour_transform"))
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("catalog", [pytest.lazy_fixture("session_catalog_hive"), pytest.lazy_fixture("session_catalog")])
+def test_add_hour_generates_default_name(catalog: Catalog) -> None:
+    table = _table(catalog)
+    table.update_spec().add_field("event_ts", HourTransform()).commit()
+    _validate_new_partition_fields(table, 1000, 1, 1000, PartitionField(2, 1000, HourTransform(), "event_ts_hour"))
 
 
 @pytest.mark.integration
@@ -133,11 +157,29 @@ def test_add_bucket(catalog: Catalog, table_schema_simple: Schema) -> None:
 
 @pytest.mark.integration
 @pytest.mark.parametrize("catalog", [pytest.lazy_fixture("session_catalog_hive"), pytest.lazy_fixture("session_catalog")])
+def test_add_bucket_generates_default_name(catalog: Catalog, table_schema_simple: Schema) -> None:
+    simple_table = _create_table_with_schema(catalog, table_schema_simple, "1")
+    simple_table.update_spec().add_field("foo", BucketTransform(12)).commit()
+    _validate_new_partition_fields(simple_table, 1000, 1, 1000, PartitionField(1, 1000, BucketTransform(12), "foo_bucket_12"))
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("catalog", [pytest.lazy_fixture("session_catalog_hive"), pytest.lazy_fixture("session_catalog")])
 def test_add_truncate(catalog: Catalog, table_schema_simple: Schema) -> None:
     simple_table = _create_table_with_schema(catalog, table_schema_simple, "1")
     simple_table.update_spec().add_field("foo", TruncateTransform(1), "truncate_transform").commit()
     _validate_new_partition_fields(
         simple_table, 1000, 1, 1000, PartitionField(1, 1000, TruncateTransform(1), "truncate_transform")
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("catalog", [pytest.lazy_fixture("session_catalog_hive"), pytest.lazy_fixture("session_catalog")])
+def test_add_truncate_generates_default_name(catalog: Catalog, table_schema_simple: Schema) -> None:
+    simple_table = _create_table_with_schema(catalog, table_schema_simple, "1")
+    simple_table.update_spec().add_field("foo", TruncateTransform(1)).commit()
+    _validate_new_partition_fields(
+        simple_table, 1000, 1, 1000, PartitionField(1, 1000, TruncateTransform(1), "foo_trunc_1")
     )
 
 
@@ -156,6 +198,36 @@ def test_multiple_adds(catalog: Catalog) -> None:
         PartitionField(1, 1000, IdentityTransform(), "id"),
         PartitionField(2, 1001, HourTransform(), "hourly_partitioned"),
         PartitionField(3, 1002, TruncateTransform(2), "truncate_str"),
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("catalog", [pytest.lazy_fixture("session_catalog_hive"), pytest.lazy_fixture("session_catalog")])
+def test_add_void(catalog: Catalog, table_schema_simple: Schema) -> None:
+    simple_table = _create_table_with_schema(catalog, table_schema_simple, "1")
+    simple_table.update_spec().add_field("foo", VoidTransform(), "void_transform").commit()
+    _validate_new_partition_fields(
+        simple_table, 1000, 1, 1000, PartitionField(1, 1000, VoidTransform(), "void_transform")
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("catalog", [pytest.lazy_fixture("session_catalog_hive"), pytest.lazy_fixture("session_catalog")])
+def test_add_void_generates_default_name(catalog: Catalog, table_schema_simple: Schema) -> None:
+    simple_table = _create_table_with_schema(catalog, table_schema_simple, "1")
+    simple_table.update_spec().add_field("foo", VoidTransform()).commit()
+    _validate_new_partition_fields(
+        simple_table, 1000, 1, 1000, PartitionField(1, 1000, VoidTransform(), "foo_null")
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("catalog", [pytest.lazy_fixture("session_catalog_hive"), pytest.lazy_fixture("session_catalog")])
+def test_add_truncate_generates_default_name(catalog: Catalog, table_schema_simple: Schema) -> None:
+    simple_table = _create_table_with_schema(catalog, table_schema_simple, "1")
+    simple_table.update_spec().add_field("foo", TruncateTransform(1)).commit()
+    _validate_new_partition_fields(
+        simple_table, 1000, 1, 1000, PartitionField(1, 1000, TruncateTransform(1), "foo_trunc_1")
     )
 
 

--- a/tests/integration/test_partition_evolution.py
+++ b/tests/integration/test_partition_evolution.py
@@ -102,6 +102,13 @@ def test_add_month(catalog: Catalog) -> None:
 
 @pytest.mark.integration
 @pytest.mark.parametrize("catalog", [pytest.lazy_fixture("session_catalog_hive"), pytest.lazy_fixture("session_catalog")])
+def test_add_month_generates_default_name(catalog: Catalog) -> None:
+    table = _table(catalog)
+    table.update_spec().add_field("event_ts", MonthTransform()).commit()
+    _validate_new_partition_fields(table, 1000, 1, 1000, PartitionField(2, 1000, MonthTransform(), "event_ts_month"))
+
+@pytest.mark.integration
+@pytest.mark.parametrize("catalog", [pytest.lazy_fixture("session_catalog_hive"), pytest.lazy_fixture("session_catalog")])
 def test_add_day(catalog: Catalog) -> None:
     table = _table(catalog)
     table.update_spec().add_field("event_ts", DayTransform(), "day_transform").commit()


### PR DESCRIPTION
Hi, 
this is fixing a minor bug where partition evolution in combination with a `MonthTransform` could raise an exception:  https://github.com/apache/iceberg-python/issues/1156
