### PR TITLE
Boto Glue standard retry policy with configuration

### DIFF
--- a/mkdocs/docs/configuration.md
+++ b/mkdocs/docs/configuration.md
@@ -341,7 +341,7 @@ catalog:
 | glue.access-key-id     | admin                                  | Configure the static access key id used to access the Glue Catalog              |
 | glue.secret-access-key | password                               | Configure the static secret access key used to access the Glue Catalog          |
 | glue.session-token     | AQoDYXdzEJr...                         | Configure the static session token used to access the Glue Catalog              |
-| glue.max-retries       | 5                                      | Configure the maximum number of retries for the Glue service calls              |
+| glue.max-retries       | 10                                     | Configure the maximum number of retries for the Glue service calls              |
 
 <!-- markdown-link-check-enable-->
 

--- a/mkdocs/docs/configuration.md
+++ b/mkdocs/docs/configuration.md
@@ -331,16 +331,17 @@ catalog:
 
 <!-- markdown-link-check-disable -->
 
-| Key                    | Example                              | Description                                                                     |
-| ---------------------- | ------------------------------------ | ------------------------------------------------------------------------------- |
-| glue.id                | 111111111111                         | Configure the 12-digit ID of the Glue Catalog                                   |
-| glue.skip-archive      | true                                 | Configure whether to skip the archival of older table versions. Default to true |
+| Key                    | Example                                | Description                                                                     |
+|------------------------|----------------------------------------|---------------------------------------------------------------------------------|
+| glue.id                | 111111111111                           | Configure the 12-digit ID of the Glue Catalog                                   |
+| glue.skip-archive      | true                                   | Configure whether to skip the archival of older table versions. Default to true |
 | glue.endpoint          | <https://glue.us-east-1.amazonaws.com> | Configure an alternative endpoint of the Glue service for GlueCatalog to access |
-| glue.profile-name      | default                              | Configure the static profile used to access the Glue Catalog                    |
-| glue.region            | us-east-1                            | Set the region of the Glue Catalog                                              |
-| glue.access-key-id     | admin                                | Configure the static access key id used to access the Glue Catalog              |
-| glue.secret-access-key | password                             | Configure the static secret access key used to access the Glue Catalog          |
-| glue.session-token     | AQoDYXdzEJr...                       | Configure the static session token used to access the Glue Catalog              |
+| glue.profile-name      | default                                | Configure the static profile used to access the Glue Catalog                    |
+| glue.region            | us-east-1                              | Set the region of the Glue Catalog                                              |
+| glue.access-key-id     | admin                                  | Configure the static access key id used to access the Glue Catalog              |
+| glue.secret-access-key | password                               | Configure the static secret access key used to access the Glue Catalog          |
+| glue.session-token     | AQoDYXdzEJr...                         | Configure the static session token used to access the Glue Catalog              |
+| glue.max-retries       | 5                                      | Configure the maximum number of retries for the Glue service calls              |
 
 <!-- markdown-link-check-enable-->
 

--- a/mkdocs/docs/configuration.md
+++ b/mkdocs/docs/configuration.md
@@ -342,6 +342,7 @@ catalog:
 | glue.secret-access-key | password                               | Configure the static secret access key used to access the Glue Catalog          |
 | glue.session-token     | AQoDYXdzEJr...                         | Configure the static session token used to access the Glue Catalog              |
 | glue.max-retries       | 10                                     | Configure the maximum number of retries for the Glue service calls              |
+| glue.retry-mode        | standard                               | Configure the retry mode for the Glue service. Default to standard.             |
 
 <!-- markdown-link-check-enable-->
 

--- a/pyiceberg/catalog/__init__.py
+++ b/pyiceberg/catalog/__init__.py
@@ -94,6 +94,7 @@ METADATA = "metadata"
 URI = "uri"
 LOCATION = "location"
 EXTERNAL_TABLE = "EXTERNAL_TABLE"
+MAX_RETRIES = 10
 
 TABLE_METADATA_FILE_NAME_REGEX = re.compile(
     r"""

--- a/pyiceberg/catalog/__init__.py
+++ b/pyiceberg/catalog/__init__.py
@@ -94,7 +94,6 @@ METADATA = "metadata"
 URI = "uri"
 LOCATION = "location"
 EXTERNAL_TABLE = "EXTERNAL_TABLE"
-MAX_RETRIES = 10
 
 TABLE_METADATA_FILE_NAME_REGEX = re.compile(
     r"""

--- a/pyiceberg/catalog/glue.py
+++ b/pyiceberg/catalog/glue.py
@@ -29,6 +29,7 @@ from typing import (
 )
 
 import boto3
+from botocore.config import Config
 from mypy_boto3_glue.client import GlueClient
 from mypy_boto3_glue.type_defs import (
     ColumnTypeDef,
@@ -44,6 +45,7 @@ from pyiceberg.catalog import (
     EXTERNAL_TABLE,
     ICEBERG,
     LOCATION,
+    MAX_RETRIES,
     METADATA_LOCATION,
     PREVIOUS_METADATA_LOCATION,
     TABLE_TYPE,
@@ -128,6 +130,7 @@ GLUE_REGION = "glue.region"
 GLUE_ACCESS_KEY_ID = "glue.access-key-id"
 GLUE_SECRET_ACCESS_KEY = "glue.secret-access-key"
 GLUE_SESSION_TOKEN = "glue.session-token"
+GLUE_MAX_RETRIES = "glue.max-retries"
 
 
 def _construct_parameters(
@@ -305,7 +308,18 @@ class GlueCatalog(MetastoreCatalog):
             aws_secret_access_key=get_first_property_value(properties, GLUE_SECRET_ACCESS_KEY, AWS_SECRET_ACCESS_KEY),
             aws_session_token=get_first_property_value(properties, GLUE_SESSION_TOKEN, AWS_SESSION_TOKEN),
         )
-        self.glue: GlueClient = session.client("glue", endpoint_url=properties.get(GLUE_CATALOG_ENDPOINT))
+        self.glue: GlueClient = session.client(
+            "glue",
+            endpoint_url=properties.get(GLUE_CATALOG_ENDPOINT),
+            config=Config(
+                retries={
+                    "max_attempts": get_first_property_value(properties, GLUE_MAX_RETRIES)
+                    if get_first_property_value(properties, GLUE_MAX_RETRIES)
+                    else MAX_RETRIES,
+                    "mode": "standard",
+                }
+            ),
+        )
 
         if glue_catalog_id := properties.get(GLUE_ID):
             _register_glue_catalog_id_with_glue_client(self.glue, glue_catalog_id)

--- a/pyiceberg/catalog/glue.py
+++ b/pyiceberg/catalog/glue.py
@@ -313,9 +313,7 @@ class GlueCatalog(MetastoreCatalog):
             endpoint_url=properties.get(GLUE_CATALOG_ENDPOINT),
             config=Config(
                 retries={
-                    "max_attempts": get_first_property_value(properties, GLUE_MAX_RETRIES)
-                    if get_first_property_value(properties, GLUE_MAX_RETRIES)
-                    else MAX_RETRIES,
+                    "max_attempts": properties.get(GLUE_MAX_RETRIES, MAX_RETRIES),
                     "mode": "standard",
                 }
             ),

--- a/tests/catalog/test_glue.py
+++ b/tests/catalog/test_glue.py
@@ -442,7 +442,6 @@ def test_list_tables(
     moto_endpoint_url: str,
     table_schema_nested: Schema,
     database_name: str,
-    table_name: str,
     table_list: List[str],
 ) -> None:
     test_catalog = GlueCatalog("glue", **{"s3.endpoint": moto_endpoint_url, "warehouse": f"s3://{BUCKET_NAME}/"})


### PR DESCRIPTION
Configurable retry mechanism for the Glue catalog Boto client.

- Setting the retry mode to `standard`
- Introducing a new configuration `glue.max-retries` with default value set to 10
- Adding the new configuration key to the documentation

Closes #1294 