### PR TITLE
check mkdocs build strict in CI

### DIFF
--- a/.github/workflows/python-ci-docs.yml
+++ b/.github/workflows/python-ci-docs.yml
@@ -17,9 +17,13 @@
 # under the License.
 #
 
-name: "Python Docs"
+name: "Python CI Docs"
 on:
-  workflow_dispatch:
+  push:
+    branches:
+    - 'main'
+  pull_request:
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -40,17 +44,3 @@ jobs:
       - name: Build
         working-directory: ./mkdocs
         run: mkdocs build --strict
-      - name: Copy
-        working-directory: ./mkdocs
-        run: mv ./site /tmp/site
-      - name: Push changes to gh-pages branch
-        run: |
-          git checkout --orphan gh-pages-tmp
-          git rm --quiet -rf .
-          cp -r /tmp/site/* .
-          git config --global user.name 'GitHub Actions'
-          git config --global user.email 'actions@github.com'
-          echo "py.iceberg.apache.org" > CNAME
-          git add --all
-          git commit -m 'Publish Python docs'
-          git push -f origin gh-pages-tmp:gh-pages || true

--- a/.github/workflows/python-ci-docs.yml
+++ b/.github/workflows/python-ci-docs.yml
@@ -18,10 +18,11 @@
 #
 
 name: "Python CI Docs"
+
 on:
   push:
     branches:
-    - 'main'
+      - 'main'
   pull_request:
 
 
@@ -37,7 +38,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python }}
+          python-version: 3.12
       - name: Install
         working-directory: ./mkdocs
         run: pip install -r requirements.txt

--- a/.github/workflows/python-release-docs.yml
+++ b/.github/workflows/python-release-docs.yml
@@ -1,0 +1,56 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: "Release Docs"
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  docs:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install
+        working-directory: ./mkdocs
+        run: pip install -r requirements.txt
+      - name: Build
+        working-directory: ./mkdocs
+        run: mkdocs build --strict
+      - name: Copy
+        working-directory: ./mkdocs
+        run: mv ./site /tmp/site
+      - name: Push changes to gh-pages branch
+        run: |
+          git checkout --orphan gh-pages-tmp
+          git rm --quiet -rf .
+          cp -r /tmp/site/* .
+          git config --global user.name 'GitHub Actions'
+          git config --global user.email 'actions@github.com'
+          echo "py.iceberg.apache.org" > CNAME
+          git add --all
+          git commit -m 'Publish Python docs'
+          git push -f origin gh-pages-tmp:gh-pages || true


### PR DESCRIPTION
This PR adds a new GitHub Action to run `mkdocs build --strict` for every PR.

* `python-ci-docs.yml` was previously used to release doc changes, it's copied over and renamed to `python-release-docs.yml`.
* `python-ci-docs.yml` now runs `mkdocs build --strict` for every PR.

When releasing docs, the `python-ci-docs.yml` GitHub Action uses `--strict`. This action is only triggered during the release process, which requires an ad-hoc fix, see #1334.

https://github.com/apache/iceberg-python/blob/7a83695330518bea0dee589b5b513297c4d59b66/.github/workflows/python-ci-docs.yml#L42

Lets make sure this is checked in new PRs
