### PR TITLE
Introduce `assign_fresh_ids` and allow skipping fresh assignment of IDs on table creation

### DIFF
--- a/mkdocs/docs/api.md
+++ b/mkdocs/docs/api.md
@@ -122,31 +122,12 @@ schema = Schema(
     ),
 )
 
-from pyiceberg.partitioning import PartitionSpec, PartitionField
-from pyiceberg.transforms import DayTransform
-
-partition_spec = PartitionSpec(
-    PartitionField(
-        source_id=1, field_id=1000, transform=DayTransform(), name="datetime_day"
-    )
-)
-
-from pyiceberg.table.sorting import SortOrder, SortField
-from pyiceberg.transforms import IdentityTransform
-
-# Sort on the symbol
-sort_order = SortOrder(SortField(source_id=2, transform=IdentityTransform()))
-
 catalog.create_table(
     identifier="docs_example.bids",
     schema=schema,
     location="s3://pyiceberg",
-    partition_spec=partition_spec,
-    sort_order=sort_order,
 )
 ```
-
-When the table is created, all IDs in the schema are re-assigned to ensure uniqueness.
 
 To create a table using a pyarrow schema:
 
@@ -164,6 +145,7 @@ schema = pa.schema(
 catalog.create_table(
     identifier="docs_example.bids",
     schema=schema,
+    location="s3://pyiceberg",
 )
 ```
 
@@ -174,8 +156,6 @@ with catalog.create_table_transaction(
     identifier="docs_example.bids",
     schema=schema,
     location="s3://pyiceberg",
-    partition_spec=partition_spec,
-    sort_order=sort_order,
 ) as txn:
     with txn.update_schema() as update_schema:
         update_schema.add_column(path="new_column", field_type=StringType())

--- a/pyiceberg/catalog/__init__.py
+++ b/pyiceberg/catalog/__init__.py
@@ -339,6 +339,7 @@ class Catalog(ABC):
         partition_spec: PartitionSpec = UNPARTITIONED_PARTITION_SPEC,
         sort_order: SortOrder = UNSORTED_SORT_ORDER,
         properties: Properties = EMPTY_DICT,
+        assign_fresh_ids: bool = True,
     ) -> Table:
         """Create a table.
 
@@ -349,6 +350,7 @@ class Catalog(ABC):
             partition_spec (PartitionSpec): PartitionSpec for the table.
             sort_order (SortOrder): SortOrder for the table.
             properties (Properties): Table properties that can be a string based dictionary.
+            assign_fresh_ids (bool): flag to assign new field IDs, defaults to True.
 
         Returns:
             Table: the created table instance.
@@ -366,6 +368,7 @@ class Catalog(ABC):
         partition_spec: PartitionSpec = UNPARTITIONED_PARTITION_SPEC,
         sort_order: SortOrder = UNSORTED_SORT_ORDER,
         properties: Properties = EMPTY_DICT,
+        assign_fresh_ids: bool = True,
     ) -> CreateTableTransaction:
         """Create a CreateTableTransaction.
 
@@ -376,6 +379,7 @@ class Catalog(ABC):
             partition_spec (PartitionSpec): PartitionSpec for the table.
             sort_order (SortOrder): SortOrder for the table.
             properties (Properties): Table properties that can be a string based dictionary.
+            assign_fresh_ids (bool): flag to assign new field IDs, defaults to True.
 
         Returns:
             CreateTableTransaction: createTableTransaction instance.
@@ -389,6 +393,7 @@ class Catalog(ABC):
         partition_spec: PartitionSpec = UNPARTITIONED_PARTITION_SPEC,
         sort_order: SortOrder = UNSORTED_SORT_ORDER,
         properties: Properties = EMPTY_DICT,
+        assign_fresh_ids: bool = True,
     ) -> Table:
         """Create a table if it does not exist.
 
@@ -399,13 +404,14 @@ class Catalog(ABC):
             partition_spec (PartitionSpec): PartitionSpec for the table.
             sort_order (SortOrder): SortOrder for the table.
             properties (Properties): Table properties that can be a string based dictionary.
+            assign_fresh_ids (bool): flag to assign new field IDs, defaults to True.
 
         Returns:
             Table: the created table instance if the table does not exist, else the existing
             table instance.
         """
         try:
-            return self.create_table(identifier, schema, location, partition_spec, sort_order, properties)
+            return self.create_table(identifier, schema, location, partition_spec, sort_order, properties, assign_fresh_ids)
         except TableAlreadyExistsError:
             return self.load_table(identifier)
 
@@ -754,9 +760,7 @@ class Catalog(ABC):
         return load_file_io({**self.properties, **properties}, location)
 
     @staticmethod
-    def _convert_schema_if_needed(schema: Union[Schema, "pa.Schema"]) -> Schema:
-        if isinstance(schema, Schema):
-            return schema
+    def _convert_to_iceberg_schema(schema: "pa.Schema") -> Schema:
         try:
             import pyarrow as pa
 
@@ -796,9 +800,10 @@ class MetastoreCatalog(Catalog, ABC):
         partition_spec: PartitionSpec = UNPARTITIONED_PARTITION_SPEC,
         sort_order: SortOrder = UNSORTED_SORT_ORDER,
         properties: Properties = EMPTY_DICT,
+        assign_fresh_ids: bool = True,
     ) -> CreateTableTransaction:
         return CreateTableTransaction(
-            self._create_staged_table(identifier, schema, location, partition_spec, sort_order, properties)
+            self._create_staged_table(identifier, schema, location, partition_spec, sort_order, properties, assign_fresh_ids)
         )
 
     def table_exists(self, identifier: Union[str, Identifier]) -> bool:
@@ -838,6 +843,7 @@ class MetastoreCatalog(Catalog, ABC):
         partition_spec: PartitionSpec = UNPARTITIONED_PARTITION_SPEC,
         sort_order: SortOrder = UNSORTED_SORT_ORDER,
         properties: Properties = EMPTY_DICT,
+        assign_fresh_ids: bool = True,
     ) -> StagedTable:
         """Create a table and return the table instance without committing the changes.
 
@@ -848,18 +854,26 @@ class MetastoreCatalog(Catalog, ABC):
             partition_spec (PartitionSpec): PartitionSpec for the table.
             sort_order (SortOrder): SortOrder for the table.
             properties (Properties): Table properties that can be a string based dictionary.
+            assign_fresh_ids (bool): flag to assign new field IDs, defaults to True.
 
         Returns:
             StagedTable: the created staged table instance.
         """
-        schema: Schema = self._convert_schema_if_needed(schema)  # type: ignore
+        if not isinstance(schema, Schema):
+            schema: Schema = self._convert_to_iceberg_schema(schema)  # type: ignore
+            assign_fresh_ids = True
 
         database_name, table_name = self.identifier_to_database_and_table(identifier)
 
         location = self._resolve_table_location(location, database_name, table_name)
         metadata_location = self._get_metadata_location(location=location)
         metadata = new_table_metadata(
-            location=location, schema=schema, partition_spec=partition_spec, sort_order=sort_order, properties=properties
+            location=location,
+            schema=schema,
+            partition_spec=partition_spec,
+            sort_order=sort_order,
+            properties=properties,
+            assign_fresh_ids=assign_fresh_ids,
         )
         io = self._load_file_io(properties=properties, location=metadata_location)
         return StagedTable(

--- a/pyiceberg/catalog/dynamodb.py
+++ b/pyiceberg/catalog/dynamodb.py
@@ -148,6 +148,7 @@ class DynamoDbCatalog(MetastoreCatalog):
         partition_spec: PartitionSpec = UNPARTITIONED_PARTITION_SPEC,
         sort_order: SortOrder = UNSORTED_SORT_ORDER,
         properties: Properties = EMPTY_DICT,
+        assign_fresh_ids: bool = True,
     ) -> Table:
         """
         Create an Iceberg table.
@@ -159,6 +160,7 @@ class DynamoDbCatalog(MetastoreCatalog):
             partition_spec: PartitionSpec for the table.
             sort_order: SortOrder for the table.
             properties: Table properties that can be a string based dictionary.
+            assign_fresh_ids (bool): flag to assign new field IDs, defaults to True.
 
         Returns:
             Table: the created table instance.
@@ -168,14 +170,21 @@ class DynamoDbCatalog(MetastoreCatalog):
             ValueError: If the identifier is invalid, or no path is given to store metadata.
 
         """
-        schema: Schema = self._convert_schema_if_needed(schema)  # type: ignore
+        if not isinstance(schema, Schema):
+            schema: Schema = self._convert_to_iceberg_schema(schema)  # type: ignore
+            assign_fresh_ids = True
 
         database_name, table_name = self.identifier_to_database_and_table(identifier)
 
         location = self._resolve_table_location(location, database_name, table_name)
         metadata_location = self._get_metadata_location(location=location)
         metadata = new_table_metadata(
-            location=location, schema=schema, partition_spec=partition_spec, sort_order=sort_order, properties=properties
+            location=location,
+            schema=schema,
+            partition_spec=partition_spec,
+            sort_order=sort_order,
+            properties=properties,
+            assign_fresh_ids=assign_fresh_ids,
         )
         io = load_file_io(properties=self.properties, location=metadata_location)
         self._write_metadata(metadata, io, metadata_location)

--- a/pyiceberg/catalog/glue.py
+++ b/pyiceberg/catalog/glue.py
@@ -384,6 +384,7 @@ class GlueCatalog(MetastoreCatalog):
         partition_spec: PartitionSpec = UNPARTITIONED_PARTITION_SPEC,
         sort_order: SortOrder = UNSORTED_SORT_ORDER,
         properties: Properties = EMPTY_DICT,
+        assign_fresh_ids: bool = True,
     ) -> Table:
         """
         Create an Iceberg table.
@@ -395,6 +396,7 @@ class GlueCatalog(MetastoreCatalog):
             partition_spec: PartitionSpec for the table.
             sort_order: SortOrder for the table.
             properties: Table properties that can be a string based dictionary.
+            assign_fresh_ids (bool): flag to assign new field IDs, defaults to True.
 
         Returns:
             Table: the created table instance.
@@ -411,6 +413,7 @@ class GlueCatalog(MetastoreCatalog):
             partition_spec=partition_spec,
             sort_order=sort_order,
             properties=properties,
+            assign_fresh_ids=assign_fresh_ids,
         )
         database_name, table_name = self.identifier_to_database_and_table(identifier)
 

--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -353,6 +353,7 @@ class HiveCatalog(MetastoreCatalog):
         partition_spec: PartitionSpec = UNPARTITIONED_PARTITION_SPEC,
         sort_order: SortOrder = UNSORTED_SORT_ORDER,
         properties: Properties = EMPTY_DICT,
+        assign_fresh_ids: bool = True,
     ) -> Table:
         """Create a table.
 
@@ -363,6 +364,7 @@ class HiveCatalog(MetastoreCatalog):
             partition_spec: PartitionSpec for the table.
             sort_order: SortOrder for the table.
             properties: Table properties that can be a string based dictionary.
+            assign_fresh_ids (bool): flag to assign new field IDs, defaults to True.
 
         Returns:
             Table: the created table instance.
@@ -379,6 +381,7 @@ class HiveCatalog(MetastoreCatalog):
             partition_spec=partition_spec,
             sort_order=sort_order,
             properties=properties,
+            assign_fresh_ids=assign_fresh_ids,
         )
         database_name, table_name = self.identifier_to_database_and_table(identifier)
 

--- a/pyiceberg/catalog/noop.py
+++ b/pyiceberg/catalog/noop.py
@@ -51,6 +51,7 @@ class NoopCatalog(Catalog):
         partition_spec: PartitionSpec = UNPARTITIONED_PARTITION_SPEC,
         sort_order: SortOrder = UNSORTED_SORT_ORDER,
         properties: Properties = EMPTY_DICT,
+        assign_fresh_ids: bool = True,
     ) -> Table:
         raise NotImplementedError
 
@@ -62,6 +63,7 @@ class NoopCatalog(Catalog):
         partition_spec: PartitionSpec = UNPARTITIONED_PARTITION_SPEC,
         sort_order: SortOrder = UNSORTED_SORT_ORDER,
         properties: Properties = EMPTY_DICT,
+        assign_fresh_ids: bool = True,
     ) -> CreateTableTransaction:
         raise NotImplementedError
 

--- a/pyiceberg/catalog/sql.py
+++ b/pyiceberg/catalog/sql.py
@@ -178,6 +178,7 @@ class SqlCatalog(MetastoreCatalog):
         partition_spec: PartitionSpec = UNPARTITIONED_PARTITION_SPEC,
         sort_order: SortOrder = UNSORTED_SORT_ORDER,
         properties: Properties = EMPTY_DICT,
+        assign_fresh_ids: bool = True,
     ) -> Table:
         """
         Create an Iceberg table.
@@ -189,6 +190,7 @@ class SqlCatalog(MetastoreCatalog):
             partition_spec: PartitionSpec for the table.
             sort_order: SortOrder for the table.
             properties: Table properties that can be a string based dictionary.
+            assign_fresh_ids (bool): flag to assign new field IDs, defaults to True.
 
         Returns:
             Table: the created table instance.
@@ -198,7 +200,9 @@ class SqlCatalog(MetastoreCatalog):
             ValueError: If the identifier is invalid, or no path is given to store metadata.
 
         """
-        schema: Schema = self._convert_schema_if_needed(schema)  # type: ignore
+        if not isinstance(schema, Schema):
+            schema: Schema = self._convert_to_iceberg_schema(schema)  # type: ignore
+            assign_fresh_ids = True
 
         identifier_nocatalog = self._identifier_to_tuple_without_catalog(identifier)
         namespace_identifier = Catalog.namespace_from(identifier_nocatalog)
@@ -210,7 +214,12 @@ class SqlCatalog(MetastoreCatalog):
         location = self._resolve_table_location(location, namespace, table_name)
         metadata_location = self._get_metadata_location(location=location)
         metadata = new_table_metadata(
-            location=location, schema=schema, partition_spec=partition_spec, sort_order=sort_order, properties=properties
+            location=location,
+            schema=schema,
+            partition_spec=partition_spec,
+            sort_order=sort_order,
+            properties=properties,
+            assign_fresh_ids=assign_fresh_ids,
         )
         io = load_file_io(properties=self.properties, location=metadata_location)
         self._write_metadata(metadata, io, metadata_location)

--- a/pyiceberg/table/metadata.py
+++ b/pyiceberg/table/metadata.py
@@ -517,12 +517,14 @@ def new_table_metadata(
     location: str,
     properties: Properties = EMPTY_DICT,
     table_uuid: Optional[uuid.UUID] = None,
+    assign_fresh_ids: bool = True,
 ) -> TableMetadata:
     from pyiceberg.table import TableProperties
 
-    fresh_schema = assign_fresh_schema_ids(schema)
-    fresh_partition_spec = assign_fresh_partition_spec_ids(partition_spec, schema, fresh_schema)
-    fresh_sort_order = assign_fresh_sort_order_ids(sort_order, schema, fresh_schema)
+    if assign_fresh_ids:
+        fresh_schema = assign_fresh_schema_ids(schema)
+        fresh_partition_spec = assign_fresh_partition_spec_ids(partition_spec, schema, fresh_schema)
+        fresh_sort_order = assign_fresh_sort_order_ids(sort_order, schema, fresh_schema)
 
     if table_uuid is None:
         table_uuid = uuid.uuid4()

--- a/pyiceberg/table/update/schema.py
+++ b/pyiceberg/table/update/schema.py
@@ -143,8 +143,11 @@ class UpdateSchema(UpdateTableMetadata["UpdateSchema"]):
     def union_by_name(self, new_schema: Union[Schema, "pa.Schema"]) -> UpdateSchema:
         from pyiceberg.catalog import Catalog
 
+        if not isinstance(new_schema, Schema):
+            new_schema: Schema = Catalog._convert_to_iceberg_schema(new_schema)  # type: ignore
+
         visit_with_partner(
-            Catalog._convert_schema_if_needed(new_schema),
+            new_schema,
             -1,
             _UnionByNameVisitor(update_schema=self, existing_schema=self._schema, case_sensitive=self._case_sensitive),
             # type: ignore

--- a/tests/integration/test_rest_schema.py
+++ b/tests/integration/test_rest_schema.py
@@ -2554,3 +2554,37 @@ def test_create_table_integrity_after_fresh_assignment(catalog: Catalog) -> None
     assert tbl.schema() == expected_schema
     assert tbl.spec() == expected_spec
     assert tbl.sort_order() == expected_sort_order
+
+
+@pytest.mark.integration
+def test_create_table_integrity_without_fresh_assignment(catalog: Catalog) -> None:
+    schema = Schema(
+        NestedField(field_id=5, name="col_uuid", field_type=UUIDType(), required=False),
+        NestedField(field_id=4, name="col_fixed", field_type=FixedType(25), required=False),
+    )
+    partition_spec = PartitionSpec(
+        PartitionField(source_id=5, field_id=1000, transform=IdentityTransform(), name="col_uuid"), spec_id=0
+    )
+    sort_order = SortOrder(SortField(source_id=4, transform=IdentityTransform()))
+    tbl_name = "default.test_create_integrity"
+    try:
+        catalog.drop_table(tbl_name)
+    except NoSuchTableError:
+        pass
+
+    tbl = catalog.create_table(
+        identifier=tbl_name, schema=schema, partition_spec=partition_spec, sort_order=sort_order, assign_fresh_ids=False
+    )
+    # Here, unfortunately the REST Catalog assigns fresh IDs - although it is still a good test to cover a different code
+    # path than 'test_create_table_integrity_after_fresh_assignment'
+    expected_schema = Schema(
+        NestedField(field_id=1, name="col_uuid", field_type=UUIDType(), required=False),
+        NestedField(field_id=2, name="col_fixed", field_type=FixedType(25), required=False),
+    )
+    expected_spec = PartitionSpec(
+        PartitionField(source_id=1, field_id=1000, transform=IdentityTransform(), name="col_uuid"), spec_id=0
+    )
+    expected_sort_order = SortOrder(SortField(source_id=2, transform=IdentityTransform()))
+    assert tbl.schema() == expected_schema
+    assert tbl.spec() == expected_spec
+    assert tbl.sort_order() == expected_sort_order


### PR DESCRIPTION
Implements: https://github.com/apache/iceberg-python/issues/1284