### PR TITLE
Bug Fix: `metadata_location` to be optional in `TableResponse`

### DIFF
--- a/dev/docker-compose-integration.yml
+++ b/dev/docker-compose-integration.yml
@@ -41,7 +41,7 @@ services:
       - hive:hive
       - minio:minio
   rest:
-    image: tabulario/iceberg-rest
+    image: apache/iceberg-rest-adapter
     container_name: pyiceberg-rest
     networks:
       iceberg_net:

--- a/dev/docker-compose-integration.yml
+++ b/dev/docker-compose-integration.yml
@@ -41,7 +41,7 @@ services:
       - hive:hive
       - minio:minio
   rest:
-    image: apache/iceberg-rest-adapter
+    image: tabulario/iceberg-rest
     container_name: pyiceberg-rest
     networks:
       iceberg_net:

--- a/pyiceberg/catalog/rest.py
+++ b/pyiceberg/catalog/rest.py
@@ -156,7 +156,7 @@ _RETRY_ARGS = {
 
 
 class TableResponse(IcebergBaseModel):
-    metadata_location: Optional[str] = Field(alias="metadata-location")
+    metadata_location: Optional[str] = Field(alias="metadata-location", default=None)
     metadata: TableMetadata
     config: Properties = Field(default_factory=dict)
 
@@ -599,7 +599,6 @@ class RestCatalog(Catalog):
             response.raise_for_status()
         except HTTPError as exc:
             self._handle_non_200_response(exc, {409: TableAlreadyExistsError})
-
         return TableResponse(**response.json())
 
     @retry(**_RETRY_ARGS)

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -80,6 +80,17 @@ def example_table_metadata_with_snapshot_v1_rest_json(example_table_metadata_wit
 
 
 @pytest.fixture
+def example_table_metadata_with_no_location(example_table_metadata_with_snapshot_v1: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "metadata": example_table_metadata_with_snapshot_v1,
+        "config": {
+            "client.factory": "io.tabular.iceberg.catalog.TabularAwsClientFactory",
+            "region": "us-west-2",
+        },
+    }
+
+
+@pytest.fixture
 def example_table_metadata_no_snapshot_v1_rest_json(example_table_metadata_no_snapshot_v1: Dict[str, Any]) -> Dict[str, Any]:
     return {
         "metadata-location": "s3://warehouse/database/table/metadata.json",
@@ -897,6 +908,70 @@ def test_create_table_with_given_location_removes_trailing_slash_200(
     )
     assert rest_mock.last_request
     assert rest_mock.last_request.json()["location"] == location
+
+
+def test_create_staged_table_200(
+    rest_mock: Mocker,
+    table_schema_simple: Schema,
+    example_table_metadata_with_no_location: Dict[str, Any],
+    example_table_metadata_no_snapshot_v1_rest_json: Dict[str, Any],
+) -> None:
+    rest_mock.post(
+        f"{TEST_URI}v1/namespaces/fokko/tables",
+        json=example_table_metadata_with_no_location,
+        status_code=200,
+        request_headers=TEST_HEADERS,
+    )
+    rest_mock.post(
+        f"{TEST_URI}v1/namespaces/fokko/tables/fokko2",
+        json=example_table_metadata_no_snapshot_v1_rest_json,
+        status_code=200,
+        request_headers=TEST_HEADERS,
+    )
+    identifier = ("fokko", "fokko2")
+    catalog = RestCatalog("rest", uri=TEST_URI, token=TEST_TOKEN)
+    txn = catalog.create_table_transaction(
+        identifier=identifier,
+        schema=table_schema_simple,
+        location=None,
+        partition_spec=PartitionSpec(
+            PartitionField(source_id=1, field_id=1000, transform=TruncateTransform(width=3), name="id"), spec_id=1
+        ),
+        sort_order=SortOrder(SortField(source_id=2, transform=IdentityTransform())),
+        properties={"owner": "fokko"},
+    )
+    txn.commit_transaction()
+
+    actual_response = rest_mock.last_request.json()
+    expected = {
+        "identifier": {"namespace": ["fokko"], "name": "fokko2"},
+        "requirements": [{"type": "assert-create"}],
+        "updates": [
+            {"action": "assign-uuid", "uuid": "b55d9dda-6561-423a-8bfc-787980ce421f"},
+            {"action": "upgrade-format-version", "format-version": 1},
+            {
+                "action": "add-schema",
+                "schema": {
+                    "type": "struct",
+                    "fields": [
+                        {"id": 1, "name": "id", "type": "int", "required": False},
+                        {"id": 2, "name": "data", "type": "string", "required": False},
+                    ],
+                    "schema-id": 0,
+                    "identifier-field-ids": [],
+                },
+                "last-column-id": 2,
+            },
+            {"action": "set-current-schema", "schema-id": -1},
+            {"action": "add-spec", "spec": {"spec-id": 0, "fields": []}},
+            {"action": "set-default-spec", "spec-id": -1},
+            {"action": "add-sort-order", "sort-order": {"order-id": 0, "fields": []}},
+            {"action": "set-default-sort-order", "sort-order-id": -1},
+            {"action": "set-location", "location": "s3://warehouse/database/table"},
+            {"action": "set-properties", "updates": {"owner": "bryan", "write.metadata.compression-codec": "gzip"}},
+        ],
+    }
+    assert actual_response == expected
 
 
 def test_create_table_409(rest_mock: Mocker, table_schema_simple: Schema) -> None:


### PR DESCRIPTION
While testing out the iceberg-rest-catalog docker image, I ran into the following error when parsing the following example TableResponse that is created in `tests/integration/test_writes/test_writes.py::test_create_table_transaction[session_catalog-2]`
```
{'metadata': {'format-version': 2, 'table-uuid': 'f269bf0e-f8c9-4443-a341-e5bd4936892a', 'location': 's3://warehouse/default/arrow_create_table_transaction_local_2', 'last-sequence-number': 0, 'last-updated-ms': 1731553376222, 'last-column-id': 1, 'current-schema-id': 0, 'schemas': [{'type': 'struct', 'schema-id': 0, 'fields': [{'id': 1, 'name': 'foo', 'required': False, 'type': 'string'}]}], 'default-spec-id': 0, 'partition-specs': [{'spec-id': 0, 'fields': []}], 'last-partition-id': 999, 'default-sort-order-id': 0, 'sort-orders': [{'order-id': 0, 'fields': []}], 'properties': {'created-at': '2024-11-14T03:02:56.222721210Z', 'write.parquet.compression-codec': 'zstd'}, 'current-snapshot-id': -1, 'refs': {}, 'snapshots': [], 'statistics': [], 'partition-statistics': [], 'snapshot-log': [], 'metadata-log': []}}
```

Error trace
```
E       pydantic_core._pydantic_core.ValidationError: 1 validation error for TableResponse
E       metadata-location
E         Field required [type=missing, input_value={'metadata': {'format-ver...[], 'metadata-log': []}}, input_type=dict]
E           For further information visit https://errors.pydantic.dev/2.9/v/missing
```

The following is noted from [pydantic docs](https://docs.pydantic.dev/latest/migration/#required-optional-and-nullable-fields):
```
A field annotated as typing.Optional[T] will be required, and will allow for a value of None. It does not mean that the field has a default value of None. (This is a breaking change from V1.)
```

@kevinjqliu I think this is a bug that we should consider in cutting out a new RC for the ongoing 0.8.0 release. The implication of not fixing this bug, is that TableResponse from staged tables cannot be parsed by PyIceberg and will lead to a fatal exception :(

According to the Iceberg Rest Catalog Spec, the metadata-location is an optional field, and may be absent from the TableResponse

https://github.com/apache/iceberg/blob/3659ded18d50206576985339bd55cd82f5e200cc/open-api/rest-catalog-open-api.yaml#L3201-L3208