### PR TITLE
fix: list_tables method in glue catalog now only return tables.

### DIFF
--- a/pyiceberg/catalog/glue.py
+++ b/pyiceberg/catalog/glue.py
@@ -784,4 +784,4 @@ class GlueCatalog(MetastoreCatalog):
 
     @staticmethod
     def __is_iceberg_table(table: TableTypeDef) -> bool:
-        return table.get("Parameters", {}).get("table_type", "").lower() == "iceberg"
+        return table.get("Parameters", {}).get("table_type", "").lower() == ICEBERG

--- a/pyiceberg/catalog/glue.py
+++ b/pyiceberg/catalog/glue.py
@@ -784,4 +784,4 @@ class GlueCatalog(MetastoreCatalog):
 
     @staticmethod
     def __is_iceberg_table(table: TableTypeDef) -> bool:
-        return table["Parameters"] is not None and table["Parameters"][TABLE_TYPE].lower() == ICEBERG
+        return table.get("Parameters", {}).get("table_type", "").lower() == "iceberg"


### PR DESCRIPTION
### Description:
 This pull request addresses an issue where the list_tables function was returning views alongside Iceberg tables. Since views lack the table_type property or have it set differently than "iceberg", they were incorrectly included in the list of tables. This change modifies the filtering logic to ensure that only actual Iceberg tables are returned.
### Problem: 
In the existing list_tables function, both Iceberg tables and Glue views were being returned. Glue views generally do not contain the table_type parameter or may have it unset, which causes them to be mistakenly included when listing Iceberg tables in a namespace. This behavior makes it challenging for users to retrieve only Iceberg tables as intended.
### Solution: 
The __is_iceberg_table helper method has been modified to:
Check if the table_type parameter is present in each table’s properties.
Ensure that the table_type parameter is explicitly set to "iceberg".
### Testing: 
Tests were added to verify that:
Only Iceberg tables are returned by list_tables.
Glue views, which lack the table_type parameter or have it set to a non-Iceberg value, are excluded from the list.