### PR TITLE
dont override global warning

### DIFF
--- a/pyiceberg/utils/deprecated.py
+++ b/pyiceberg/utils/deprecated.py
@@ -55,11 +55,10 @@ def deprecation_message(deprecated_in: str, removed_in: str, help_message: Optio
 
 
 def _deprecation_warning(message: str) -> None:
-    warnings.simplefilter("always", DeprecationWarning)  # turn off filter
-
-    warnings.warn(
-        message,
-        category=DeprecationWarning,
-        stacklevel=2,
-    )
-    warnings.simplefilter("default", DeprecationWarning)  # reset filter
+    with warnings.catch_warnings():  # temporarily override warning handling
+        warnings.simplefilter("always", DeprecationWarning)  # turn off filter
+        warnings.warn(
+            message,
+            category=DeprecationWarning,
+            stacklevel=2,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -903,6 +903,8 @@ filterwarnings = [
   "ignore:unclosed <socket.socket",
   # Remove this in a future release of PySpark.
   "ignore:distutils Version classes are deprecated. Use packaging.version instead.",
+  # Remove this in a future release of PySpark. https://github.com/apache/iceberg-python/issues/1349
+  "ignore:datetime.datetime.utcfromtimestamp\\(\\) is deprecated and scheduled for removal in a future version.",
   # Remove this once https://github.com/boto/boto3/issues/3889 is fixed.
   "ignore:datetime.datetime.utcnow\\(\\) is deprecated and scheduled for removal in a future version.",
 ]


### PR DESCRIPTION
When looking into #1346, I was confused by why the `datetime.datetime.utcfromtimestamp` warning only errored for the branch and not for the `main` branch. 
Turns out there's a bug in the `_deprecation_warning` code where **all warnings** are suppressed when displaying a deprecation warning. The `datetime.datetime.utcfromtimestamp` warning is suppressed in the `main` branch because the test also triggered other deprecation warnings. When those deprecation warnings are removed in the feature branch, the only other warning is shown and causes the test to fail. 

This PR changes `_deprecation_warning` to temporarily override warning handling. 
