### PR TITLE
[infra] Prevent running `python-release` action without a specified rc version

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -37,19 +37,15 @@ jobs:
         os: [ ubuntu-22.04, windows-2022, macos-13, macos-14, macos-15 ]
 
     steps:
-      - name: Validate version input
-        run: |
-          version="${{ github.event.inputs.version }}"
-          # Trim whitespace
-          version="${version// /}"
-          echo "Checking if version is 'main' or a valid rc candidate"
-          # Matches "main" or any string ending with "rc" followed by one or more digits.
-          if echo "$version" | grep -E -q '^(main|.*rc[0-9]+)$'; then
-            echo "Valid version: $version"
-          else
-            echo "Invalid version: $version" >&2
-            exit 1
-          fi
+    - name: Validate version input
+      if: ${{ github.event.inputs.version != 'main' && !contains(github.event.inputs.version, 'rc') }}
+      run: |
+        echo "Error: Invalid version format. You provided: '${{ github.event.inputs.version }}'"
+        echo "Allowed formats:"
+        echo "  - 'main'"
+        echo "  - version string containing 'rc' (e.g., 0.8.0rc1, 0.8.0rc2)"
+        exit 1
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -34,15 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Echo version input
-        run: echo "Version input: '${{ github.event.inputs.version }}'"
+        run: echo "Version input is: ${{ github.event.inputs.version }}"
 
       - name: Validate version input
         if: ${{ github.event.inputs.version != 'main' && !contains(github.event.inputs.version, 'rc') }}
         run: |
           echo "Error: Invalid version format. You provided: '${{ github.event.inputs.version }}'"
           echo "Allowed formats:"
-          echo "  - 'main'"
-          echo "  - version string containing 'rc' (e.g., 0.8.0rc1, 0.8.0rc2)"
+          echo " - 'main'"
+          echo " - version string containing 'rc' (e.g., 0.8.0rc1, 0.8.0rc2)"
           exit 1
 
   build_wheels:

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -29,6 +29,19 @@ on:
 
 
 jobs:
+  validate_version:
+    name: Validate version input
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check version format
+        if: ${{ github.event.inputs.version != 'main' && !contains(github.event.inputs.version, 'rc') }}
+        run: |
+          echo "Error: Invalid version format. You provided: '${{ github.event.inputs.version }}'"
+          echo "Allowed formats:"
+          echo "  - 'main'"
+          echo "  - Semantic version with 'rc' suffix (e.g., 0.8.0rc1, 0.8.0rc2)"
+          exit 1
+
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -37,15 +50,6 @@ jobs:
         os: [ ubuntu-22.04, windows-2022, macos-13, macos-14, macos-15 ]
 
     steps:
-      - name: Validate version input
-        if: ${{ github.event.inputs.version != 'main' && !contains(github.event.inputs.version, 'rc') }}
-        run: |
-          echo "Error: Invalid version format. You provided: '${{ github.event.inputs.version }}'"
-          echo "Allowed formats:"
-          echo "  - 'main'"
-          echo "  - version string containing 'rc' (e.g., 0.8.0rc1, 0.8.0rc2)"
-          exit 1
-
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -37,6 +37,18 @@ jobs:
         os: [ ubuntu-22.04, windows-2022, macos-13, macos-14, macos-15 ]
 
     steps:
+      - name: Validate version input
+        run: |
+          version="${{ github.event.inputs.version }}"
+          if [[ "$version" == "main" ]]; then
+            echo "Valid version: main"
+          elif [[ "$version" == rc* ]] && [[ "${version:2}" =~ ^[0-9]+$ ]]; then
+            echo "Valid version: $version"
+          else
+            echo "Error: Version must be 'main' or 'rc' followed by a number (e.g., rc1, rc2, etc.)"
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -34,7 +34,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Echo version input
-        run: echo "Version input is: ${{ github.event.inputs.version }}"
+        run: |
+          echo "Version input is: ${{ github.event.inputs.version }}"
 
       - name: Validate version input
         if: ${{ github.event.inputs.version != 'main' && !contains(github.event.inputs.version, 'rc') }}

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -48,6 +48,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-22.04, windows-2022, macos-13, macos-14, macos-15 ]
+    needs: validate_version
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -33,13 +33,13 @@ jobs:
     name: Validate version input
     runs-on: ubuntu-latest
     steps:
-      - name: Check version format
+      - name: Validate version input
         if: ${{ github.event.inputs.version != 'main' && !contains(github.event.inputs.version, 'rc') }}
         run: |
           echo "Error: Invalid version format. You provided: '${{ github.event.inputs.version }}'"
           echo "Allowed formats:"
           echo "  - 'main'"
-          echo "  - Semantic version with 'rc' suffix (e.g., 0.8.0rc1, 0.8.0rc2)"
+          echo "  - version string containing 'rc' (e.g., 0.8.0rc1, 0.8.0rc2)"
           exit 1
 
   build_wheels:

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -42,22 +42,14 @@ jobs:
           version="${{ github.event.inputs.version }}"
           # Trim whitespace
           version="${version// /}"
-          
-          if [[ -z "$version" ]]; then
-            echo "Error: Version input cannot be empty"
-            exit 1
-          fi
-          
-          if [[ "$version" == "main" ]]; then
-            echo "✓ Valid version: main"
-          elif [[ "$version" =~ ^rc[0-9]+$ ]]; then
-            echo "✓ Valid version: $version"
+          echo "Checking if version is 'main' or a valid rc candidate"
+          # Matches "main" or any string ending with "rc" followed by one or more digits.
+          if echo "$version" | grep -E -q '^(main|.*rc[0-9]+)$'; then
+            echo "Valid version: $version"
           else
-            echo "❌ Error: Version must be 'main' or 'rc' followed by a number (e.g., rc1, rc2)"
-            echo "   Received: '$version'"
+            echo "Invalid version: $version" >&2
             exit 1
           fi
-
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -37,14 +37,14 @@ jobs:
         os: [ ubuntu-22.04, windows-2022, macos-13, macos-14, macos-15 ]
 
     steps:
-    - name: Validate version input
-      if: ${{ github.event.inputs.version != 'main' && !contains(github.event.inputs.version, 'rc') }}
-      run: |
-        echo "Error: Invalid version format. You provided: '${{ github.event.inputs.version }}'"
-        echo "Allowed formats:"
-        echo "  - 'main'"
-        echo "  - version string containing 'rc' (e.g., 0.8.0rc1, 0.8.0rc2)"
-        exit 1
+      - name: Validate version input
+        if: ${{ github.event.inputs.version != 'main' && !contains(github.event.inputs.version, 'rc') }}
+        run: |
+          echo "Error: Invalid version format. You provided: '${{ github.event.inputs.version }}'"
+          echo "Allowed formats:"
+          echo "  - 'main'"
+          echo "  - version string containing 'rc' (e.g., 0.8.0rc1, 0.8.0rc2)"
+          exit 1
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -33,6 +33,9 @@ jobs:
     name: Validate version input
     runs-on: ubuntu-latest
     steps:
+      - name: Echo version input
+        run: echo "Version input: '${{ github.event.inputs.version }}'"
+
       - name: Validate version input
         if: ${{ github.event.inputs.version != 'main' && !contains(github.event.inputs.version, 'rc') }}
         run: |

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -40,12 +40,21 @@ jobs:
       - name: Validate version input
         run: |
           version="${{ github.event.inputs.version }}"
+          # Trim whitespace
+          version="${version// /}"
+          
+          if [[ -z "$version" ]]; then
+            echo "Error: Version input cannot be empty"
+            exit 1
+          fi
+          
           if [[ "$version" == "main" ]]; then
-            echo "Valid version: main"
-          elif [[ "$version" == rc* ]] && [[ "${version:2}" =~ ^[0-9]+$ ]]; then
-            echo "Valid version: $version"
+            echo "✓ Valid version: main"
+          elif [[ "$version" =~ ^rc[0-9]+$ ]]; then
+            echo "✓ Valid version: $version"
           else
-            echo "Error: Version must be 'main' or 'rc' followed by a number (e.g., rc1, rc2, etc.)"
+            echo "❌ Error: Version must be 'main' or 'rc' followed by a number (e.g., rc1, rc2)"
+            echo "   Received: '$version'"
             exit 1
           fi
 


### PR DESCRIPTION
When running without RC version, artifacts will be published to PyPi as the "official version", which is not what we want. 

Let's always run with RC version (or as `main`) to prevent accidentally pushing new official versions to PyPi.

When the RC passes, releasing as the official version downloads artifacts from SVN
https://github.com/apache/iceberg-python/blob/main/mkdocs/docs/how-to-release.md#upload-the-accepted-release-to-pypi

Testing
* `0.8.1` failed https://github.com/kevinjqliu/iceberg-python/actions/runs/12060385596/job/33630708983
* `main` succeeded https://github.com/kevinjqliu/iceberg-python/actions/runs/12060379890/job/33630692213
* `0.8.1rc1` succeeded https://github.com/kevinjqliu/iceberg-python/actions/runs/12060386335/job/33630711338