### PR TITLE
0.8.1 post release

### DIFF
--- a/.github/ISSUE_TEMPLATE/iceberg_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/iceberg_bug_report.yml
@@ -28,7 +28,8 @@ body:
       description: What Apache Iceberg version are you using?
       multiple: false
       options:
-        - "0.8.0 (latest release)"
+        - "0.8.1 (latest release)"
+        - "0.8.0"
         - "0.7.1"
         - "0.7.0"
         - "0.6.1"

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -39,7 +39,7 @@ WORKDIR ${SPARK_HOME}
 ENV SPARK_VERSION=3.5.3
 ENV ICEBERG_SPARK_RUNTIME_VERSION=3.5_2.12
 ENV ICEBERG_VERSION=1.6.0
-ENV PYICEBERG_VERSION=0.8.0
+ENV PYICEBERG_VERSION=0.8.1
 
 RUN curl --retry 3 -s -C - https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz -o spark-${SPARK_VERSION}-bin-hadoop3.tgz \
  && tar xzf spark-${SPARK_VERSION}-bin-hadoop3.tgz --directory /opt/spark --strip-components 1 \


### PR DESCRIPTION
Post-release steps for 0.8.1 release https://py.iceberg.apache.org/how-to-release/#post-release

Similar to #1334