### PR TITLE
Parallelize release github action

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -30,12 +30,12 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build wheels on ${{ matrix.os }} with Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ ubuntu-22.04, windows-2022, macos-12, macos-13, macos-14 ]
-
+        python-version: [3.9, 3.10, 3.11, 3.12]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -43,11 +43,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: |
-            3.9
-            3.10
-            3.11
-            3.12
+          python-version: ${{ matrix.python-version }}
 
       - name: Install poetry
         run: pip install poetry
@@ -60,7 +56,7 @@ jobs:
       # the repository, otherwise the tests will fail
       - name: Compile source distribution
         run: python3 -m poetry build --format=sdist
-        if: startsWith(matrix.os, 'ubuntu')
+        if: "matrix.os == 'ubuntu-22.04' && matrix.python-version == '3.12'"
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21.3
@@ -81,8 +77,8 @@ jobs:
           CIBW_TEST_SKIP: "pp* *macosx*"
 
       - name: Add source distribution
-        if: startsWith(matrix.os, 'ubuntu')
         run: ls -lah dist/* && cp dist/* wheelhouse/
+        if: "matrix.os == 'ubuntu-22.04' && matrix.python-version == '3.12'"
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-22.04, windows-2022, macos-12, macos-13, macos-14 ]
-        python-version: [3.9, 3.10, 3.11, 3.12]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This PR improves the release process (`python-release.yml`) by parallelizing the action per `os` and `python` versions to speed up the overall run.

Test run on branch, https://github.com/kevinjqliu/iceberg-python/actions/runs/12016469529
Versus main, https://github.com/kevinjqliu/iceberg-python/actions/runs/12016505196/job/33496840039