### PR TITLE
fix `KeyError` raised by `add_files` when parquet file doe not have column stats

### DIFF
--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -2397,8 +2397,8 @@ def data_file_statistics_from_parquet_metadata(
     split_offsets.sort()
 
     for field_id in invalidate_col:
-        del col_aggs[field_id]
-        del null_value_counts[field_id]
+        col_aggs.pop(field_id, None)
+        null_value_counts.pop(field_id, None)
 
     return DataFileStatistics(
         record_count=parquet_metadata.num_rows,

--- a/tests/io/test_pyarrow_stats.py
+++ b/tests/io/test_pyarrow_stats.py
@@ -711,12 +711,13 @@ def test_read_missing_statistics() -> None:
 
     # expect only "strings" column values to be reflected in the
     # upper_bound, lower_bound and null_value_counts props of datafile
+    string_col_idx = 1
     assert len(datafile.lower_bounds) == 1
-    assert datafile.lower_bounds[1].decode() == "aaaaaaaaaaaaaaaa"
+    assert datafile.lower_bounds[string_col_idx].decode() == "aaaaaaaaaaaaaaaa"
     assert len(datafile.upper_bounds) == 1
-    assert datafile.upper_bounds[1].decode() == "zzzzzzzzzzzzzzz{"
+    assert datafile.upper_bounds[string_col_idx].decode() == "zzzzzzzzzzzzzzz{"
     assert len(datafile.null_value_counts) == 1
-    assert datafile.null_value_counts[1] == 1
+    assert datafile.null_value_counts[string_col_idx] == 1
 
 
 # This is commented out for now because write_to_dataset drops the partition


### PR DESCRIPTION
Resolves #1353, by switching `del` with `pop` to prevent `KeyError`.