### PR TITLE
[release] Pyiceberg 0.8.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/iceberg_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/iceberg_bug_report.yml
@@ -9,7 +9,8 @@ body:
       description: What Apache Iceberg version are you using?
       multiple: false
       options:
-        - "0.7.1 (latest release)"
+        - "0.8.0 (latest release)"
+        - "0.7.1"
         - "0.7.0"
         - "0.6.1"
         - "0.6.0"

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -39,7 +39,7 @@ WORKDIR ${SPARK_HOME}
 ENV SPARK_VERSION=3.5.0
 ENV ICEBERG_SPARK_RUNTIME_VERSION=3.5_2.12
 ENV ICEBERG_VERSION=1.6.0
-ENV PYICEBERG_VERSION=0.7.1
+ENV PYICEBERG_VERSION=0.8.0
 
 RUN curl --retry 3 -s -C - https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz -o spark-${SPARK_VERSION}-bin-hadoop3.tgz \
  && tar xzf spark-${SPARK_VERSION}-bin-hadoop3.tgz --directory /opt/spark --strip-components 1 \

--- a/mkdocs/docs/how-to-release.md
+++ b/mkdocs/docs/how-to-release.md
@@ -87,11 +87,14 @@ Update the version in `pyproject.toml` and `pyiceberg/__init__.py` to match the 
 To create a patch branch from the latest release tag:
 
 ```bash
-# Check out the base branch for the patch version
-git checkout pyiceberg-0.8.x
+# Fetch all tags
+git fetch --tags
 
-# Create a new branch for the upcoming patch release
-git checkout -b pyiceberg-0.8.1
+# Assuming 0.8.0 is the latest release tag
+git checkout -b pyiceberg-0.8.x pyiceberg-0.8.0
+
+# Cherry-pick commits for the upcoming patch release
+git cherry-pick <commit>
 ```
 
 ### Create Tag

--- a/mkdocs/docs/how-to-release.md
+++ b/mkdocs/docs/how-to-release.md
@@ -17,15 +17,31 @@
   - under the License.
   -->
 
-# How to release
+# How to Release
 
-The guide to release PyIceberg.
+This guide outlines the process for releasing PyIceberg in accordance with the [Apache Release Process](https://infra.apache.org/release-publishing.html). The steps include:
 
-The first step is to publish a release candidate (RC) and publish it to the public for testing and validation. Once the vote has passed on the RC, the RC turns into the new release.
+1. Preparing for a release
+2. Publishing a Release Candidate (RC)
+3. Community Voting and Validation
+4. Publishing the Final Release (if the vote passes)
+5. Post-Release Step
 
-## Preparing for a release
+## Requirements
 
-Before running the release candidate, we want to remove any APIs that were marked for removal under the @deprecated tag for this release.
+* A GPG key must be registered and published in the [Apache Iceberg KEYS file](https://downloads.apache.org/iceberg/KEYS). Follow [the instructions for setting up a GPG key and uploading it to the KEYS file](#set-up-gpg-key-and-upload-to-apache-iceberg-keys-file).
+* SVN Access
+    * Permission to upload artifacts to the [Apache development distribution](https://dist.apache.org/repos/dist/dev/iceberg/) (requires Apache Commmitter access).
+    * Permission to upload artifacts to the [Apache release distribution](https://dist.apache.org/repos/dist/release/iceberg/) (requires Apache PMC access).
+* PyPI Access
+    * The `twine` package must be installed for uploading releases to PyPi.
+    * A PyPI account with publishing permissions for the [pyiceberg project](https://pypi.org/project/pyiceberg/).
+
+## Preparing for a Release
+
+### Remove Deprecated APIs
+
+Before running the release candidate, we want to remove any APIs that were marked for removal under the `@deprecated` tag for this release. See [#1269](https://github.com/apache/iceberg-python/pull/1269).
 
 For example, the API with the following deprecation tag should be removed when preparing for the 0.2.0 release.
 
@@ -48,23 +64,46 @@ deprecation_message(
 )
 ```
 
-## Running a release candidate
+### Update Library Version
 
-Make sure that the version is correct in `pyproject.toml` and `pyiceberg/__init__.py`. Correct means that it reflects the version that you want to release.
+Update the version in `pyproject.toml` and `pyiceberg/__init__.py` to match the release version. See [#1276](https://github.com/apache/iceberg-python/pull/1276).
 
-### Setting the tag
+## Publishing a Release Candidate (RC)
 
-Make sure that you're on the right branch, and the latest branch:
+### Release Types
 
-For a Major/Minor release, make sure that you're on `main`, for patch versions the branch corresponding to the version that you want to patch, i.e. `pyiceberg-0.6.x`.
+#### Major/Minor Release
+
+* Use the `main` branch for the release.
+* Includes new features, enhancements, and any necessary backward-compatible changes.
+* Examples: `0.8.0`, `0.9.0`, `1.0.0`.
+
+#### Patch Release
+
+* Use the branch corresponding to the patch version, such as `pyiceberg-0.8.x`.
+* Focuses on critical bug fixes or security patches that maintain backward compatibility.
+* Examples: `0.8.1`, `0.8.2`.
+
+To create a patch branch from the latest release tag:
 
 ```bash
-git checkout <branch>
-git fetch --all
-git reset --hard apache/<branch>
+# Check out the base branch for the patch version
+git checkout pyiceberg-0.8.x
+
+# Create a new branch for the upcoming patch release
+git checkout -b pyiceberg-0.8.1
 ```
 
-Set the tag on the last commit:
+### Create Tag
+
+Ensure you are on the correct branch:
+
+* For a major/minor release, use the `main` branch
+* For a patch release, use the branch corresponding to the patch version, i.e. `pyiceberg-0.6.x`.
+
+Create a signed tag:
+
+Replace `VERSION` and `RC` with the appropriate values for the release.
 
 ```bash
 export RC=rc1
@@ -74,48 +113,49 @@ export VERSION_BRANCH=${VERSION_WITHOUT_RC//./-}
 export GIT_TAG=pyiceberg-${VERSION}
 
 git tag -s ${GIT_TAG} -m "PyIceberg ${VERSION}"
-git push apache ${GIT_TAG}
-
-export GIT_TAG_REF=$(git show-ref ${GIT_TAG})
-export GIT_TAG_HASH=${GIT_TAG_REF:0:40}
-export LAST_COMMIT_ID=$(git rev-list ${GIT_TAG} 2> /dev/null | head -n 1)
+git push git@github.com:apache/iceberg-python.git ${GIT_TAG}
 ```
 
-The `-s` option will sign the commit. If you don't have a key yet, you can find the instructions [here](http://www.apache.org/dev/openpgp.html#key-gen-generate-key). To install gpg on a M1 based Mac, a couple of additional steps are required: <https://gist.github.com/phortuin/cf24b1cca3258720c71ad42977e1ba57>.
-If you have not published your GPG key in [KEYS](https://downloads.apache.org/iceberg/KEYS) yet, you must publish it before sending the vote email by doing:
+### Publish Release Candidate (RC)
 
-```bash
-svn co https://dist.apache.org/repos/dist/release/iceberg icebergsvn
-cd icebergsvn
-echo "" >> KEYS # append a newline
-gpg --list-sigs <YOUR KEY ID HERE> >> KEYS # append signatures
-gpg --armor --export <YOUR KEY ID HERE> >> KEYS # append public key block
-svn commit -m "add key for <YOUR NAME HERE>"
-```
+#### Upload to Apache Dev SVN
 
-### Upload to Apache SVN
+##### Create Artifacts for SVN
 
-Both the source distribution (`sdist`) and the binary distributions (`wheels`) need to be published for the RC. The wheels are convenient to avoid having people to install compilers locally. The downside is that each architecture requires its own wheel. [use `cibuildwheel`](https://github.com/pypa/cibuildwheel) runs in Github actions to create a wheel for each of the architectures.
+Run the [`Python release` Github Action](https://github.com/apache/iceberg-python/actions/workflows/python-release.yml).
 
-Before committing the files to the Apache SVN artifact distribution SVN hashes need to be generated, and those need to be signed with gpg to make sure that they are authentic.
-
-Go to [Github Actions and run the `Python release` action](https://github.com/apache/iceberg-python/actions/workflows/python-release.yml). **Set the version to main, since we cannot modify the source**.
+* Tag: Use the newly created tag.
+* Version: Set the `version` to `main`, as the source cannot be modified.
 
 ![Github Actions Run Workflow for SVN Upload](assets/images/ghactions-run-workflow-svn-upload.png)
 
-Download the zip, and sign the files:
+This action will generate:
+
+* Source distribution (`sdist`)
+* Binary distributions (`wheels`) for each architectures. These are created using [`cibuildwheel`](https://github.com/pypa/cibuildwheel)
+
+##### Download Artifacts, Sign, and Generate Checksums
+
+Download the ZIP file containing the artifacts from the GitHub Actions run and unzip it.
+
+Navigate to the release directory. Sign the files and generate checksums:
+
+* `.asc` files: GPG-signed versions of each artifact to ensure authenticity.
+* `.sha512` files: SHA-512 checksums for verifying file integrity.
 
 ```bash
 cd release-main/
 
 for name in $(ls pyiceberg-*.whl pyiceberg-*.tar.gz)
 do
-    gpg --yes --armor --local-user fokko@apache.org --output "${name}.asc" --detach-sig "${name}"
+    gpg --yes --armor --output "${name}.asc" --detach-sig "${name}"
     shasum -a 512 "${name}" > "${name}.sha512"
 done
 ```
 
-Now we can upload the files from the same directory:
+##### Upload Artifacts to Apache Dev SVN
+
+Now, upload the files from the same directory:
 
 ```bash
 export SVN_TMP_DIR=/tmp/iceberg-${VERSION_BRANCH}/
@@ -128,21 +168,59 @@ svn add $SVN_TMP_DIR_VERSIONED
 svn ci -m "PyIceberg ${VERSION}" ${SVN_TMP_DIR_VERSIONED}
 ```
 
-### Upload to PyPi
+Verify the artifact is uploaded to [https://dist.apache.org/repos/dist/dev/iceberg](https://dist.apache.org/repos/dist/dev/iceberg/).
 
-Go to Github Actions and run the `Python release` action again. This time, set the **version** of the release candidate as the input: e.g. `0.7.0rc1`. Download the zip and unzip it locally.
+##### Remove Old Artifacts From Apache Dev SVN
+
+Clean up old RC artifacts:
+
+```bash
+svn delete https://dist.apache.org/repos/dist/dev/iceberg/pyiceberg-<OLD_RC_VERSION> -m "Remove old RC artifacts"
+```
+
+#### Upload to PyPi
+
+##### Create Artifacts for PyPi
+
+Run the [`Python release` Github Action](https://github.com/apache/iceberg-python/actions/workflows/python-release.yml).
+
+* Tag: Use the newly created tag.
+* Version: Set the `version` to release candidate, e.g. `0.7.0rc1`.
 
 ![Github Actions Run Workflow for PyPi Upload](assets/images/ghactions-run-workflow-pypi-upload.png)
 
-Next step is to upload them to pypi. Please keep in mind that this **won't** bump the version for everyone that hasn't pinned their version, since it is set to an RC [pre-release and those are ignored](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#pre-release-versioning).
+##### Download Artifacts
+
+Download the zip file from the Github Action run and unzip locally.
+
+##### Upload Artifacts to PyPi
+
+Upload release candidate to PyPi. This **won't** bump the version for everyone that hasn't pinned their version, since it is set to an RC [pre-release and those are ignored](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#pre-release-versioning).
+
+<!-- prettier-ignore-start -->
+
+!!! note
+    `twine` might require an PyPi API token.
+
+<!-- prettier-ignore-end -->
 
 ```bash
-twine upload release-0.7.0rc1/*
+twine upload release-${VERSION}/*
 ```
+
+Verify the artifact is uploaded to [PyPi](https://pypi.org/project/pyiceberg/#history).
+
+## Vote
+
+### Generate Vote Email
 
 Final step is to generate the email to the dev mail list:
 
 ```bash
+export GIT_TAG_REF=$(git show-ref ${GIT_TAG})
+export GIT_TAG_HASH=${GIT_TAG_REF:0:40}
+export LAST_COMMIT_ID=$(git rev-list ${GIT_TAG} 2> /dev/null | head -n 1)
+
 cat << EOF > release-announcement-email.txt
 To: dev@iceberg.apache.org
 Subject: [VOTE] Release Apache PyIceberg $VERSION
@@ -185,12 +263,19 @@ Please vote in the next 72 hours.
 [ ] +0
 [ ] -1 Do not release this because...
 EOF
-
-cat release-announcement-email.txt
 ```
 
-## Vote has passed
+### Send Vote Email
 
+Verify the content of `release-announcement-email.txt` and send it to `dev@iceberg.apache.org` with the corresponding subject line.
+
+## Vote has failed
+
+If there are concerns with the RC, address the issues and generate another RC.
+
+## Publish the Final Release (Vote has passed)
+
+A minimum of 3 binding +1 votes is required to pass an RC.
 Once the vote has been passed, you can close the vote thread by concluding it:
 
 ```text
@@ -205,19 +290,7 @@ The release candidate has been accepted as PyIceberg <VERSION>. Thanks everyone,
 Kind regards,
 ```
 
-### Copy the artifacts to the release dist
-
-```bash
-export RC=rc2
-export VERSION=0.7.0${RC}
-export VERSION_WITHOUT_RC=${VERSION/rc?/}
-
-export SVN_DEV_DIR_VERSIONED="https://dist.apache.org/repos/dist/dev/iceberg/pyiceberg-${VERSION}"
-export SVN_RELEASE_DIR_VERSIONED="https://dist.apache.org/repos/dist/release/iceberg/pyiceberg-${VERSION_WITHOUT_RC}"
-
-svn mv ${SVN_DEV_DIR_VERSIONED} ${SVN_RELEASE_DIR_VERSIONED} -m "PyIceberg: Add release ${VERSION_WITHOUT_RC}"
-```
-
+### Upload the accepted RC to Apache Release SVN
 <!-- prettier-ignore-start -->
 
 !!! note
@@ -225,15 +298,45 @@ svn mv ${SVN_DEV_DIR_VERSIONED} ${SVN_RELEASE_DIR_VERSIONED} -m "PyIceberg: Add 
 
 <!-- prettier-ignore-end -->
 
+```bash
+export SVN_DEV_DIR_VERSIONED="https://dist.apache.org/repos/dist/dev/iceberg/pyiceberg-${VERSION}"
+export SVN_RELEASE_DIR_VERSIONED="https://dist.apache.org/repos/dist/release/iceberg/pyiceberg-${VERSION_WITHOUT_RC}"
+
+svn mv ${SVN_DEV_DIR_VERSIONED} ${SVN_RELEASE_DIR_VERSIONED} -m "PyIceberg: Add release ${VERSION_WITHOUT_RC}"
+```
+
+Verify the artifact is uploaded to [https://dist.apache.org/repos/dist/release/iceberg](https://dist.apache.org/repos/dist/release/iceberg/).
+
+### Remove Old Artifacts From Apache Release SVN
+
+We only want to host the latest release. Clean up old release artifacts:
+
+```bash
+svn delete https://dist.apache.org/repos/dist/release/iceberg/pyiceberg-<OLD_RELEASE_VERSION> -m "Remove old release artifacts"
+```
+
 ### Upload the accepted release to PyPi
 
 The latest version can be pushed to PyPi. Check out the Apache SVN and make sure to publish the right version with `twine`:
+
+<!-- prettier-ignore-start -->
+
+!!! note
+    `twine` might require an PyPi API token.
+
+<!-- prettier-ignore-end -->
 
 ```bash
 svn checkout https://dist.apache.org/repos/dist/release/iceberg /tmp/iceberg-dist-release/
 cd /tmp/iceberg-dist-release/pyiceberg-${VERSION_WITHOUT_RC}
 twine upload pyiceberg-*.whl pyiceberg-*.tar.gz
 ```
+
+Verify the artifact is uploaded to [PyPi](https://pypi.org/project/pyiceberg/#history).
+
+## Post Release
+
+### Send out Release Announcement Email
 
 Send out an announcement on the dev mail list:
 
@@ -253,19 +356,19 @@ This Python release can be downloaded from: https://pypi.org/project/pyiceberg/<
 Thanks to everyone for contributing!
 ```
 
-## Release the docs
+### Release the docs
 
-A committer triggers the [`Python Docs` Github Actions](https://github.com/apache/iceberg-python/actions/workflows/python-ci-docs.yml) through the UI by selecting the branch that just has been released. This will publish the new docs.
+Run the [`Release Docs` Github Action](https://github.com/apache/iceberg-python/actions/workflows/python-release-docs.yml).
 
-## Update the Github template
+### Update the Github template
 
 Make sure to create a PR to update the [GitHub issues template](https://github.com/apache/iceberg-python/blob/main/.github/ISSUE_TEMPLATE/iceberg_bug_report.yml) with the latest version.
 
-## Update the integration tests
+### Update the integration tests
 
 Ensure to update the `PYICEBERG_VERSION` in the [Dockerfile](https://github.com/apache/iceberg-python/blob/main/dev/Dockerfile).
 
-## Create a Github Release Note
+### Create a Github Release Note
 
 Create a [new Release Note](https://github.com/apache/iceberg-python/releases/new) on the iceberg-python Github repository.
 
@@ -278,3 +381,22 @@ Then, select the previous release version as the **Previous tag** to use the dif
 **Generate release notes**.
 
 **Set as the latest release** and **Publish**.
+
+## Misc
+
+### Set up GPG key and Upload to Apache Iceberg KEYS file
+
+To set up GPG key locally, see the instructions [here](http://www.apache.org/dev/openpgp.html#key-gen-generate-key).
+
+To install gpg on a M1 based Mac, a couple of additional steps are required: <https://gist.github.com/phortuin/cf24b1cca3258720c71ad42977e1ba57>.
+
+Then, published GPG key to the [Apache Iceberg KEYS file](https://downloads.apache.org/iceberg/KEYS):
+
+```bash
+svn co https://dist.apache.org/repos/dist/release/iceberg icebergsvn
+cd icebergsvn
+echo "" >> KEYS # append a newline
+gpg --list-sigs <YOUR KEY ID HERE> >> KEYS # append signatures
+gpg --armor --export <YOUR KEY ID HERE> >> KEYS # append public key block
+svn commit -m "add key for <YOUR NAME HERE>"
+```

--- a/poetry.lock
+++ b/poetry.lock
@@ -2562,43 +2562,47 @@ files = [
 
 [[package]]
 name = "numpy"
-version = "1.26.0"
+version = "1.26.4"
 description = "Fundamental package for array computing in Python"
 optional = true
-python-versions = "<3.13,>=3.9"
+python-versions = ">=3.9"
 files = [
-    {file = "numpy-1.26.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f8db2f125746e44dce707dd44d4f4efeea8d7e2b43aace3f8d1f235cfa2733dd"},
-    {file = "numpy-1.26.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0621f7daf973d34d18b4e4bafb210bbaf1ef5e0100b5fa750bd9cde84c7ac292"},
-    {file = "numpy-1.26.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:51be5f8c349fdd1a5568e72713a21f518e7d6707bcf8503b528b88d33b57dc68"},
-    {file = "numpy-1.26.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:767254ad364991ccfc4d81b8152912e53e103ec192d1bb4ea6b1f5a7117040be"},
-    {file = "numpy-1.26.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:436c8e9a4bdeeee84e3e59614d38c3dbd3235838a877af8c211cfcac8a80b8d3"},
-    {file = "numpy-1.26.0-cp310-cp310-win32.whl", hash = "sha256:c2e698cb0c6dda9372ea98a0344245ee65bdc1c9dd939cceed6bb91256837896"},
-    {file = "numpy-1.26.0-cp310-cp310-win_amd64.whl", hash = "sha256:09aaee96c2cbdea95de76ecb8a586cb687d281c881f5f17bfc0fb7f5890f6b91"},
-    {file = "numpy-1.26.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:637c58b468a69869258b8ae26f4a4c6ff8abffd4a8334c830ffb63e0feefe99a"},
-    {file = "numpy-1.26.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:306545e234503a24fe9ae95ebf84d25cba1fdc27db971aa2d9f1ab6bba19a9dd"},
-    {file = "numpy-1.26.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c6adc33561bd1d46f81131d5352348350fc23df4d742bb246cdfca606ea1208"},
-    {file = "numpy-1.26.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e062aa24638bb5018b7841977c360d2f5917268d125c833a686b7cbabbec496c"},
-    {file = "numpy-1.26.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:546b7dd7e22f3c6861463bebb000646fa730e55df5ee4a0224408b5694cc6148"},
-    {file = "numpy-1.26.0-cp311-cp311-win32.whl", hash = "sha256:c0b45c8b65b79337dee5134d038346d30e109e9e2e9d43464a2970e5c0e93229"},
-    {file = "numpy-1.26.0-cp311-cp311-win_amd64.whl", hash = "sha256:eae430ecf5794cb7ae7fa3808740b015aa80747e5266153128ef055975a72b99"},
-    {file = "numpy-1.26.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:166b36197e9debc4e384e9c652ba60c0bacc216d0fc89e78f973a9760b503388"},
-    {file = "numpy-1.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f042f66d0b4ae6d48e70e28d487376204d3cbf43b84c03bac57e28dac6151581"},
-    {file = "numpy-1.26.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e5e18e5b14a7560d8acf1c596688f4dfd19b4f2945b245a71e5af4ddb7422feb"},
-    {file = "numpy-1.26.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f6bad22a791226d0a5c7c27a80a20e11cfe09ad5ef9084d4d3fc4a299cca505"},
-    {file = "numpy-1.26.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4acc65dd65da28060e206c8f27a573455ed724e6179941edb19f97e58161bb69"},
-    {file = "numpy-1.26.0-cp312-cp312-win32.whl", hash = "sha256:bb0d9a1aaf5f1cb7967320e80690a1d7ff69f1d47ebc5a9bea013e3a21faec95"},
-    {file = "numpy-1.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:ee84ca3c58fe48b8ddafdeb1db87388dce2c3c3f701bf447b05e4cfcc3679112"},
-    {file = "numpy-1.26.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4a873a8180479bc829313e8d9798d5234dfacfc2e8a7ac188418189bb8eafbd2"},
-    {file = "numpy-1.26.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:914b28d3215e0c721dc75db3ad6d62f51f630cb0c277e6b3bcb39519bed10bd8"},
-    {file = "numpy-1.26.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c78a22e95182fb2e7874712433eaa610478a3caf86f28c621708d35fa4fd6e7f"},
-    {file = "numpy-1.26.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86f737708b366c36b76e953c46ba5827d8c27b7a8c9d0f471810728e5a2fe57c"},
-    {file = "numpy-1.26.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:b44e6a09afc12952a7d2a58ca0a2429ee0d49a4f89d83a0a11052da696440e49"},
-    {file = "numpy-1.26.0-cp39-cp39-win32.whl", hash = "sha256:5671338034b820c8d58c81ad1dafc0ed5a00771a82fccc71d6438df00302094b"},
-    {file = "numpy-1.26.0-cp39-cp39-win_amd64.whl", hash = "sha256:020cdbee66ed46b671429c7265cf00d8ac91c046901c55684954c3958525dab2"},
-    {file = "numpy-1.26.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:0792824ce2f7ea0c82ed2e4fecc29bb86bee0567a080dacaf2e0a01fe7654369"},
-    {file = "numpy-1.26.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7d484292eaeb3e84a51432a94f53578689ffdea3f90e10c8b203a99be5af57d8"},
-    {file = "numpy-1.26.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:186ba67fad3c60dbe8a3abff3b67a91351100f2661c8e2a80364ae6279720299"},
-    {file = "numpy-1.26.0.tar.gz", hash = "sha256:f93fc78fe8bf15afe2b8d6b6499f1c73953169fad1e9a8dd086cdff3190e7fdf"},
+    {file = "numpy-1.26.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9ff0f4f29c51e2803569d7a51c2304de5554655a60c5d776e35b4a41413830d0"},
+    {file = "numpy-1.26.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e4ee3380d6de9c9ec04745830fd9e2eccb3e6cf790d39d7b98ffd19b0dd754a"},
+    {file = "numpy-1.26.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d209d8969599b27ad20994c8e41936ee0964e6da07478d6c35016bc386b66ad4"},
+    {file = "numpy-1.26.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffa75af20b44f8dba823498024771d5ac50620e6915abac414251bd971b4529f"},
+    {file = "numpy-1.26.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:62b8e4b1e28009ef2846b4c7852046736bab361f7aeadeb6a5b89ebec3c7055a"},
+    {file = "numpy-1.26.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a4abb4f9001ad2858e7ac189089c42178fcce737e4169dc61321660f1a96c7d2"},
+    {file = "numpy-1.26.4-cp310-cp310-win32.whl", hash = "sha256:bfe25acf8b437eb2a8b2d49d443800a5f18508cd811fea3181723922a8a82b07"},
+    {file = "numpy-1.26.4-cp310-cp310-win_amd64.whl", hash = "sha256:b97fe8060236edf3662adfc2c633f56a08ae30560c56310562cb4f95500022d5"},
+    {file = "numpy-1.26.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4c66707fabe114439db9068ee468c26bbdf909cac0fb58686a42a24de1760c71"},
+    {file = "numpy-1.26.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:edd8b5fe47dab091176d21bb6de568acdd906d1887a4584a15a9a96a1dca06ef"},
+    {file = "numpy-1.26.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e"},
+    {file = "numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5"},
+    {file = "numpy-1.26.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:96ff0b2ad353d8f990b63294c8986f1ec3cb19d749234014f4e7eb0112ceba5a"},
+    {file = "numpy-1.26.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:60dedbb91afcbfdc9bc0b1f3f402804070deed7392c23eb7a7f07fa857868e8a"},
+    {file = "numpy-1.26.4-cp311-cp311-win32.whl", hash = "sha256:1af303d6b2210eb850fcf03064d364652b7120803a0b872f5211f5234b399f20"},
+    {file = "numpy-1.26.4-cp311-cp311-win_amd64.whl", hash = "sha256:cd25bcecc4974d09257ffcd1f098ee778f7834c3ad767fe5db785be9a4aa9cb2"},
+    {file = "numpy-1.26.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b3ce300f3644fb06443ee2222c2201dd3a89ea6040541412b8fa189341847218"},
+    {file = "numpy-1.26.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:03a8c78d01d9781b28a6989f6fa1bb2c4f2d51201cf99d3dd875df6fbd96b23b"},
+    {file = "numpy-1.26.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fad7dcb1aac3c7f0584a5a8133e3a43eeb2fe127f47e3632d43d677c66c102b"},
+    {file = "numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:675d61ffbfa78604709862923189bad94014bef562cc35cf61d3a07bba02a7ed"},
+    {file = "numpy-1.26.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab47dbe5cc8210f55aa58e4805fe224dac469cde56b9f731a4c098b91917159a"},
+    {file = "numpy-1.26.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1dda2e7b4ec9dd512f84935c5f126c8bd8b9f2fc001e9f54af255e8c5f16b0e0"},
+    {file = "numpy-1.26.4-cp312-cp312-win32.whl", hash = "sha256:50193e430acfc1346175fcbdaa28ffec49947a06918b7b92130744e81e640110"},
+    {file = "numpy-1.26.4-cp312-cp312-win_amd64.whl", hash = "sha256:08beddf13648eb95f8d867350f6a018a4be2e5ad54c8d8caed89ebca558b2818"},
+    {file = "numpy-1.26.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7349ab0fa0c429c82442a27a9673fc802ffdb7c7775fad780226cb234965e53c"},
+    {file = "numpy-1.26.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:52b8b60467cd7dd1e9ed082188b4e6bb35aa5cdd01777621a1658910745b90be"},
+    {file = "numpy-1.26.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5241e0a80d808d70546c697135da2c613f30e28251ff8307eb72ba696945764"},
+    {file = "numpy-1.26.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f870204a840a60da0b12273ef34f7051e98c3b5961b61b0c2c1be6dfd64fbcd3"},
+    {file = "numpy-1.26.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:679b0076f67ecc0138fd2ede3a8fd196dddc2ad3254069bcb9faf9a79b1cebcd"},
+    {file = "numpy-1.26.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:47711010ad8555514b434df65f7d7b076bb8261df1ca9bb78f53d3b2db02e95c"},
+    {file = "numpy-1.26.4-cp39-cp39-win32.whl", hash = "sha256:a354325ee03388678242a4d7ebcd08b5c727033fcff3b2f536aea978e15ee9e6"},
+    {file = "numpy-1.26.4-cp39-cp39-win_amd64.whl", hash = "sha256:3373d5d70a5fe74a2c1bb6d2cfd9609ecf686d47a2d7b1d37a8f3b6bf6003aea"},
+    {file = "numpy-1.26.4-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:afedb719a9dcfc7eaf2287b839d8198e06dcd4cb5d276a3df279231138e83d30"},
+    {file = "numpy-1.26.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95a7476c59002f2f6c590b9b7b998306fba6a5aa646b1e22ddfeaf8f78c3a29c"},
+    {file = "numpy-1.26.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:7e50d0a0cc3189f9cb0aeb3a6a6af18c16f59f004b866cd2be1c14b36134a4a0"},
+    {file = "numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010"},
 ]
 
 [[package]]
@@ -4569,5 +4573,5 @@ zstandard = ["zstandard"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.9, <3.13, !=3.9.7"
-content-hash = "faf7cc64ff950544f90d04eea2d54bfcc118799f2c376aa43149a1f91637033a"
+python-versions = "^3.9, !=3.9.7"
+content-hash = "c711643812ed5d98298621a7b46050cd1d2a8a7f6c288de9e1d7d20a94bb1a69"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4570,4 +4570,4 @@ zstandard = ["zstandard"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9, <3.13, !=3.9.7"
-content-hash = "54d7d52db7c08c6474f28aa9f62cb7f3d745c0341969db0ccb76b0195b3372a2"
+content-hash = "faf7cc64ff950544f90d04eea2d54bfcc118799f2c376aa43149a1f91637033a"

--- a/pyiceberg/__init__.py
+++ b/pyiceberg/__init__.py
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"

--- a/pyiceberg/catalog/glue.py
+++ b/pyiceberg/catalog/glue.py
@@ -459,7 +459,7 @@ class GlueCatalog(MetastoreCatalog):
             NoSuchTableError: If a table with the given identifier does not exist.
             CommitFailedException: Requirement not met, or a conflict with a concurrent commit.
         """
-        table_identifier = self._identifier_to_tuple_without_catalog(table.identifier)
+        table_identifier = table.name()
         database_name, table_name = self.identifier_to_database_and_table(table_identifier, NoSuchTableError)
 
         current_glue_table: Optional[TableTypeDef]

--- a/pyiceberg/catalog/glue.py
+++ b/pyiceberg/catalog/glue.py
@@ -773,4 +773,4 @@ class GlueCatalog(MetastoreCatalog):
 
     @staticmethod
     def __is_iceberg_table(table: TableTypeDef) -> bool:
-        return table.get("Parameters", {}).get("table_type", "").lower() == ICEBERG
+        return table.get("Parameters", {}).get(TABLE_TYPE, "").lower() == ICEBERG

--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -314,7 +314,7 @@ class HiveCatalog(MetastoreCatalog):
         )
 
     def _convert_iceberg_into_hive(self, table: Table) -> HiveTable:
-        identifier_tuple = self._identifier_to_tuple_without_catalog(table.identifier)
+        identifier_tuple = table.name()
         database_name, table_name = self.identifier_to_database_and_table(identifier_tuple, NoSuchTableError)
         current_time_millis = int(time.time() * 1000)
 
@@ -455,7 +455,7 @@ class HiveCatalog(MetastoreCatalog):
             NoSuchTableError: If a table with the given identifier does not exist.
             CommitFailedException: Requirement not met, or a conflict with a concurrent commit.
         """
-        table_identifier = self._identifier_to_tuple_without_catalog(table.identifier)
+        table_identifier = table.name()
         database_name, table_name = self.identifier_to_database_and_table(table_identifier, NoSuchTableError)
         # commit to hive
         # https://github.com/apache/hive/blob/master/standalone-metastore/metastore-common/src/main/thrift/hive_metastore.thrift#L1232

--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -651,7 +651,7 @@ class HiveCatalog(MetastoreCatalog):
                 for table in open_client.get_table_objects_by_name(
                     dbname=database_name, tbl_names=open_client.get_all_tables(db_name=database_name)
                 )
-                if table.parameters[TABLE_TYPE].lower() == ICEBERG
+                if table.parameters.get(TABLE_TYPE, "").lower() == ICEBERG
             ]
 
     def list_namespaces(self, namespace: Union[str, Identifier] = ()) -> List[Identifier]:

--- a/pyiceberg/catalog/rest.py
+++ b/pyiceberg/catalog/rest.py
@@ -775,7 +775,7 @@ class RestCatalog(Catalog):
             CommitFailedException: Requirement not met, or a conflict with a concurrent commit.
             CommitStateUnknownException: Failed due to an internal exception on the side of the catalog.
         """
-        identifier = self._identifier_to_tuple_without_catalog(table.identifier)
+        identifier = table.name()
         table_identifier = TableIdentifier(namespace=identifier[:-1], name=identifier[-1])
         table_request = CommitTableRequest(identifier=table_identifier, requirements=requirements, updates=updates)
 

--- a/pyiceberg/catalog/rest.py
+++ b/pyiceberg/catalog/rest.py
@@ -899,7 +899,7 @@ class RestCatalog(Catalog):
 
     @retry(**_RETRY_ARGS)
     def drop_view(self, identifier: Union[str]) -> None:
-        identifier_tuple = self.identifier_to_tuple_without_catalog(identifier)
+        identifier_tuple = self._identifier_to_tuple_without_catalog(identifier)
         response = self._session.delete(
             self.url(
                 Endpoints.drop_view, prefixed=True, **self._split_identifier_for_path(identifier_tuple, IdentifierKind.VIEW)

--- a/pyiceberg/catalog/sql.py
+++ b/pyiceberg/catalog/sql.py
@@ -419,7 +419,7 @@ class SqlCatalog(MetastoreCatalog):
             NoSuchTableError: If a table with the given identifier does not exist.
             CommitFailedException: Requirement not met, or a conflict with a concurrent commit.
         """
-        table_identifier = self._identifier_to_tuple_without_catalog(table.identifier)
+        table_identifier = table.name()
         namespace_tuple = Catalog.namespace_from(table_identifier)
         namespace = Catalog.namespace_to_string(namespace_tuple)
         table_name = Catalog.table_name_from(table_identifier)
@@ -430,7 +430,7 @@ class SqlCatalog(MetastoreCatalog):
         except NoSuchTableError:
             current_table = None
 
-        updated_staged_table = self._update_and_stage_table(current_table, table.identifier, requirements, updates)
+        updated_staged_table = self._update_and_stage_table(current_table, table.name(), requirements, updates)
         if current_table and updated_staged_table.metadata == current_table.metadata:
             # no changes, do nothing
             return CommitTableResponse(metadata=current_table.metadata, metadata_location=current_table.metadata_location)

--- a/pyiceberg/cli/output.py
+++ b/pyiceberg/cli/output.py
@@ -137,7 +137,7 @@ class ConsoleOutput(Output):
             else:
                 snapshots = []
 
-        snapshot_tree = Tree(f"Snapshots: {'.'.join(table.identifier)}")
+        snapshot_tree = Tree(f"Snapshots: {'.'.join(table.name())}")
         io = table.io
 
         for snapshot in snapshots:
@@ -216,7 +216,7 @@ class JsonOutput(Output):
 
         print(
             FauxTable(
-                identifier=table.identifier, metadata=table.metadata, metadata_location=table.metadata_location
+                identifier=table.name(), metadata=table.metadata, metadata_location=table.metadata_location
             ).model_dump_json()
         )
 

--- a/pyiceberg/expressions/parser.py
+++ b/pyiceberg/expressions/parser.py
@@ -79,7 +79,7 @@ NULL = CaselessKeyword("null")
 NAN = CaselessKeyword("nan")
 LIKE = CaselessKeyword("like")
 
-unquoted_identifier = Word(alphas, alphanums + "_$")
+unquoted_identifier = Word(alphas + "_", alphanums + "_$")
 quoted_identifier = Suppress('"') + unquoted_identifier + Suppress('"')
 identifier = MatchFirst([unquoted_identifier, quoted_identifier]).set_results_name("identifier")
 column = DelimitedList(identifier, delim=".", combine=False).set_results_name("column")

--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -2397,8 +2397,8 @@ def data_file_statistics_from_parquet_metadata(
     split_offsets.sort()
 
     for field_id in invalidate_col:
-        del col_aggs[field_id]
-        del null_value_counts[field_id]
+        col_aggs.pop(field_id, None)
+        null_value_counts.pop(field_id, None)
 
     return DataFileStatistics(
         record_count=parquet_metadata.num_rows,

--- a/pyiceberg/manifest.py
+++ b/pyiceberg/manifest.py
@@ -957,7 +957,11 @@ class ManifestListWriterV1(ManifestListWriter):
         super().__init__(
             format_version=1,
             output_file=output_file,
-            meta={"snapshot-id": str(snapshot_id), "parent-snapshot-id": str(parent_snapshot_id), "format-version": "1"},
+            meta={
+                "snapshot-id": str(snapshot_id),
+                "parent-snapshot-id": str(parent_snapshot_id) if parent_snapshot_id is not None else "null",
+                "format-version": "1",
+            },
         )
 
     def prepare_manifest(self, manifest_file: ManifestFile) -> ManifestFile:
@@ -976,7 +980,7 @@ class ManifestListWriterV2(ManifestListWriter):
             output_file=output_file,
             meta={
                 "snapshot-id": str(snapshot_id),
-                "parent-snapshot-id": str(parent_snapshot_id),
+                "parent-snapshot-id": str(parent_snapshot_id) if parent_snapshot_id is not None else "null",
                 "sequence-number": str(sequence_number),
                 "format-version": "2",
             },

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -801,7 +801,7 @@ class Table:
         Returns:
             An Identifier tuple of the table name
         """
-        return self.identifier
+        return self._identifier
 
     def scan(
         self,

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -822,7 +822,7 @@ class Table:
             row_filter:
                 A string or BooleanExpression that decsribes the
                 desired rows
-            selected_fileds:
+            selected_fields:
                 A tuple of strings representing the column names
                 to return in the output dataframe.
             case_sensitive:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@
 # under the License.
 [tool.poetry]
 name = "pyiceberg"
-version = "0.8.0"
+version = "0.8.1"
 readme = "README.md"
 homepage = "https://py.iceberg.apache.org/"
 repository = "https://github.com/apache/iceberg-python"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.9, <3.13, !=3.9.7"
+python = "^3.9, !=3.9.7"
 mmh3 = ">=4.0.0,<6.0.0"
 requests = ">=2.20.0,<3.0.0"
 click = ">=7.1.1,<9.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ rich = ">=10.11.0,<14.0.0"
 strictyaml = ">=1.7.0,<2.0.0" # CVE-2020-14343 was fixed in 5.4.
 pydantic = ">=2.0,<3.0,!=2.4.0,!=2.4.1" # 2.4.0, 2.4.1 has a critical bug
 sortedcontainers = "2.4.0"
-fsspec = ">=2023.1.0,<2025.1.0"
+fsspec = ">=2023.1.0"
 pyparsing = ">=3.1.0,<4.0.0"
 zstandard = ">=0.13.0,<1.0.0"
 tenacity = ">=8.2.3,<10.0.0"
@@ -72,9 +72,9 @@ python-snappy = { version = ">=0.6.0,<1.0.0", optional = true }
 thrift = { version = ">=0.13.0,<1.0.0", optional = true }
 mypy-boto3-glue = { version = ">=1.28.18", optional = true }
 boto3 = { version = ">=1.24.59", optional = true }
-s3fs = { version = ">=2023.1.0,<2024.1.0", optional = true }
-adlfs = { version = ">=2023.1.0,<2024.8.0", optional = true }
-gcsfs = { version = ">=2023.1.0,<2024.1.0", optional = true }
+s3fs = { version = ">=2023.1.0", optional = true }
+adlfs = { version = ">=2023.1.0", optional = true }
+gcsfs = { version = ">=2023.1.0", optional = true }
 psycopg2-binary = { version = ">=2.9.6", optional = true }
 sqlalchemy = { version = "^2.0.18", optional = true }
 getdaft = { version = ">=0.2.12", optional = true }

--- a/tests/catalog/integration_test_dynamodb.py
+++ b/tests/catalog/integration_test_dynamodb.py
@@ -57,7 +57,7 @@ def test_create_table(
     test_catalog.create_namespace(database_name)
     test_catalog.create_table(identifier, table_schema_nested, get_s3_path(get_bucket_name(), database_name, table_name))
     table = test_catalog.load_table(identifier)
-    assert table.identifier == (test_catalog.name,) + identifier
+    assert table.name() == identifier
     metadata_location = table.metadata_location.split(get_bucket_name())[1][1:]
     s3.head_object(Bucket=get_bucket_name(), Key=metadata_location)
 
@@ -78,7 +78,7 @@ def test_create_table_with_default_location(
     test_catalog.create_namespace(database_name)
     test_catalog.create_table(identifier, table_schema_nested)
     table = test_catalog.load_table(identifier)
-    assert table.identifier == (test_catalog.name,) + identifier
+    assert table.name() == identifier
     metadata_location = table.metadata_location.split(get_bucket_name())[1][1:]
     s3.head_object(Bucket=get_bucket_name(), Key=metadata_location)
 
@@ -102,7 +102,7 @@ def test_create_table_if_not_exists_duplicated_table(
     test_catalog.create_namespace(database_name)
     table1 = test_catalog.create_table((database_name, table_name), table_schema_nested)
     table2 = test_catalog.create_table_if_not_exists((database_name, table_name), table_schema_nested)
-    assert table1.identifier == table2.identifier
+    assert table1.name() == table2.name()
 
 
 def test_load_table(test_catalog: Catalog, table_schema_nested: Schema, database_name: str, table_name: str) -> None:
@@ -110,7 +110,7 @@ def test_load_table(test_catalog: Catalog, table_schema_nested: Schema, database
     test_catalog.create_namespace(database_name)
     table = test_catalog.create_table(identifier, table_schema_nested)
     loaded_table = test_catalog.load_table(identifier)
-    assert table.identifier == loaded_table.identifier
+    assert table.name() == loaded_table.name()
     assert table.metadata_location == loaded_table.metadata_location
     assert table.metadata == loaded_table.metadata
 
@@ -134,11 +134,11 @@ def test_rename_table(
     new_table_name = f"rename-{table_name}"
     identifier = (database_name, table_name)
     table = test_catalog.create_table(identifier, table_schema_nested)
-    assert table.identifier == (test_catalog.name,) + identifier
+    assert table.name() == identifier
     new_identifier = (new_database_name, new_table_name)
     test_catalog.rename_table(identifier, new_identifier)
     new_table = test_catalog.load_table(new_identifier)
-    assert new_table.identifier == (test_catalog.name,) + new_identifier
+    assert new_table.name() == new_identifier
     assert new_table.metadata_location == table.metadata_location
     metadata_location = new_table.metadata_location.split(get_bucket_name())[1][1:]
     s3.head_object(Bucket=get_bucket_name(), Key=metadata_location)
@@ -150,7 +150,7 @@ def test_drop_table(test_catalog: Catalog, table_schema_nested: Schema, table_na
     identifier = (database_name, table_name)
     test_catalog.create_namespace(database_name)
     table = test_catalog.create_table(identifier, table_schema_nested)
-    assert table.identifier == (test_catalog.name,) + identifier
+    assert table.name() == identifier
     test_catalog.drop_table(identifier)
     with pytest.raises(NoSuchTableError):
         test_catalog.load_table(identifier)
@@ -163,7 +163,7 @@ def test_purge_table(
     test_catalog.create_namespace(database_name)
     test_catalog.create_table(identifier, table_schema_nested)
     table = test_catalog.load_table(identifier)
-    assert table.identifier == (test_catalog.name,) + identifier
+    assert table.name() == identifier
     metadata_location = table.metadata_location.split(get_bucket_name())[1][1:]
     s3.head_object(Bucket=get_bucket_name(), Key=metadata_location)
     test_catalog.purge_table(identifier)

--- a/tests/catalog/integration_test_glue.py
+++ b/tests/catalog/integration_test_glue.py
@@ -119,7 +119,7 @@ def test_create_table(
     test_catalog.create_namespace(database_name)
     test_catalog.create_table(identifier, table_schema_nested, get_s3_path(get_bucket_name(), database_name, table_name))
     table = test_catalog.load_table(identifier)
-    assert table.identifier == (CATALOG_NAME,) + identifier
+    assert table.name() == identifier
     metadata_location = table.metadata_location.split(get_bucket_name())[1][1:]
     s3.head_object(Bucket=get_bucket_name(), Key=metadata_location)
     assert MetastoreCatalog._parse_metadata_version(table.metadata_location) == 0
@@ -183,7 +183,7 @@ def test_create_table_with_default_location(
     test_catalog.create_namespace(database_name)
     test_catalog.create_table(identifier, table_schema_nested)
     table = test_catalog.load_table(identifier)
-    assert table.identifier == (CATALOG_NAME,) + identifier
+    assert table.name() == identifier
     metadata_location = table.metadata_location.split(get_bucket_name())[1][1:]
     s3.head_object(Bucket=get_bucket_name(), Key=metadata_location)
     assert MetastoreCatalog._parse_metadata_version(table.metadata_location) == 0
@@ -208,7 +208,7 @@ def test_create_table_if_not_exists_duplicated_table(
     test_catalog.create_namespace(database_name)
     table1 = test_catalog.create_table((database_name, table_name), table_schema_nested)
     table2 = test_catalog.create_table_if_not_exists((database_name, table_name), table_schema_nested)
-    assert table1.identifier == table2.identifier
+    assert table1.name() == table2.name()
 
 
 def test_load_table(test_catalog: Catalog, table_schema_nested: Schema, table_name: str, database_name: str) -> None:
@@ -216,7 +216,7 @@ def test_load_table(test_catalog: Catalog, table_schema_nested: Schema, table_na
     test_catalog.create_namespace(database_name)
     table = test_catalog.create_table(identifier, table_schema_nested)
     loaded_table = test_catalog.load_table(identifier)
-    assert table.identifier == loaded_table.identifier
+    assert table.name() == loaded_table.name()
     assert table.metadata_location == loaded_table.metadata_location
     assert table.metadata == loaded_table.metadata
     assert MetastoreCatalog._parse_metadata_version(table.metadata_location) == 0
@@ -242,11 +242,11 @@ def test_rename_table(
     identifier = (database_name, table_name)
     table = test_catalog.create_table(identifier, table_schema_nested)
     assert MetastoreCatalog._parse_metadata_version(table.metadata_location) == 0
-    assert table.identifier == (CATALOG_NAME,) + identifier
+    assert table.name() == identifier
     new_identifier = (new_database_name, new_table_name)
     test_catalog.rename_table(identifier, new_identifier)
     new_table = test_catalog.load_table(new_identifier)
-    assert new_table.identifier == (CATALOG_NAME,) + new_identifier
+    assert new_table.name() == new_identifier
     assert new_table.metadata_location == table.metadata_location
     metadata_location = new_table.metadata_location.split(get_bucket_name())[1][1:]
     s3.head_object(Bucket=get_bucket_name(), Key=metadata_location)
@@ -258,7 +258,7 @@ def test_drop_table(test_catalog: Catalog, table_schema_nested: Schema, table_na
     identifier = (database_name, table_name)
     test_catalog.create_namespace(database_name)
     table = test_catalog.create_table(identifier, table_schema_nested)
-    assert table.identifier == (CATALOG_NAME,) + identifier
+    assert table.name() == identifier
     test_catalog.drop_table(identifier)
     with pytest.raises(NoSuchTableError):
         test_catalog.load_table(identifier)
@@ -271,7 +271,7 @@ def test_purge_table(
     test_catalog.create_namespace(database_name)
     test_catalog.create_table(identifier, table_schema_nested)
     table = test_catalog.load_table(identifier)
-    assert table.identifier == (CATALOG_NAME,) + identifier
+    assert table.name() == identifier
     metadata_location = table.metadata_location.split(get_bucket_name())[1][1:]
     s3.head_object(Bucket=get_bucket_name(), Key=metadata_location)
     test_catalog.purge_table(identifier)
@@ -536,7 +536,7 @@ def test_create_table_transaction(
                 update_snapshot.append_data_file(data_file)
 
     table = test_catalog.load_table(identifier)
-    assert table.identifier == (CATALOG_NAME,) + identifier
+    assert table.name() == identifier
     metadata_location = table.metadata_location.split(get_bucket_name())[1][1:]
     s3.head_object(Bucket=get_bucket_name(), Key=metadata_location)
     assert MetastoreCatalog._parse_metadata_version(table.metadata_location) == 0
@@ -584,6 +584,6 @@ def test_register_table_with_given_location(
     test_catalog.drop_table(identifier)  # drops the table but keeps the metadata file
     assert not test_catalog.table_exists(identifier)
     table = test_catalog.register_table(new_identifier, location)
-    assert table.identifier == (CATALOG_NAME,) + new_identifier
+    assert table.name() == new_identifier
     assert table.metadata_location == location
     assert test_catalog.table_exists(new_identifier)

--- a/tests/catalog/test_base.py
+++ b/tests/catalog/test_base.py
@@ -133,7 +133,7 @@ class InMemoryCatalog(MetastoreCatalog):
     def commit_table(
         self, table: Table, requirements: Tuple[TableRequirement, ...], updates: Tuple[TableUpdate, ...]
     ) -> CommitTableResponse:
-        identifier_tuple = self._identifier_to_tuple_without_catalog(table.identifier)
+        identifier_tuple = table.name()
         current_table = self.load_table(identifier_tuple)
         base_metadata = current_table.metadata
 

--- a/tests/catalog/test_glue.py
+++ b/tests/catalog/test_glue.py
@@ -59,7 +59,7 @@ def test_create_table_with_database_location(
     test_catalog = GlueCatalog(catalog_name, **{"s3.endpoint": moto_endpoint_url})
     test_catalog.create_namespace(namespace=database_name, properties={"location": f"s3://{BUCKET_NAME}/{database_name}.db"})
     table = test_catalog.create_table(identifier, table_schema_nested)
-    assert table.identifier == (catalog_name,) + identifier
+    assert table.name() == identifier
     assert TABLE_METADATA_LOCATION_REGEX.match(table.metadata_location)
     assert test_catalog._parse_metadata_version(table.metadata_location) == 0
 
@@ -121,7 +121,7 @@ def test_create_table_with_default_warehouse(
     test_catalog = GlueCatalog(catalog_name, **{"s3.endpoint": moto_endpoint_url, "warehouse": f"s3://{BUCKET_NAME}"})
     test_catalog.create_namespace(namespace=database_name)
     table = test_catalog.create_table(identifier, table_schema_nested)
-    assert table.identifier == (catalog_name,) + identifier
+    assert table.name() == identifier
     assert TABLE_METADATA_LOCATION_REGEX.match(table.metadata_location)
     assert test_catalog._parse_metadata_version(table.metadata_location) == 0
 
@@ -137,7 +137,7 @@ def test_create_table_with_given_location(
     table = test_catalog.create_table(
         identifier=identifier, schema=table_schema_nested, location=f"s3://{BUCKET_NAME}/{database_name}.db/{table_name}"
     )
-    assert table.identifier == (catalog_name,) + identifier
+    assert table.name() == identifier
     assert TABLE_METADATA_LOCATION_REGEX.match(table.metadata_location)
     assert test_catalog._parse_metadata_version(table.metadata_location) == 0
 
@@ -152,7 +152,7 @@ def test_create_table_removes_trailing_slash_in_location(
     test_catalog.create_namespace(namespace=database_name)
     location = f"s3://{BUCKET_NAME}/{database_name}.db/{table_name}"
     table = test_catalog.create_table(identifier=identifier, schema=table_schema_nested, location=f"{location}/")
-    assert table.identifier == (catalog_name,) + identifier
+    assert table.name() == identifier
     assert table.location() == location
     assert TABLE_METADATA_LOCATION_REGEX.match(table.metadata_location)
     assert test_catalog._parse_metadata_version(table.metadata_location) == 0
@@ -175,7 +175,7 @@ def test_create_table_with_pyarrow_schema(
         schema=pyarrow_schema_simple_without_ids,
         location=f"s3://{BUCKET_NAME}/{database_name}.db/{table_name}",
     )
-    assert table.identifier == (catalog_name,) + identifier
+    assert table.name() == identifier
     assert TABLE_METADATA_LOCATION_REGEX.match(table.metadata_location)
     assert test_catalog._parse_metadata_version(table.metadata_location) == 0
 
@@ -201,7 +201,7 @@ def test_create_table_with_strips(
     test_catalog = GlueCatalog(catalog_name, **{"s3.endpoint": moto_endpoint_url})
     test_catalog.create_namespace(namespace=database_name, properties={"location": f"s3://{BUCKET_NAME}/{database_name}.db/"})
     table = test_catalog.create_table(identifier, table_schema_nested)
-    assert table.identifier == (catalog_name,) + identifier
+    assert table.name() == identifier
     assert TABLE_METADATA_LOCATION_REGEX.match(table.metadata_location)
     assert test_catalog._parse_metadata_version(table.metadata_location) == 0
 
@@ -210,12 +210,11 @@ def test_create_table_with_strips(
 def test_create_table_with_strips_bucket_root(
     _bucket_initialize: None, moto_endpoint_url: str, table_schema_nested: Schema, database_name: str, table_name: str
 ) -> None:
-    catalog_name = "glue"
     identifier = (database_name, table_name)
     test_catalog = GlueCatalog("glue", **{"s3.endpoint": moto_endpoint_url, "warehouse": f"s3://{BUCKET_NAME}/"})
     test_catalog.create_namespace(namespace=database_name)
     table_strip = test_catalog.create_table(identifier, table_schema_nested)
-    assert table_strip.identifier == (catalog_name,) + identifier
+    assert table_strip.name() == identifier
     assert TABLE_METADATA_LOCATION_REGEX.match(table_strip.metadata_location)
     assert test_catalog._parse_metadata_version(table_strip.metadata_location) == 0
 
@@ -242,7 +241,7 @@ def test_create_table_with_glue_catalog_id(
     )
     test_catalog.create_namespace(namespace=database_name)
     table = test_catalog.create_table(identifier, table_schema_nested)
-    assert table.identifier == (catalog_name,) + identifier
+    assert table.name() == identifier
     assert TABLE_METADATA_LOCATION_REGEX.match(table.metadata_location)
     assert test_catalog._parse_metadata_version(table.metadata_location) == 0
 
@@ -273,7 +272,7 @@ def test_load_table(
     test_catalog.create_namespace(namespace=database_name)
     test_catalog.create_table(identifier, table_schema_nested)
     table = test_catalog.load_table(identifier)
-    assert table.identifier == (catalog_name,) + identifier
+    assert table.name() == identifier
     assert TABLE_METADATA_LOCATION_REGEX.match(table.metadata_location)
     assert test_catalog._parse_metadata_version(table.metadata_location) == 0
 
@@ -287,8 +286,8 @@ def test_load_table_from_self_identifier(
     test_catalog = GlueCatalog(catalog_name, **{"s3.endpoint": moto_endpoint_url, "warehouse": f"s3://{BUCKET_NAME}/"})
     test_catalog.create_namespace(namespace=database_name)
     intermediate = test_catalog.create_table(identifier, table_schema_nested)
-    table = test_catalog.load_table(intermediate.identifier)
-    assert table.identifier == (catalog_name,) + identifier
+    table = test_catalog.load_table(intermediate.name())
+    assert table.name() == identifier
     assert TABLE_METADATA_LOCATION_REGEX.match(table.metadata_location)
 
 
@@ -311,7 +310,7 @@ def test_drop_table(
     test_catalog.create_namespace(namespace=database_name)
     test_catalog.create_table(identifier, table_schema_nested)
     table = test_catalog.load_table(identifier)
-    assert table.identifier == (catalog_name,) + identifier
+    assert table.name() == identifier
     assert TABLE_METADATA_LOCATION_REGEX.match(table.metadata_location)
     test_catalog.drop_table(identifier)
     with pytest.raises(NoSuchTableError):
@@ -328,13 +327,13 @@ def test_drop_table_from_self_identifier(
     test_catalog.create_namespace(namespace=database_name)
     test_catalog.create_table(identifier, table_schema_nested)
     table = test_catalog.load_table(identifier)
-    assert table.identifier == (catalog_name,) + identifier
+    assert table.name() == identifier
     assert TABLE_METADATA_LOCATION_REGEX.match(table.metadata_location)
-    test_catalog.drop_table(table.identifier)
+    test_catalog.drop_table(table.name())
     with pytest.raises(NoSuchTableError):
         test_catalog.load_table(identifier)
     with pytest.raises(NoSuchTableError):
-        test_catalog.load_table(table.identifier)
+        test_catalog.load_table(table.name())
 
 
 @mock_aws
@@ -349,19 +348,18 @@ def test_drop_non_exist_table(_bucket_initialize: None, moto_endpoint_url: str, 
 def test_rename_table(
     _bucket_initialize: None, moto_endpoint_url: str, table_schema_nested: Schema, database_name: str, table_name: str
 ) -> None:
-    catalog_name = "glue"
     new_table_name = f"{table_name}_new"
     identifier = (database_name, table_name)
     new_identifier = (database_name, new_table_name)
     test_catalog = GlueCatalog("glue", **{"s3.endpoint": moto_endpoint_url, "warehouse": f"s3://{BUCKET_NAME}/"})
     test_catalog.create_namespace(namespace=database_name)
     table = test_catalog.create_table(identifier, table_schema_nested)
-    assert table.identifier == (catalog_name,) + identifier
+    assert table.name() == identifier
     assert TABLE_METADATA_LOCATION_REGEX.match(table.metadata_location)
     assert test_catalog._parse_metadata_version(table.metadata_location) == 0
     test_catalog.rename_table(identifier, new_identifier)
     new_table = test_catalog.load_table(new_identifier)
-    assert new_table.identifier == (catalog_name,) + new_identifier
+    assert new_table.name() == new_identifier
     # the metadata_location should not change
     assert new_table.metadata_location == table.metadata_location
     # old table should be dropped
@@ -373,25 +371,24 @@ def test_rename_table(
 def test_rename_table_from_self_identifier(
     _bucket_initialize: None, moto_endpoint_url: str, table_schema_nested: Schema, database_name: str, table_name: str
 ) -> None:
-    catalog_name = "glue"
     new_table_name = f"{table_name}_new"
     identifier = (database_name, table_name)
     new_identifier = (database_name, new_table_name)
     test_catalog = GlueCatalog("glue", **{"s3.endpoint": moto_endpoint_url, "warehouse": f"s3://{BUCKET_NAME}/"})
     test_catalog.create_namespace(namespace=database_name)
     table = test_catalog.create_table(identifier, table_schema_nested)
-    assert table.identifier == (catalog_name,) + identifier
+    assert table.name() == identifier
     assert TABLE_METADATA_LOCATION_REGEX.match(table.metadata_location)
-    test_catalog.rename_table(table.identifier, new_identifier)
+    test_catalog.rename_table(table.name(), new_identifier)
     new_table = test_catalog.load_table(new_identifier)
-    assert new_table.identifier == (catalog_name,) + new_identifier
+    assert new_table.name() == new_identifier
     # the metadata_location should not change
     assert new_table.metadata_location == table.metadata_location
     # old table should be dropped
     with pytest.raises(NoSuchTableError):
         test_catalog.load_table(identifier)
     with pytest.raises(NoSuchTableError):
-        test_catalog.load_table(table.identifier)
+        test_catalog.load_table(table.name())
 
 
 @mock_aws
@@ -924,7 +921,7 @@ def test_register_table_with_given_location(
     test_catalog = GlueCatalog(catalog_name, **{"s3.endpoint": moto_endpoint_url, "warehouse": f"s3://{BUCKET_NAME}"})
     test_catalog.create_namespace(namespace=database_name, properties={"location": f"s3://{BUCKET_NAME}/{database_name}.db"})
     table = test_catalog.register_table(identifier, location)
-    assert table.identifier == (catalog_name,) + identifier
+    assert table.name() == identifier
     assert test_catalog.table_exists(identifier) is True
 
 

--- a/tests/catalog/test_glue.py
+++ b/tests/catalog/test_glue.py
@@ -449,6 +449,7 @@ def test_list_tables(
     test_catalog.create_namespace(namespace=database_name)
 
     non_iceberg_table_name = "non_iceberg_table"
+    non_table_type_table_name = "non_table_type_table"
     glue_client = boto3.client("glue", endpoint_url=moto_endpoint_url)
     glue_client.create_table(
         DatabaseName=database_name,
@@ -458,12 +459,21 @@ def test_list_tables(
             "Parameters": {"table_type": "noniceberg"},
         },
     )
+    glue_client.create_table(
+        DatabaseName=database_name,
+        TableInput={
+            "Name": non_table_type_table_name,
+            "TableType": "OTHER_TABLE_TYPE",
+            "Parameters": {},
+        },
+    )
 
     for table_name in table_list:
         test_catalog.create_table((database_name, table_name), table_schema_nested)
     loaded_table_list = test_catalog.list_tables(database_name)
 
     assert (database_name, non_iceberg_table_name) not in loaded_table_list
+    assert (database_name, non_table_type_table_name) not in loaded_table_list
     for table_name in table_list:
         assert (database_name, table_name) in loaded_table_list
 

--- a/tests/catalog/test_hive.py
+++ b/tests/catalog/test_hive.py
@@ -699,7 +699,7 @@ def test_load_table(hive_table: HiveTable) -> None:
         last_sequence_number=34,
     )
 
-    assert table.identifier == (HIVE_CATALOG_NAME, "default", "new_tabl2e")
+    assert table.name() == ("default", "new_tabl2e")
     assert expected == table.metadata
 
 
@@ -709,7 +709,7 @@ def test_load_table_from_self_identifier(hive_table: HiveTable) -> None:
     catalog._client = MagicMock()
     catalog._client.__enter__().get_table.return_value = hive_table
     intermediate = catalog.load_table(("default", "new_tabl2e"))
-    table = catalog.load_table(intermediate.identifier)
+    table = catalog.load_table(intermediate.name())
 
     catalog._client.__enter__().get_table.assert_called_with(dbname="default", tbl_name="new_tabl2e")
 
@@ -800,7 +800,7 @@ def test_load_table_from_self_identifier(hive_table: HiveTable) -> None:
         last_sequence_number=34,
     )
 
-    assert table.identifier == (HIVE_CATALOG_NAME, "default", "new_tabl2e")
+    assert table.name() == ("default", "new_tabl2e")
     assert expected == table.metadata
 
 
@@ -819,7 +819,7 @@ def test_rename_table(hive_table: HiveTable) -> None:
     to_identifier = ("default", "new_tabl3e")
     table = catalog.rename_table(from_identifier, to_identifier)
 
-    assert table.identifier == ("hive",) + to_identifier
+    assert table.name() == to_identifier
 
     calls = [call(dbname="default", tbl_name="new_tabl2e"), call(dbname="default", tbl_name="new_tabl3e")]
     catalog._client.__enter__().get_table.assert_has_calls(calls)
@@ -843,9 +843,9 @@ def test_rename_table_from_self_identifier(hive_table: HiveTable) -> None:
     catalog._client.__enter__().get_table.side_effect = [hive_table, renamed_table]
     catalog._client.__enter__().alter_table.return_value = None
     to_identifier = ("default", "new_tabl3e")
-    table = catalog.rename_table(from_table.identifier, to_identifier)
+    table = catalog.rename_table(from_table.name(), to_identifier)
 
-    assert table.identifier == ("hive",) + to_identifier
+    assert table.name() == to_identifier
 
     calls = [call(dbname="default", tbl_name="new_tabl2e"), call(dbname="default", tbl_name="new_tabl3e")]
     catalog._client.__enter__().get_table.assert_has_calls(calls)
@@ -966,7 +966,7 @@ def test_drop_table_from_self_identifier(hive_table: HiveTable) -> None:
     table = catalog.load_table(("default", "new_tabl2e"))
 
     catalog._client.__enter__().get_all_databases.return_value = ["namespace1", "namespace2"]
-    catalog.drop_table(table.identifier)
+    catalog.drop_table(table.name())
 
     catalog._client.__enter__().drop_table.assert_called_with(dbname="default", name="new_tabl2e", deleteData=False)
 

--- a/tests/catalog/test_hive.py
+++ b/tests/catalog/test_hive.py
@@ -919,16 +919,20 @@ def test_list_tables(hive_table: HiveTable) -> None:
     tbl3.tableName = "table3"
     tbl3.dbName = "database"
     tbl3.parameters["table_type"] = "non_iceberg"
+    tbl4 = deepcopy(hive_table)
+    tbl4.tableName = "table4"
+    tbl4.dbName = "database"
+    tbl4.parameters.pop("table_type")
 
     catalog._client = MagicMock()
-    catalog._client.__enter__().get_all_tables.return_value = ["table1", "table2", "table3"]
-    catalog._client.__enter__().get_table_objects_by_name.return_value = [tbl1, tbl2, tbl3]
+    catalog._client.__enter__().get_all_tables.return_value = ["table1", "table2", "table3", "table4"]
+    catalog._client.__enter__().get_table_objects_by_name.return_value = [tbl1, tbl2, tbl3, tbl4]
 
     got_tables = catalog.list_tables("database")
     assert got_tables == [("database", "table1"), ("database", "table2")]
     catalog._client.__enter__().get_all_tables.assert_called_with(db_name="database")
     catalog._client.__enter__().get_table_objects_by_name.assert_called_with(
-        dbname="database", tbl_names=["table1", "table2", "table3"]
+        dbname="database", tbl_names=["table1", "table2", "table3", "table4"]
     )
 
 

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -763,7 +763,7 @@ def test_load_table_from_self_identifier_200(
     )
     catalog = RestCatalog("rest", uri=TEST_URI, token=TEST_TOKEN)
     table = catalog.load_table(("pdames", "table"))
-    actual = catalog.load_table(table.identifier)
+    actual = catalog.load_table(table.name())
     expected = Table(
         identifier=("pdames", "table"),
         metadata_location=example_table_metadata_with_snapshot_v1_rest_json["metadata-location"],
@@ -1111,7 +1111,7 @@ def test_register_table_200(
     )
     assert actual.metadata.model_dump() == expected.metadata.model_dump()
     assert actual.metadata_location == expected.metadata_location
-    assert actual.identifier == expected.identifier
+    assert actual.name() == expected.name()
 
 
 def test_register_table_409(rest_mock: Mocker, table_schema_simple: Schema) -> None:
@@ -1174,7 +1174,7 @@ def test_delete_table_from_self_identifier_204(
         status_code=204,
         request_headers=TEST_HEADERS,
     )
-    catalog.drop_table(table.identifier)
+    catalog.drop_table(table.name())
 
 
 def test_rename_table_200(rest_mock: Mocker, example_table_metadata_with_snapshot_v1_rest_json: Dict[str, Any]) -> None:
@@ -1236,7 +1236,7 @@ def test_rename_table_from_self_identifier_200(
         status_code=200,
         request_headers=TEST_HEADERS,
     )
-    actual = catalog.rename_table(table.identifier, to_identifier)
+    actual = catalog.rename_table(table.name(), to_identifier)
     expected = Table(
         identifier=("pdames", "destination"),
         metadata_location=example_table_metadata_with_snapshot_v1_rest_json["metadata-location"],

--- a/tests/expressions/test_parser.py
+++ b/tests/expressions/test_parser.py
@@ -53,6 +53,10 @@ def test_quoted_column() -> None:
     assert EqualTo("foo", True) == parser.parse('"foo" = TRUE')
 
 
+def test_leading_underscore() -> None:
+    assert EqualTo("_foo", True) == parser.parse("_foo = true")
+
+
 def test_equals_true() -> None:
     assert EqualTo("foo", True) == parser.parse("foo = true")
     assert EqualTo("foo", True) == parser.parse("foo == TRUE")

--- a/tests/integration/test_reads.py
+++ b/tests/integration/test_reads.py
@@ -673,7 +673,7 @@ def test_hive_locking(session_catalog_hive: HiveCatalog) -> None:
 
     database_name: str
     table_name: str
-    _, database_name, table_name = table.identifier
+    database_name, table_name = table.name()
 
     hive_client: _HiveClient = _HiveClient(session_catalog_hive.properties["uri"])
     blocking_lock_request: LockRequest = session_catalog_hive._create_lock_request(database_name, table_name)
@@ -694,7 +694,7 @@ def test_hive_locking_with_retry(session_catalog_hive: HiveCatalog) -> None:
     table = create_table(session_catalog_hive)
     database_name: str
     table_name: str
-    _, database_name, table_name = table.identifier
+    database_name, table_name = table.name()
     session_catalog_hive._lock_check_min_wait_time = 0.1
     session_catalog_hive._lock_check_max_wait_time = 0.5
     session_catalog_hive._lock_check_retries = 5

--- a/tests/utils/test_manifest.py
+++ b/tests/utils/test_manifest.py
@@ -16,7 +16,7 @@
 # under the License.
 # pylint: disable=redefined-outer-name,arguments-renamed,fixme
 from tempfile import TemporaryDirectory
-from typing import Dict
+from typing import Dict, Optional
 from unittest.mock import patch
 
 import fastavro
@@ -526,14 +526,18 @@ def test_write_manifest(
 
 
 @pytest.mark.parametrize("format_version", [1, 2])
+@pytest.mark.parametrize("parent_snapshot_id", [19, None])
 def test_write_manifest_list(
-    generated_manifest_file_file_v1: str, generated_manifest_file_file_v2: str, format_version: TableVersion
+    generated_manifest_file_file_v1: str,
+    generated_manifest_file_file_v2: str,
+    format_version: TableVersion,
+    parent_snapshot_id: Optional[int],
 ) -> None:
     io = load_file_io()
 
     snapshot = Snapshot(
         snapshot_id=25,
-        parent_snapshot_id=19,
+        parent_snapshot_id=parent_snapshot_id,
         timestamp_ms=1602638573590,
         manifest_list=generated_manifest_file_file_v1 if format_version == 1 else generated_manifest_file_file_v2,
         summary=Summary(Operation.APPEND),
@@ -545,12 +549,20 @@ def test_write_manifest_list(
         path = tmp_dir + "/manifest-list.avro"
         output = io.new_output(path)
         with write_manifest_list(
-            format_version=format_version, output_file=output, snapshot_id=25, parent_snapshot_id=19, sequence_number=0
+            format_version=format_version,
+            output_file=output,
+            snapshot_id=25,
+            parent_snapshot_id=parent_snapshot_id,
+            sequence_number=0,
         ) as writer:
             writer.add_manifests(demo_manifest_list)
         new_manifest_list = list(read_manifest_list(io.new_input(path)))
 
-        expected_metadata = {"snapshot-id": "25", "parent-snapshot-id": "19", "format-version": str(format_version)}
+        if parent_snapshot_id:
+            expected_metadata = {"snapshot-id": "25", "parent-snapshot-id": "19", "format-version": str(format_version)}
+        else:
+            expected_metadata = {"snapshot-id": "25", "parent-snapshot-id": "null", "format-version": str(format_version)}
+
         if format_version == 2:
             expected_metadata["sequence-number"] = "0"
         _verify_metadata_with_fastavro(path, expected_metadata)


### PR DESCRIPTION
[pyiceberg 0.8.1 proposal on devlist](https://lists.apache.org/thread/j4l5xk92j6z3pb31wyqtxk7fbf1621kv)

## 0.8.1 Release Note
The behavior of `Table.name` is changed to return the table name **without the catalog name**. This is a broader effort to remove references to the catalog name in pyiceberg. 
* Replace usage of `Table.identifier` with `Table.name` which returns the table name without the catalog name
* Replace the use of a deprecated function (`identifier_to_tuple_without_catalog`) in pyiceberg; remove unnecessary warnings

Documentation updates are included to reflect the updated process in https://py.iceberg.apache.org/
* Update “how to release” documentation
* 0.8.0 post-release steps

Bug fixes
* Fix `add_files` for parquet files without column stats
* Allow leading underscore in column name used in row filter
* Ignore tables without table_type property from Glue and Hive
* Write `null` in manifest list metadata when there is no parent-snapshot-id

Remove upper bound restrictions for dependency libraries; allow early testing of new versions
* Remove Python library version upper bound restriction; allow Python 3.13
* Remove fsspec library version upper bound restriction

## Commits
[36 new commits since the `0.8.0` release](https://github.com/apache/iceberg-python/compare/pyiceberg-0.8.0...acbd071375ac4cc2053435346737a3b1a64cce2e). 

11 new commits will be included in 0.8.1
* 12 commits cherry-picked as bug fixes (listed below)
*  1 [commit](https://github.com/apache/iceberg-python/pull/1369/commits/e64bb8f56978b71a624fb4ee1d64e778e3ba2a04) to bump version to `0.8.1`

### 11 bug fixes (cherry-picked)
acbd071 Write `null` when there is no parent-snapshot-id (#1383)
bb078cf Add instruction for patch release (#1373)
ab43c6c fix `KeyError` raised by `add_files` when parquet file doe not have column stats (#1354)
cc1ab2c Improve documentation for "how to release" (#1359)
64dc6fe Remove Python 3.13 upper bound restriction (#1355)
d86ab6e Allow leading underscore in column name used in row filter (#1358)
7a4734e Replace reference of `Table.identifier` with `Table.name` (#1346)
a66ddc0 Ignore tables without `table_type` from Glue and Hive (#1332)
2cbc77d Drop upper bounds for fsspec and it's implementations (#1341)
7660a5b 0.8.0 post release steps (#1334)
b2f0a9e use the non-deprecated func (#1326)

### 9 features (not cherry-picked)
b4395ed Extend bugfix report (#1380)
3230186 Update `upload-artifact` to use v4 (#1371)
3b559c4 Deprecate the use of `last-column-id` (#1367)
6316900 check mkdocs build strict in CI (#1360)
8e0e6a1 dont override global warning (#1350)
12e87a4 Boto Glue standard retry policy with configuration (#1307)
150fa0c Set default for `SortField`'s `transform`  (#1347)
5f0f770 Remove deprecated `datetime` functions (#1134)
a90c014 Tests: Bump Spark to 3.5.3 (#1322)

### 16 misc (not cherry-picked)
7fe8fdc Bump Poetry to 1.8.4 (#1379)
1e9bdc2 Bump pypa/cibuildwheel from 2.21.3 to 2.22.0 (#1374)
8f6a3d4 Bump coverage from 7.6.7 to 7.6.8 (#1375)
d5fa615 Bump mkdocs-material from 9.5.45 to 9.5.46 (#1376)
c21aefd Bump getdaft from 0.3.13 to 0.3.14 (#1361)
e8e0037 Bump pydantic from 2.10.0 to 2.10.1 (#1364)
7a83695 Bump mkdocs-material from 9.5.44 to 9.5.45 (#1351)
15cfc51 Bump pydantic from 2.9.1 to 2.10.0 (#1352)
102a3bb Bump `pre-commit` versions (#1344)
93ebd39 Bump deptry from 0.21.0 to 0.21.1 (#1342)
a2b11de Bump mypy-boto3-glue from 1.35.53 to 1.35.65 (#1343)
7ecfa71 Bump moto from 5.0.20 to 5.0.21 (#1339)
42145f1 Bump aiohttp from 3.10.5 to 3.10.11 (#1338)
b4c43b0 Bump coverage from 7.6.5 to 7.6.7 (#1329)
1cbf429 Bump mkdocstrings from 0.26.2 to 0.27.0 (#1324)
60800d8 Bump coverage from 7.6.4 to 7.6.5 (#1325)
