### PR TITLE
Added support for lowercase FileFormat for Issue #1340

### DIFF
--- a/pyiceberg/manifest.py
+++ b/pyiceberg/manifest.py
@@ -97,7 +97,7 @@ class FileFormat(str, Enum):
     PARQUET = "PARQUET", "parquet"
     ORC = "ORC", "orc"
 
-    def __new__(cls, value, *value_aliases):
+    def __new__(cls, value: str, *value_aliases: List[str]) -> "FileFormat":
         obj = str.__new__(cls)
         obj._value_ = value
         for alias in value_aliases:

--- a/pyiceberg/manifest.py
+++ b/pyiceberg/manifest.py
@@ -93,9 +93,16 @@ class ManifestEntryStatus(int, Enum):
 
 
 class FileFormat(str, Enum):
-    AVRO = "AVRO"
-    PARQUET = "PARQUET"
-    ORC = "ORC"
+    AVRO = "AVRO", "avro"
+    PARQUET = "PARQUET", "parquet"
+    ORC = "ORC", "orc"
+
+    def __new__(cls, value, *value_aliases):
+        obj = str.__new__(cls)
+        obj._value_ = value
+        for alias in value_aliases:
+            cls._value2member_map_[alias] = obj
+        return obj
 
     def __repr__(self) -> str:
         """Return the string representation of the FileFormat class."""


### PR DESCRIPTION
Modified the FileFormat class so that it utilizes EnumMeta value aliases.

This allows specifying both "AVRO" and "avro" to map to AVRO, for example.

This addresses Issue #1340

Closes #1340 