### PR TITLE
Support for ns

### DIFF
--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -1077,8 +1077,6 @@ class _ConvertToIceberg(PyArrowSchemaVisitor[Union[IcebergType, Schema]]):
                     raise TypeError(
                         "Iceberg does not yet support 'ns' timestamp precision. Use 'downcast-ns-timestamp-to-us-on-write' configuration property to automatically downcast 'ns' to 'us' on write."
                     )
-            else:
-                raise TypeError(f"Unsupported precision for timestamp type: {primitive.unit}")
             return TimeType()
         
         elif pa.types.is_timestamp(primitive):

--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -1068,8 +1068,19 @@ class _ConvertToIceberg(PyArrowSchemaVisitor[Union[IcebergType, Schema]]):
             return StringType()
         elif pa.types.is_date32(primitive):
             return DateType()
-        elif isinstance(primitive, pa.Time64Type) and primitive.unit == "us":
+        elif isinstance(primitive, pa.Time64Type) and (primitive.unit == "us" or primitive.unit == "ns"):
+            primitive = cast(pa.TimestampType, primitive)
+            if primitive.unit == "ns":
+                if self._downcast_ns_timestamp_to_us:
+                    logger.warning("Iceberg does not yet support 'ns' timestamp precision. Downcasting to 'us'.")
+                else:
+                    raise TypeError(
+                        "Iceberg does not yet support 'ns' timestamp precision. Use 'downcast-ns-timestamp-to-us-on-write' configuration property to automatically downcast 'ns' to 'us' on write."
+                    )
+            else:
+                raise TypeError(f"Unsupported precision for timestamp type: {primitive.unit}")
             return TimeType()
+        
         elif pa.types.is_timestamp(primitive):
             primitive = cast(pa.TimestampType, primitive)
             if primitive.unit in ("s", "ms", "us"):


### PR DESCRIPTION
added support for ns and enabled downcasting similar to the similar to the ` pa.types.is_timestamp(primitive):`   ,  didn't enable upcasting as it wasn't mentioned in the issue