### PR TITLE
Do not deprecate `botocore_session`

### DIFF
--- a/mkdocs/docs/configuration.md
+++ b/mkdocs/docs/configuration.md
@@ -347,7 +347,7 @@ catalog:
 <!-- prettier-ignore-start -->
 
 !!! warning "Removed Properties"
-    The properties `profile_name`, `region_name`, `botocore_session`, `aws_access_key_id`, `aws_secret_access_key`, and `aws_session_token` were deprecated and removed in 0.8.0
+    The properties `profile_name`, `region_name`, `aws_access_key_id`, `aws_secret_access_key`, and `aws_session_token` were deprecated and removed in 0.8.0
 
 <!-- prettier-ignore-end -->
 
@@ -403,7 +403,7 @@ catalog:
 <!-- prettier-ignore-start -->
 
 !!! warning "Removed Properties"
-    The properties `profile_name`, `region_name`, `botocore_session`, `aws_access_key_id`, `aws_secret_access_key`, and `aws_session_token` were deprecated and removed in 0.8.0
+    The properties `profile_name`, `region_name`, `aws_access_key_id`, `aws_secret_access_key`, and `aws_session_token` were deprecated and removed in 0.8.0
 
 <!-- prettier-ignore-end -->
 

--- a/pyiceberg/catalog/__init__.py
+++ b/pyiceberg/catalog/__init__.py
@@ -106,6 +106,8 @@ TABLE_METADATA_FILE_NAME_REGEX = re.compile(
     re.X,
 )
 
+DEPRECATED_BOTOCORE_SESSION = "botocore_session"
+
 
 class CatalogType(Enum):
     REST = "rest"

--- a/pyiceberg/catalog/__init__.py
+++ b/pyiceberg/catalog/__init__.py
@@ -781,6 +781,13 @@ class MetastoreCatalog(Catalog, ABC):
     def __init__(self, name: str, **properties: str):
         super().__init__(name, **properties)
 
+        if self.properties.get(DEPRECATED_BOTOCORE_SESSION):
+            deprecation_message(
+                deprecated_in="0.8.0",
+                removed_in="0.9.0",
+                help_message=f"The property {DEPRECATED_BOTOCORE_SESSION} is deprecated and will be removed.",
+            )
+
     def create_table_transaction(
         self,
         identifier: Union[str, Identifier],

--- a/pyiceberg/catalog/dynamodb.py
+++ b/pyiceberg/catalog/dynamodb.py
@@ -30,6 +30,7 @@ from typing import (
 import boto3
 
 from pyiceberg.catalog import (
+    DEPRECATED_BOTOCORE_SESSION,
     ICEBERG,
     METADATA_LOCATION,
     PREVIOUS_METADATA_LOCATION,
@@ -98,6 +99,7 @@ class DynamoDbCatalog(MetastoreCatalog):
         session = boto3.Session(
             profile_name=properties.get(DYNAMODB_PROFILE_NAME),
             region_name=get_first_property_value(properties, DYNAMODB_REGION, AWS_REGION),
+            botocore_session=properties.get(DEPRECATED_BOTOCORE_SESSION),
             aws_access_key_id=get_first_property_value(properties, DYNAMODB_ACCESS_KEY_ID, AWS_ACCESS_KEY_ID),
             aws_secret_access_key=get_first_property_value(properties, DYNAMODB_SECRET_ACCESS_KEY, AWS_SECRET_ACCESS_KEY),
             aws_session_token=get_first_property_value(properties, DYNAMODB_SESSION_TOKEN, AWS_SESSION_TOKEN),

--- a/pyiceberg/catalog/glue.py
+++ b/pyiceberg/catalog/glue.py
@@ -40,6 +40,7 @@ from mypy_boto3_glue.type_defs import (
 )
 
 from pyiceberg.catalog import (
+    DEPRECATED_BOTOCORE_SESSION,
     EXTERNAL_TABLE,
     ICEBERG,
     LOCATION,
@@ -299,6 +300,7 @@ class GlueCatalog(MetastoreCatalog):
         session = boto3.Session(
             profile_name=properties.get(GLUE_PROFILE_NAME),
             region_name=get_first_property_value(properties, GLUE_REGION, AWS_REGION),
+            botocore_session=properties.get(DEPRECATED_BOTOCORE_SESSION),
             aws_access_key_id=get_first_property_value(properties, GLUE_ACCESS_KEY_ID, AWS_ACCESS_KEY_ID),
             aws_secret_access_key=get_first_property_value(properties, GLUE_SECRET_ACCESS_KEY, AWS_SECRET_ACCESS_KEY),
             aws_session_token=get_first_property_value(properties, GLUE_SESSION_TOKEN, AWS_SESSION_TOKEN),

--- a/tests/catalog/test_dynamodb.py
+++ b/tests/catalog/test_dynamodb.py
@@ -585,6 +585,7 @@ def test_passing_glue_session_properties() -> None:
             aws_session_token="dynamodb.session-token",
             region_name="dynamodb.region",
             profile_name="dynamodb.profile-name",
+            botocore_session=None,
         )
         assert test_catalog.dynamodb is mock_session().client()
 
@@ -608,6 +609,7 @@ def test_passing_unified_session_properties_to_dynamodb() -> None:
             aws_session_token="client.session-token",
             region_name="client.region",
             profile_name="dynamodb.profile-name",
+            botocore_session=None,
         )
         assert test_catalog.dynamodb is mock_session().client()
 

--- a/tests/catalog/test_glue.py
+++ b/tests/catalog/test_glue.py
@@ -657,6 +657,7 @@ def test_passing_glue_session_properties() -> None:
         aws_session_token="glue.session-token",
         region_name="glue.region",
         profile_name="glue.profile-name",
+        botocore_session=None,
     )
     assert test_catalog.glue is mock_session().client()
 
@@ -677,6 +678,7 @@ def test_passing_unified_session_properties_to_glue() -> None:
         aws_session_token="client.session-token",
         region_name="client.region",
         profile_name="glue.profile-name",
+        botocore_session=None,
     )
     assert test_catalog.glue is mock_session().client()
 


### PR DESCRIPTION
Do not deprecate `botocore_session` in 0.8.0 release, due to #1104
Partial revert of #1269

Fixes https://github.com/apache/iceberg-python/issues/1104

