### PR TITLE
Update `upload-artifact` to use v4

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -97,3 +97,4 @@ jobs:
         with:
           name: "release-${{ github.event.inputs.version }}"
           pattern: release-*
+          delete-merged: true

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -84,7 +84,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         run: ls -lah dist/* && cp dist/* wheelhouse/
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: "release-${{ github.event.inputs.version }}"
           path: ./wheelhouse/*

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-22.04, windows-2022, macos-12, macos-13, macos-14 ]
+        os: [ ubuntu-22.04, windows-2022, macos-13, macos-14 ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-22.04, windows-2022, macos-13, macos-14 ]
+        os: [ ubuntu-22.04, windows-2022, macos-13, macos-14, macos-15 ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -86,5 +86,14 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: "release-${{ github.event.inputs.version }}"
+          name: "release-${{ matrix.os }}"
           path: ./wheelhouse/*
+  merge:
+    runs-on: ubuntu-latest
+    needs: build_wheels
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: "release-${{ github.event.inputs.version }}"
+          pattern: release-*


### PR DESCRIPTION
Both `actions/upload-artifact@v3` and `actions/download-artifact@v3` are deprecated and requires update, based on https://lists.apache.org/thread/nx19j3h61tjmsk8c8vx24gbq6ygf7pyf

`upload-artifact@v3` only used in iceberg-python
https://grep.app/search?q=actions/upload-artifact%40v3&filter[repo.pattern][0]=apache/iceberg

`download-artifact@v3` is not used in any iceberg-related repos
https://grep.app/search?q=actions/download-artifact&filter[repo.pattern][0]=apache/iceberg

Migrate from V3 to V4 following [the migration guide to merge multiple artifacts into one](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#merging-multiple-artifacts) with [`@actions/upload-artifact/merge`](https://github.com/actions/upload-artifact/blob/main/merge/README.md). 

Removed `macos-12` from the os matrix since its deprecated and added `macos-15` which is [currently in public preview](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories). 



Testing "Python Release" action
* main branch https://github.com/kevinjqliu/iceberg-python/actions/runs/12036359688
* feature branch https://github.com/kevinjqliu/iceberg-python/actions/runs/12035706304

Downloaded artifacts and verified that they have the same file names, but different hash. 