### PR TITLE
Add support for boolean expressions and quoted columns

### DIFF
--- a/pyiceberg/expressions/parser.py
+++ b/pyiceberg/expressions/parser.py
@@ -272,14 +272,29 @@ def handle_or(result: ParseResults) -> Or:
     return Or(*result[0])
 
 
-boolean_expression = infix_notation(
-    predicate,
-    [
-        (Suppress(NOT), 1, opAssoc.RIGHT, handle_not),
-        (Suppress(AND), 2, opAssoc.LEFT, handle_and),
-        (Suppress(OR), 2, opAssoc.LEFT, handle_or),
-    ],
-).set_name("expr")
+def handle_always_expression(result: ParseResults) -> BooleanExpression:
+    # If the entire result is "true" or "false", return AlwaysTrue or AlwaysFalse
+    expr = result[0]
+    if isinstance(expr, BooleanLiteral):
+        if expr.value:
+            return AlwaysTrue()
+        else:
+            return AlwaysFalse()
+    return result[0]
+
+
+boolean_expression = (
+    infix_notation(
+        predicate,
+        [
+            (Suppress(NOT), 1, opAssoc.RIGHT, handle_not),
+            (Suppress(AND), 2, opAssoc.LEFT, handle_and),
+            (Suppress(OR), 2, opAssoc.LEFT, handle_or),
+        ],
+    )
+    .set_name("expr")
+    .add_parse_action(handle_always_expression)
+)
 
 
 def parse(expr: str) -> BooleanExpression:

--- a/pyiceberg/expressions/parser.py
+++ b/pyiceberg/expressions/parser.py
@@ -82,7 +82,6 @@ LIKE = CaselessKeyword("like")
 unquoted_identifier = Word(alphas, alphanums + "_$")
 quoted_identifier = Suppress('"') + unquoted_identifier + Suppress('"')
 identifier = MatchFirst([unquoted_identifier, quoted_identifier]).set_results_name("identifier")
-# identifier = Word(alphas, alphanums + "_$").set_results_name("identifier")
 column = DelimitedList(identifier, delim=".", combine=False).set_results_name("column")
 
 like_regex = r"(?P<valid_wildcard>(?<!\\)%$)|(?P<invalid_wildcard>(?<!\\)%)"

--- a/tests/expressions/test_parser.py
+++ b/tests/expressions/test_parser.py
@@ -41,12 +41,22 @@ from pyiceberg.expressions import (
 )
 
 
-def test_true() -> None:
+def test_always_true() -> None:
     assert AlwaysTrue() == parser.parse("true")
 
 
-def test_false() -> None:
+def test_always_false() -> None:
     assert AlwaysFalse() == parser.parse("false")
+
+
+def test_equals_true() -> None:
+    assert EqualTo("foo", True) == parser.parse("foo = true")
+    assert EqualTo("foo", True) == parser.parse("foo == TRUE")
+
+
+def test_equals_false() -> None:
+    assert EqualTo("foo", False) == parser.parse("foo = false")
+    assert EqualTo("foo", False) == parser.parse("foo == FALSE")
 
 
 def test_is_null() -> None:

--- a/tests/expressions/test_parser.py
+++ b/tests/expressions/test_parser.py
@@ -49,6 +49,10 @@ def test_always_false() -> None:
     assert AlwaysFalse() == parser.parse("false")
 
 
+def test_quoted_column() -> None:
+    assert EqualTo("foo", True) == parser.parse('"foo" = TRUE')
+
+
 def test_equals_true() -> None:
     assert EqualTo("foo", True) == parser.parse("foo = true")
     assert EqualTo("foo", True) == parser.parse("foo == TRUE")


### PR DESCRIPTION
Currently, `row_filter` expressions involving a `boolean` expression fail. This pull adds in the already-defined boolean literals as part of the list of parsed literals. 

In addition, identifiers can now be defined with double quotes (`"`) as part of the SQL spec.