### PR TITLE
Support python 3.12 in poetry

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -69,7 +69,7 @@ jobs:
         env:
           # Ignore 32 bit architectures
           CIBW_ARCHS: "auto64"
-          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8,<=3.12"
+          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8,<3.13"
           CIBW_TEST_REQUIRES: "pytest==7.4.2 moto==5.0.1"
           CIBW_TEST_EXTRAS: "s3fs,glue"
           CIBW_TEST_COMMAND: "pytest {project}/tests/avro/test_decoder.py"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4649,5 +4649,5 @@ zstandard = ["zstandard"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.8, <3.12, !=3.9.7"
-content-hash = "415b57aefef279427e674d3d7fc58bc1d001c7fca2bfc346ec1c7af3bccfdc8d"
+python-versions = "^3.8, <3.13, !=3.9.7"
+content-hash = "086f6774fe006d24ded1141068f63f2aa22c356c75979b2b44781d43dc10d977"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.8, <3.12, !=3.9.7"
+python = "^3.8, <3.13, !=3.9.7"
 mmh3 = ">=4.0.0,<5.0.0"
 requests = ">=2.20.0,<3.0.0"
 click = ">=7.1.1,<9.0.0"


### PR DESCRIPTION
Allow python 3.12 to run poetry. 

Changed to use caret requirements, same logic. Greater than or equal to 3.8, less than 3.13 which is currently in pre-release.
Changed from `<=` to `<` because sometimes, `3.12.6` doesn't match `<= 3.12`, `<3.13` is fixes that

https://python-poetry.org/docs/dependency-specification/#caret-requirements
https://www.python.org/doc/versions/