### PR TITLE
Improve documentation for "how to release"

### DIFF
--- a/mkdocs/docs/how-to-release.md
+++ b/mkdocs/docs/how-to-release.md
@@ -334,7 +334,7 @@ Thanks to everyone for contributing!
 
 ### Release the docs
 
-Run the [`Python Docs` Github Action](https://github.com/apache/iceberg-python/actions/workflows/python-ci-docs.yml).
+Run the [`Python Docs` Github Action](https://github.com/apache/iceberg-python/actions/workflows/python-release-docs.yml).
 
 ### Update the Github template
 

--- a/mkdocs/docs/how-to-release.md
+++ b/mkdocs/docs/how-to-release.md
@@ -19,23 +19,23 @@
 
 # How to Release
 
-This guide documents the process for releasing PyIceberg following the [Apache Release Process](https://infra.apache.org/release-publishing.html). The process involves:
+This guide outlines the process for releasing PyIceberg in accordance with the [Apache Release Process](https://infra.apache.org/release-publishing.html). The steps include:
 
 1. Preparing for a release
-2. Publishing a release candidate (RC)
-3. Community voting and validation
-4. Publishing the final release if the vote passes
-5. Post release
+2. Publishing a Release Candidate (RC)
+3. Community Voting and Validation
+4. Publishing the Final Release (if the vote passes)
+5. Post-Release Step
 
 ## Requirements
 
-* GPG key registered and published in [Apache Iceberg KEYS file](https://downloads.apache.org/iceberg/KEYS). See instructions at [Set up GPG key and Upload to Apache Iceberg KEYS file](#set-up-gpg-key-and-upload-to-apache-iceberg-keys-file).
-* SVN
-    * Access to Apache SVN for uploading artifacts to [Apache Iceberg dev dist](https://dist.apache.org/repos/dist/dev/iceberg/) (requires Apache Commmitter)
-    * Access to Apache SVN for uploading artifacts to [Apache Iceberg release dist](https://dist.apache.org/repos/dist/release/iceberg/) (requires Apache PMC)
-* PyPI
-    * `twine` installed for uploading to PyPi
-    * PyPI account with access to publish to the [pyiceberg project](https://pypi.org/project/pyiceberg/)
+* A GPG key must be registered and published in the [Apache Iceberg KEYS file](https://downloads.apache.org/iceberg/KEYS). Follow [the instructions for setting up a GPG key and uploading it to the KEYS file](#set-up-gpg-key-and-upload-to-apache-iceberg-keys-file).
+* SVN Access
+    * Permission to upload artifacts to the [Apache development distribution](https://dist.apache.org/repos/dist/dev/iceberg/) (requires Apache Commmitter access).
+    * Permission to upload artifacts to the [Apache release distribution](https://dist.apache.org/repos/dist/release/iceberg/) (requires Apache PMC access).
+* PyPI Access
+    * The `twine` package must be installed for uploading releases to PyPi.
+    * A PyPI account with publishing permissions for the [pyiceberg project](https://pypi.org/project/pyiceberg/).
 
 ## Preparing for a Release
 

--- a/mkdocs/docs/how-to-release.md
+++ b/mkdocs/docs/how-to-release.md
@@ -334,7 +334,7 @@ Thanks to everyone for contributing!
 
 ### Release the docs
 
-Run the [`Python Docs` Github Action](https://github.com/apache/iceberg-python/actions/workflows/python-release-docs.yml).
+Run the [`Release Docs` Github Action](https://github.com/apache/iceberg-python/actions/workflows/python-release-docs.yml).
 
 ### Update the Github template
 

--- a/mkdocs/docs/how-to-release.md
+++ b/mkdocs/docs/how-to-release.md
@@ -146,6 +146,14 @@ svn ci -m "PyIceberg ${VERSION}" ${SVN_TMP_DIR_VERSIONED}
 
 Verify the artifact is uploaded to [https://dist.apache.org/repos/dist/dev/iceberg](https://dist.apache.org/repos/dist/dev/iceberg/).
 
+##### Remove Old Artifacts From Apache Dev SVN
+
+Clean up old RC artifacts:
+
+```bash
+svn delete https://dist.apache.org/repos/dist/dev/iceberg/pyiceberg-<OLD_RC_VERSION> -m "Remove old RC artifacts"
+```
+
 #### Upload to PyPi
 
 ##### Create Artifacts for PyPi
@@ -274,6 +282,14 @@ svn mv ${SVN_DEV_DIR_VERSIONED} ${SVN_RELEASE_DIR_VERSIONED} -m "PyIceberg: Add 
 ```
 
 Verify the artifact is uploaded to [https://dist.apache.org/repos/dist/release/iceberg](https://dist.apache.org/repos/dist/release/iceberg/).
+
+### Remove Old Artifacts From Apache Release SVN
+
+We only want to host the latest release. Clean up old release artifacts:
+
+```bash
+svn delete https://dist.apache.org/repos/dist/release/iceberg/pyiceberg-<OLD_RELEASE_VERSION> -m "Remove old release artifacts"
+```
 
 ### Upload the accepted release to PyPi
 

--- a/mkdocs/docs/how-to-release.md
+++ b/mkdocs/docs/how-to-release.md
@@ -70,6 +70,30 @@ Update the version in `pyproject.toml` and `pyiceberg/__init__.py` to match the 
 
 ## Publishing a Release Candidate (RC)
 
+### Release Types
+
+#### Major/Minor Release
+
+* Use the `main` branch for the release.
+* Includes new features, enhancements, and any necessary backward-compatible changes.
+* Examples: `0.8.0`, `0.9.0`, `1.0.0`.
+
+#### Patch Release
+
+* Use the branch corresponding to the patch version, such as `pyiceberg-0.8.x`.
+* Focuses on critical bug fixes or security patches that maintain backward compatibility.
+* Examples: `0.8.1`, `0.8.2`.
+
+To create a patch branch from the latest release tag:
+
+```bash
+# Check out the base branch for the patch version
+git checkout pyiceberg-0.8.x
+
+# Create a new branch for the upcoming patch release
+git checkout -b pyiceberg-0.8.1
+```
+
 ### Create Tag
 
 Ensure you are on the correct branch:

--- a/mkdocs/docs/how-to-release.md
+++ b/mkdocs/docs/how-to-release.md
@@ -138,6 +138,8 @@ svn add $SVN_TMP_DIR_VERSIONED
 svn ci -m "PyIceberg ${VERSION}" ${SVN_TMP_DIR_VERSIONED}
 ```
 
+Verify the artifact is uploaded to [https://dist.apache.org/repos/dist/dev/iceberg](https://dist.apache.org/repos/dist/dev/iceberg/).
+
 #### Upload to PyPi
 
 ##### Create Artifacts for PyPi
@@ -160,6 +162,8 @@ Upload release candidate to PyPi. This **won't** bump the version for everyone t
 ```bash
 twine upload release-${VERSION}/*
 ```
+
+Verify the artifact is uploaded to [PyPi](https://pypi.org/project/pyiceberg/#history).
 
 ## Vote
 
@@ -256,6 +260,8 @@ export SVN_RELEASE_DIR_VERSIONED="https://dist.apache.org/repos/dist/release/ice
 svn mv ${SVN_DEV_DIR_VERSIONED} ${SVN_RELEASE_DIR_VERSIONED} -m "PyIceberg: Add release ${VERSION_WITHOUT_RC}"
 ```
 
+Verify the artifact is uploaded to [https://dist.apache.org/repos/dist/release/iceberg](https://dist.apache.org/repos/dist/release/iceberg/).
+
 ### Upload the accepted release to PyPi
 
 The latest version can be pushed to PyPi. Check out the Apache SVN and make sure to publish the right version with `twine`:
@@ -265,6 +271,8 @@ svn checkout https://dist.apache.org/repos/dist/release/iceberg /tmp/iceberg-dis
 cd /tmp/iceberg-dist-release/pyiceberg-${VERSION_WITHOUT_RC}
 twine upload pyiceberg-*.whl pyiceberg-*.tar.gz
 ```
+
+Verify the artifact is uploaded to [PyPi](https://pypi.org/project/pyiceberg/#history).
 
 ## Post Release
 

--- a/mkdocs/docs/how-to-release.md
+++ b/mkdocs/docs/how-to-release.md
@@ -29,7 +29,7 @@ This guide documents the process for releasing PyIceberg following the [Apache R
 
 ## Requirements
 
-* GPG key registered and published in [Apache Iceberg KEYS file](https://downloads.apache.org/iceberg/KEYS)
+* GPG key registered and published in [Apache Iceberg KEYS file](https://downloads.apache.org/iceberg/KEYS). See instructions at [Set up GPG key and Upload to Apache Iceberg KEYS file](#set-up-gpg-key-and-upload-to-apache-iceberg-keys-file).
 * SVN
     * Access to Apache SVN for uploading artifacts to [Apache Iceberg dev dist](https://dist.apache.org/repos/dist/dev/iceberg/) (requires Apache Commmitter)
     * Access to Apache SVN for uploading artifacts to [Apache Iceberg release dist](https://dist.apache.org/repos/dist/release/iceberg/) (requires Apache PMC)
@@ -41,7 +41,7 @@ This guide documents the process for releasing PyIceberg following the [Apache R
 
 ### Remove Deprecated APIs
 
-Before running the release candidate, we want to remove any APIs that were marked for removal under the `@deprecated` tag for this release.
+Before running the release candidate, we want to remove any APIs that were marked for removal under the `@deprecated` tag for this release. See [#1269](https://github.com/apache/iceberg-python/pull/1269).
 
 For example, the API with the following deprecation tag should be removed when preparing for the 0.2.0 release.
 
@@ -66,7 +66,7 @@ deprecation_message(
 
 ### Update Library Version
 
-Update the version in `pyproject.toml` and `pyiceberg/__init__.py` to match the release version.
+Update the version in `pyproject.toml` and `pyiceberg/__init__.py` to match the release version. See [#1276](https://github.com/apache/iceberg-python/pull/1276).
 
 ## Publishing a release candidate (RC)
 
@@ -313,3 +313,22 @@ Then, select the previous release version as the **Previous tag** to use the dif
 **Generate release notes**.
 
 **Set as the latest release** and **Publish**.
+
+## Misc
+
+### Set up GPG key and Upload to Apache Iceberg KEYS file
+
+To set up GPG key locally, see the instructions [here](http://www.apache.org/dev/openpgp.html#key-gen-generate-key).
+
+To install gpg on a M1 based Mac, a couple of additional steps are required: <https://gist.github.com/phortuin/cf24b1cca3258720c71ad42977e1ba57>.
+
+Then, published GPG key to the [Apache Iceberg KEYS file](https://downloads.apache.org/iceberg/KEYS):
+
+```bash
+svn co https://dist.apache.org/repos/dist/release/iceberg icebergsvn
+cd icebergsvn
+echo "" >> KEYS # append a newline
+gpg --list-sigs <YOUR KEY ID HERE> >> KEYS # append signatures
+gpg --armor --export <YOUR KEY ID HERE> >> KEYS # append public key block
+svn commit -m "add key for <YOUR NAME HERE>"
+```

--- a/mkdocs/docs/how-to-release.md
+++ b/mkdocs/docs/how-to-release.md
@@ -68,18 +68,18 @@ deprecation_message(
 
 Update the version in `pyproject.toml` and `pyiceberg/__init__.py` to match the release version. See [#1276](https://github.com/apache/iceberg-python/pull/1276).
 
-## Publishing a release candidate (RC)
+## Publishing a Release Candidate (RC)
 
 ### Create Tag
 
-Make sure you are on the correct branch:
+Ensure you are on the correct branch:
 
-* For a Major/Minor release, use the `main` branch
-* For a Patch release, use the branch corresponding to the pathch version, i.e. `pyiceberg-0.6.x`.
+* For a major/minor release, use the `main` branch
+* For a patch release, use the branch corresponding to the patch version, i.e. `pyiceberg-0.6.x`.
 
-Then, create a signed tag:
+Create a signed tag:
 
-Change `VERSION` and `RC` to the appropriate values.
+Replace `VERSION` and `RC` with the appropriate values for the release.
 
 ```bash
 export RC=rc1
@@ -92,7 +92,7 @@ git tag -s ${GIT_TAG} -m "PyIceberg ${VERSION}"
 git push git@github.com:apache/iceberg-python.git ${GIT_TAG}
 ```
 
-### Publish RC
+### Publish Release Candidate (RC)
 
 #### Upload to Apache Dev SVN
 
@@ -100,18 +100,24 @@ git push git@github.com:apache/iceberg-python.git ${GIT_TAG}
 
 Run the [`Python release` Github Action](https://github.com/apache/iceberg-python/actions/workflows/python-release.yml).
 
-* Use the newly created tag.
-* Set the `version` to `main`, since we cannot modify the source.
+* Tag: Use the newly created tag.
+* Version: Set the `version` to `main`, as the source cannot be modified.
 
 ![Github Actions Run Workflow for SVN Upload](assets/images/ghactions-run-workflow-svn-upload.png)
 
-This will create the source distribution (`sdist`) and the binary distributions (`wheels`) for each architectures, using [`cibuildwheel`](https://github.com/pypa/cibuildwheel)
+This action will generate:
 
-##### Download Artifacts, Sign and Generate Checksums
+* Source distribution (`sdist`)
+* Binary distributions (`wheels`) for each architectures. These are created using [`cibuildwheel`](https://github.com/pypa/cibuildwheel)
 
-Before committing the files to the Apache SVN artifact distribution SVN hashes need to be generated, and those need to be signed with gpg to make sure that they are authentic.
+##### Download Artifacts, Sign, and Generate Checksums
 
-Download the zip file from the Github Action run, unzip, and sign the files:
+Download the ZIP file containing the artifacts from the GitHub Actions run and unzip it.
+
+Navigate to the release directory. Sign the files and generate checksums:
+
+* `.asc` files: GPG-signed versions of each artifact to ensure authenticity.
+* `.sha512` files: SHA-512 checksums for verifying file integrity.
 
 ```bash
 cd release-main/
@@ -146,8 +152,8 @@ Verify the artifact is uploaded to [https://dist.apache.org/repos/dist/dev/icebe
 
 Run the [`Python release` Github Action](https://github.com/apache/iceberg-python/actions/workflows/python-release.yml).
 
-* Use the newly created tag.
-* Set the `version` to release candidate, e.g. `0.7.0rc1`.
+* Tag: Use the newly created tag.
+* Version: Set the `version` to release candidate, e.g. `0.7.0rc1`.
 
 ![Github Actions Run Workflow for PyPi Upload](assets/images/ghactions-run-workflow-pypi-upload.png)
 

--- a/mkdocs/docs/how-to-release.md
+++ b/mkdocs/docs/how-to-release.md
@@ -21,7 +21,7 @@
 
 This guide documents the process for releasing PyIceberg following the [Apache Release Process](https://infra.apache.org/release-publishing.html). The process involves:
 
-1. Prepare for a release
+1. Preparing for a release
 2. Publishing a release candidate (RC)
 3. Community voting and validation
 4. Publishing the final release if the vote passes
@@ -30,18 +30,18 @@ This guide documents the process for releasing PyIceberg following the [Apache R
 ## Requirements
 
 * GPG key registered and published in [Apache Iceberg KEYS file](https://downloads.apache.org/iceberg/KEYS)
+* SVN
+    * Access to Apache SVN for uploading artifacts to [Apache Iceberg dev dist](https://dist.apache.org/repos/dist/dev/iceberg/) (requires Apache Commmitter)
+    * Access to Apache SVN for uploading artifacts to [Apache Iceberg release dist](https://dist.apache.org/repos/dist/release/iceberg/) (requires Apache PMC)
 * PyPI
     * `twine` installed for uploading to PyPi
     * PyPI account with access to publish to the [pyiceberg project](https://pypi.org/project/pyiceberg/)
-* SVN
-    * Access to Apache SVN for uploading artifacts to [Apache Iceberg dev/ dist](https://dist.apache.org/repos/dist/dev/iceberg/) (requires Apache Commmitter)
-    * Access to Apache SVN for uploading artifacts to [Apache Iceberg release/ dist](https://dist.apache.org/repos/dist/release/iceberg/) (requires Apache PMC)
 
 ## Preparing for a Release
 
 ### Remove Deprecated APIs
 
-Before running the release candidate, we want to remove any APIs that were marked for removal under the @deprecated tag for this release.
+Before running the release candidate, we want to remove any APIs that were marked for removal under the `@deprecated` tag for this release.
 
 For example, the API with the following deprecation tag should be removed when preparing for the 0.2.0 release.
 
@@ -68,16 +68,18 @@ deprecation_message(
 
 Update the version in `pyproject.toml` and `pyiceberg/__init__.py` to match the release version.
 
-## Release
+## Publishing a release candidate (RC)
 
 ### Create Tag
 
 Make sure you are on the correct branch:
 
-* For a Major/Minor release, make sure that you're on `main`
-* For a Patch release, make sure that you're on the branch corresponding to the pathch version, i.e. `pyiceberg-0.6.x`.
+* For a Major/Minor release, use the `main` branch
+* For a Patch release, use the branch corresponding to the pathch version, i.e. `pyiceberg-0.6.x`.
 
 Then, create a signed tag:
+
+Change `VERSION` and `RC` to the appropriate values.
 
 ```bash
 export RC=rc1
@@ -123,7 +125,7 @@ done
 
 ##### Upload Artifacts to Apache Dev SVN
 
-Now we can upload the files from the same directory:
+Now, upload the files from the same directory:
 
 ```bash
 export SVN_TMP_DIR=/tmp/iceberg-${VERSION_BRANCH}/
@@ -216,13 +218,13 @@ EOF
 
 ### Send Vote Email
 
-Send the content of `release-announcement-email.txt` to `dev@iceberg.apache.org`.
+Verify the content of `release-announcement-email.txt` and send it to `dev@iceberg.apache.org` with the corresponding subject line.
 
 ## Vote has failed
 
 If there are concerns with the RC, address the issues and generate another RC.
 
-## Vote has passed
+## Publish the Final Release (Vote has passed)
 
 A minimum of 3 binding +1 votes is required to pass an RC.
 Once the vote has been passed, you can close the vote thread by concluding it:
@@ -290,15 +292,15 @@ Thanks to everyone for contributing!
 
 Run the [`Python Docs` Github Action](https://github.com/apache/iceberg-python/actions/workflows/python-ci-docs.yml).
 
-## Update the Github template
+### Update the Github template
 
 Make sure to create a PR to update the [GitHub issues template](https://github.com/apache/iceberg-python/blob/main/.github/ISSUE_TEMPLATE/iceberg_bug_report.yml) with the latest version.
 
-## Update the integration tests
+### Update the integration tests
 
 Ensure to update the `PYICEBERG_VERSION` in the [Dockerfile](https://github.com/apache/iceberg-python/blob/main/dev/Dockerfile).
 
-## Create a Github Release Note
+### Create a Github Release Note
 
 Create a [new Release Note](https://github.com/apache/iceberg-python/releases/new) on the iceberg-python Github repository.
 

--- a/mkdocs/docs/how-to-release.md
+++ b/mkdocs/docs/how-to-release.md
@@ -159,6 +159,13 @@ Download the zip file from the Github Action run and unzip locally.
 
 Upload release candidate to PyPi. This **won't** bump the version for everyone that hasn't pinned their version, since it is set to an RC [pre-release and those are ignored](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#pre-release-versioning).
 
+<!-- prettier-ignore-start -->
+
+!!! note
+    `twine` might require an PyPi API token.
+
+<!-- prettier-ignore-end -->
+
 ```bash
 twine upload release-${VERSION}/*
 ```
@@ -265,6 +272,13 @@ Verify the artifact is uploaded to [https://dist.apache.org/repos/dist/release/i
 ### Upload the accepted release to PyPi
 
 The latest version can be pushed to PyPi. Check out the Apache SVN and make sure to publish the right version with `twine`:
+
+<!-- prettier-ignore-start -->
+
+!!! note
+    `twine` might require an PyPi API token.
+
+<!-- prettier-ignore-end -->
 
 ```bash
 svn checkout https://dist.apache.org/repos/dist/release/iceberg /tmp/iceberg-dist-release/


### PR DESCRIPTION
Closes #1306

Uploaded the documentation for "how to release" based on recent experience with releasing 0.8.0 (See [PyIceberg 0.8.0 release notes](https://docs.google.com/document/d/1gPG8pZKavUgd-Avj4Od8qJSP7fCd9ga6x6qVqaaDw1w/edit?usp=sharing))

Additional potential improvements
* Use `gh` command to trigger GitHub Actions and download artifacts (similar to [iceberg-go release script](https://github.com/apache/iceberg-go/blob/adc8193de3299b04c9763c2fba529a7b94d080ce/dev/release/release_rc.sh#L89-L96))
* Consider triggering `Python release` github action on tag push. Is it possible to run the release action once instead of twice (main + tag)?
