### PR TITLE
TEST: adopt new rest catalog image and enable tableExists tests

### DIFF
--- a/dev/docker-compose-integration.yml
+++ b/dev/docker-compose-integration.yml
@@ -41,7 +41,8 @@ services:
       - hive:hive
       - minio:minio
   rest:
-    image: tabulario/iceberg-rest
+    # TODO: This needs to be updated to apache/iceberg-rest-fixture once https://github.com/apache/iceberg/pull/11676 is merged
+    image: asfjenkins/iceberg-rest-fixture
     container_name: pyiceberg-rest
     networks:
       iceberg_net:

--- a/dev/docker-compose-integration.yml
+++ b/dev/docker-compose-integration.yml
@@ -41,8 +41,7 @@ services:
       - hive:hive
       - minio:minio
   rest:
-    # TODO: This needs to be updated to apache/iceberg-rest-fixture once https://github.com/apache/iceberg/pull/11676 is merged
-    image: asfjenkins/iceberg-rest-fixture
+    image: apache/iceberg-rest-fixture
     container_name: pyiceberg-rest
     networks:
       iceberg_net:

--- a/pyiceberg/catalog/rest.py
+++ b/pyiceberg/catalog/rest.py
@@ -887,7 +887,7 @@ class RestCatalog(Catalog):
 
         if response.status_code == 404:
             return False
-        elif response.status_code == 204:
+        elif response.status_code in (200, 204):
             return True
 
         try:

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -801,7 +801,7 @@ def test_table_exists_200(rest_mock: Mocker) -> None:
         request_headers=TEST_HEADERS,
     )
     catalog = RestCatalog("rest", uri=TEST_URI, token=TEST_TOKEN)
-    assert not catalog.table_exists(("fokko", "table"))
+    assert catalog.table_exists(("fokko", "table"))
 
 
 def test_table_exists_204(rest_mock: Mocker) -> None:

--- a/tests/integration/test_writes/test_writes.py
+++ b/tests/integration/test_writes/test_writes.py
@@ -1368,10 +1368,9 @@ def test_table_v1_with_null_nested_namespace(session_catalog: Catalog, arrow_tab
     identifier = "default.lower.table_v1_with_null_nested_namespace"
     tbl = _create_table(session_catalog, identifier, {"format-version": "1"}, [arrow_table_with_null])
     assert tbl.format_version == 1, f"Expected v1, got: v{tbl.format_version}"
-    # TODO: Add session_catalog.table_exists check here when we integrate a REST catalog image
-    # that supports HEAD request on table endpoint
 
-    # assert session_catalog.table_exists(identifier)
+    assert session_catalog.load_table(identifier) is not None
+    assert session_catalog.table_exists(identifier)
 
     # We expect no error here
     session_catalog.drop_table(identifier)


### PR DESCRIPTION
NOTE: the test is failing because tableExists endpoint isn't exposed on the adapter. Related fix: https://github.com/apache/iceberg/pull/11678