### PR TITLE
[Doc] Remove the dead link to pass markdown link check

### DIFF
--- a/mkdocs/docs/contributing.md
+++ b/mkdocs/docs/contributing.md
@@ -42,7 +42,7 @@ To get started, you can run `make install`, which installs Poetry and all the de
 
 If you want to install the library on the host, you can simply run `pip3 install -e .`. If you wish to use a virtual environment, you can run `poetry shell`. Poetry will open up a virtual environment with all the dependencies set.
 
-To set up IDEA with Poetry ([also on Loom](https://www.loom.com/share/6d36464d45f244729d91003e7f671fd2)):
+To set up IDEA with Poetry:
 
 - Open up the Python project in IntelliJ
 - Make sure that you're on latest main (that includes Poetry)

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -853,7 +853,7 @@ class Table:
             row_filter:
                 A string or BooleanExpression that decsribes the
                 desired rows
-            selected_fileds:
+            selected_fields:
                 A tuple of strings representing the column names
                 to return in the output dataframe.
             case_sensitive:


### PR DESCRIPTION
This PR removes the dead link in `contributing.md` and make CI pass again.

It also fixes a typo that causing `mkdocs build --strict` fail with
```
WARNING -  griffe: .../pyiceberg/table/__init__.py:856: No type or annotation for parameter 'selected_fileds'
WARNING -  griffe:.../pyiceberg/table/__init__.py:856: Parameter 'selected_fileds' does not appear in the function signature

```