### PR TITLE
0.8.0 post release steps

### DIFF
--- a/.github/ISSUE_TEMPLATE/iceberg_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/iceberg_bug_report.yml
@@ -9,7 +9,8 @@ body:
       description: What Apache Iceberg version are you using?
       multiple: false
       options:
-        - "0.7.1 (latest release)"
+        - "0.8.0 (latest release)"
+        - "0.7.1"
         - "0.7.0"
         - "0.6.1"
         - "0.6.0"

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -39,7 +39,7 @@ WORKDIR ${SPARK_HOME}
 ENV SPARK_VERSION=3.5.0
 ENV ICEBERG_SPARK_RUNTIME_VERSION=3.5_2.12
 ENV ICEBERG_VERSION=1.6.0
-ENV PYICEBERG_VERSION=0.7.1
+ENV PYICEBERG_VERSION=0.8.0
 
 RUN curl --retry 3 -s -C - https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz -o spark-${SPARK_VERSION}-bin-hadoop3.tgz \
  && tar xzf spark-${SPARK_VERSION}-bin-hadoop3.tgz --directory /opt/spark --strip-components 1 \

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -822,7 +822,7 @@ class Table:
             row_filter:
                 A string or BooleanExpression that decsribes the
                 desired rows
-            selected_fileds:
+            selected_fields:
                 A tuple of strings representing the column names
                 to return in the output dataframe.
             case_sensitive:


### PR DESCRIPTION
This PR addresses post-release steps as documented in https://py.iceberg.apache.org/how-to-release/ including
* Update the Github template
* Update the integration tests

This PR also fixes `Release the docs` since `mkdocs build --strict` fails https://github.com/apache/iceberg-python/actions/runs/11898959772/job/33156549032



