### PR TITLE
Deprecate the use of `last-column-id`

### DIFF
--- a/pyiceberg/table/update/__init__.py
+++ b/pyiceberg/table/update/__init__.py
@@ -88,7 +88,15 @@ class AddSchemaUpdate(IcebergBaseModel):
     action: Literal["add-schema"] = Field(default="add-schema")
     schema_: Schema = Field(alias="schema")
     # This field is required: https://github.com/apache/iceberg/pull/7445
-    last_column_id: int = Field(alias="last-column-id")
+    last_column_id: Optional[int] = Field(
+        alias="last-column-id",
+        default=None,
+        deprecated=deprecation_notice(
+            deprecated_in="0.9.0",
+            removed_in="0.10.0",
+            help_message="last-field-id is handled internally, and should not be part of the update.",
+        ),
+    )
 
     initial_change: bool = Field(
         default=False,
@@ -318,11 +326,8 @@ def _(update: RemovePropertiesUpdate, base_metadata: TableMetadata, context: _Ta
 
 @_apply_table_update.register(AddSchemaUpdate)
 def _(update: AddSchemaUpdate, base_metadata: TableMetadata, context: _TableMetadataUpdateContext) -> TableMetadata:
-    if update.last_column_id < base_metadata.last_column_id:
-        raise ValueError(f"Invalid last column id {update.last_column_id}, must be >= {base_metadata.last_column_id}")
-
     metadata_updates: Dict[str, Any] = {
-        "last_column_id": update.last_column_id,
+        "last_column_id": max(base_metadata.last_column_id, update.schema_.highest_field_id),
         "schemas": base_metadata.schemas + [update.schema_],
     }
 


### PR DESCRIPTION
This should not be part of the public API: https://github.com/apache/iceberg/pull/11514

This PR depends on a later version of the REST catalog for the integration tests.