### PR TITLE
Use ArrowScan.to_table to replace project_table

### DIFF
--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -1379,6 +1379,7 @@ class ArrowScan:
             if not isinstance(self._projected_schema.find_type(id), (MapType, ListType))
         }.union(extract_field_ids(self._bound_row_filter))
 
+
     def to_table(self, tasks: Iterable[FileScanTask]) -> pa.Table:
         """Scan the Iceberg table and return a pa.Table.
 

--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -1379,7 +1379,6 @@ class ArrowScan:
             if not isinstance(self._projected_schema.find_type(id), (MapType, ListType))
         }.union(extract_field_ids(self._bound_row_filter))
 
-
     def to_table(self, tasks: Iterable[FileScanTask]) -> pa.Table:
         """Scan the Iceberg table and return a pa.Table.
 

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -523,9 +523,9 @@ class Transaction:
             snapshot_properties: Custom properties to be added to the snapshot summary
         """
         from pyiceberg.io.pyarrow import (
+            ArrowScan,
             _dataframe_to_data_files,
             _expression_to_complementary_pyarrow,
-            ArrowScan,
         )
 
         if (
@@ -564,9 +564,7 @@ class Transaction:
                     io=self._table.io,
                     projected_schema=self.table_metadata.schema(),
                     row_filter=AlwaysTrue(),
-                ).to_table(
-                    tasks=[original_file]
-                )
+                ).to_table(tasks=[original_file])
                 filtered_df = df.filter(preserve_row_filter)
 
                 # Only rewrite if there are records being deleted

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -525,7 +525,7 @@ class Transaction:
         from pyiceberg.io.pyarrow import (
             _dataframe_to_data_files,
             _expression_to_complementary_pyarrow,
-            project_table,
+            ArrowScan,
         )
 
         if (
@@ -559,13 +559,12 @@ class Transaction:
             #   - Apply the latest partition-spec
             #   - And sort order when added
             for original_file in files:
-                df = project_table(
-                    tasks=[original_file],
+                df = ArrowScan(
                     table_metadata=self.table_metadata,
                     io=self._table.io,
-                    row_filter=AlwaysTrue(),
                     projected_schema=self.table_metadata.schema(),
-                )
+                    row_filter=AlwaysTrue(),
+                ).to_table([original_file])
                 filtered_df = df.filter(preserve_row_filter)
 
                 # Only rewrite if there are records being deleted

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -564,7 +564,9 @@ class Transaction:
                     io=self._table.io,
                     projected_schema=self.table_metadata.schema(),
                     row_filter=AlwaysTrue(),
-                ).to_table([original_file])
+                ).to_table(
+                    tasks=[original_file]
+                )
                 filtered_df = df.filter(preserve_row_filter)
 
                 # Only rewrite if there are records being deleted

--- a/tests/io/test_pyarrow.py
+++ b/tests/io/test_pyarrow.py
@@ -58,6 +58,7 @@ from pyiceberg.expressions.literals import literal
 from pyiceberg.io import InputStream, OutputStream, load_file_io
 from pyiceberg.io.pyarrow import (
     ICEBERG_SCHEMA,
+    ArrowScan,
     PyArrowFile,
     PyArrowFileIO,
     StatsAggregator,
@@ -69,7 +70,6 @@ from pyiceberg.io.pyarrow import (
     _to_requested_schema,
     bin_pack_arrow_table,
     expression_to_pyarrow,
-    ArrowScan,
     schema_to_pyarrow,
 )
 from pyiceberg.manifest import DataFile, DataFileContent, FileFormat
@@ -1424,9 +1424,7 @@ def test_delete(deletes_file: str, example_task: FileScanTask, table_schema_simp
         io=load_file_io(),
         projected_schema=table_schema_simple,
         row_filter=AlwaysTrue(),
-    ).to_table(
-        tasks=[example_task_with_delete]
-    )
+    ).to_table(tasks=[example_task_with_delete])
 
     assert (
         str(with_deletes)
@@ -1463,9 +1461,7 @@ def test_delete_duplicates(deletes_file: str, example_task: FileScanTask, table_
         io=load_file_io(),
         projected_schema=table_schema_simple,
         row_filter=AlwaysTrue(),
-    ).to_table(
-        tasks=[example_task_with_delete]
-    )
+    ).to_table(tasks=[example_task_with_delete])
 
     assert (
         str(with_deletes)
@@ -1496,9 +1492,7 @@ def test_pyarrow_wrap_fsspec(example_task: FileScanTask, table_schema_simple: Sc
         case_sensitive=True,
         projected_schema=table_schema_simple,
         row_filter=AlwaysTrue(),
-    ).to_table(
-        tasks=[example_task]
-    )
+    ).to_table(tasks=[example_task])
 
     assert (
         str(projection)


### PR DESCRIPTION
PR #1119 
- Use ArrowScan.to_table to replace project_table in these files: 
  - pyiceberg\table\__init__.py
  - pyiceberg\io\pyarrow.py
  - pyiceberg\test_pyarrow.py