### PR TITLE
abort the whole table transaction if any updates in the transaction has failed

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -23,6 +23,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from functools import cached_property
 from itertools import chain
+from types import TracebackType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -33,6 +34,7 @@ from typing import (
     Optional,
     Set,
     Tuple,
+    Type,
     TypeVar,
     Union,
 )
@@ -231,9 +233,12 @@ class Transaction:
         """Start a transaction to update the table."""
         return self
 
-    def __exit__(self, _: Any, value: Any, traceback: Any) -> None:
-        """Close and commit the transaction."""
-        self.commit_transaction()
+    def __exit__(
+        self, exctype: Optional[Type[BaseException]], excinst: Optional[BaseException], exctb: Optional[TracebackType]
+    ) -> None:
+        """Close and commit the transaction if no exceptions have been raised."""
+        if exctype is None and excinst is None and exctb is None:
+            self.commit_transaction()
 
     def _apply(self, updates: Tuple[TableUpdate, ...], requirements: Tuple[TableRequirement, ...] = ()) -> Transaction:
         """Check if the requirements are met, and applies the updates to the metadata."""

--- a/tests/integration/test_writes/test_writes.py
+++ b/tests/integration/test_writes/test_writes.py
@@ -1470,5 +1470,5 @@ def test_abort_table_transaction_on_exception(
             raise ValueError
             txn.append(arrow_table_with_null)  # type: ignore
 
-    # Validate the transaction is aborted
-    assert len(tbl.scan().to_pandas()) == 3  # type: ignore
+    # Validate the transaction is aborted and no partial update is applied
+    assert len(tbl.scan().to_pandas()) == table_size

--- a/tests/integration/test_writes/test_writes.py
+++ b/tests/integration/test_writes/test_writes.py
@@ -1471,4 +1471,4 @@ def test_abort_table_transaction_on_exception(
             txn.append(arrow_table_with_null)  # type: ignore
 
     # Validate the transaction is aborted and no partial update is applied
-    assert len(tbl.scan().to_pandas()) == table_size
+    assert len(tbl.scan().to_pandas()) == table_size  # type: ignore

--- a/tests/integration/test_writes/test_writes.py
+++ b/tests/integration/test_writes/test_writes.py
@@ -1460,7 +1460,8 @@ def test_abort_table_transaction_on_exception(
 
     # Pre-populate some data
     tbl.append(arrow_table_with_null)
-    assert len(tbl.scan().to_pandas()) == 3
+    table_size = len(arrow_table_with_null)
+    assert len(tbl.scan().to_pandas()) == table_size
 
     # try to commit a transaction that raises exception at the middle
     with pytest.raises(ValueError):


### PR DESCRIPTION
We have encountered a data loss issue when using pyIceberg to perform an overwrite operation. Typically, an overwrite operation involves creating both a delete snapshot and an append snapshot. However, if an exception occurs during the creation of the append snapshot, the current code still attempts to commit the delete snapshot, leading to potential data loss. One thing to note is this does not apply to only overwrite but potentially other operations as well.

To address this issue, we need to ensure that the entire transaction is aborted if any part of the update process fails.

Also provided a simple test case, where before this change, the transaction will only contains a delete snapshot update deleting the data. Whereas after this fix, we still keep the same data before the partially failed transaction since the whole transaction is now aborted.