### PR TITLE
Deserialize NestedField initial-default and write-default Attributes

### DIFF
--- a/pyiceberg/types.py
+++ b/pyiceberg/types.py
@@ -328,8 +328,8 @@ class NestedField(IcebergType):
         data["type"] = data["type"] if "type" in data else field_type
         data["required"] = required
         data["doc"] = doc
-        data["initial-default"] = initial_default
-        data["write-default"] = write_default
+        data["initial-default"] = data["initial-default"] if "initial-default" in data else initial_default
+        data["write-default"] = data["write-default"] if "write-default" in data else write_default
         super().__init__(**data)
 
     def __str__(self) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -150,6 +150,35 @@ def table_schema_simple() -> Schema:
 
 
 @pytest.fixture(scope="session")
+def table_schema_with_full_nested_fields() -> Schema:
+    return schema.Schema(
+        NestedField(
+            field_id=1,
+            name="foo",
+            field_type=StringType(),
+            required=False,
+            doc="foo doc",
+            initial_default="foo initial",
+            write_default="foo write",
+        ),
+        NestedField(
+            field_id=2, name="bar", field_type=IntegerType(), required=True, doc="bar doc", initial_default=42, write_default=43
+        ),
+        NestedField(
+            field_id=3,
+            name="baz",
+            field_type=BooleanType(),
+            required=False,
+            doc="baz doc",
+            initial_default=True,
+            write_default=False,
+        ),
+        schema_id=1,
+        identifier_field_ids=[2],
+    )
+
+
+@pytest.fixture(scope="session")
 def table_schema_nested() -> Schema:
     return schema.Schema(
         NestedField(field_id=1, name="foo", field_type=StringType(), required=False),

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -421,17 +421,17 @@ def test_build_position_accessors_with_struct(table_schema_nested: Schema) -> No
     assert inner_accessor.get(container) == "name"
 
 
-def test_serialize_schema(table_schema_simple: Schema) -> None:
-    actual = table_schema_simple.model_dump_json()
-    expected = """{"type":"struct","fields":[{"id":1,"name":"foo","type":"string","required":false},{"id":2,"name":"bar","type":"int","required":true},{"id":3,"name":"baz","type":"boolean","required":false}],"schema-id":1,"identifier-field-ids":[2]}"""
+def test_serialize_schema(table_schema_with_full_nested_fields: Schema) -> None:
+    actual = table_schema_with_full_nested_fields.model_dump_json()
+    expected = """{"type":"struct","fields":[{"id":1,"name":"foo","type":"string","required":false,"doc":"foo doc","initial-default":"foo initial","write-default":"foo write"},{"id":2,"name":"bar","type":"int","required":true,"doc":"bar doc","initial-default":42,"write-default":43},{"id":3,"name":"baz","type":"boolean","required":false,"doc":"baz doc","initial-default":true,"write-default":false}],"schema-id":1,"identifier-field-ids":[2]}"""
     assert actual == expected
 
 
-def test_deserialize_schema(table_schema_simple: Schema) -> None:
+def test_deserialize_schema(table_schema_with_full_nested_fields: Schema) -> None:
     actual = Schema.model_validate_json(
-        """{"type": "struct", "fields": [{"id": 1, "name": "foo", "type": "string", "required": false}, {"id": 2, "name": "bar", "type": "int", "required": true}, {"id": 3, "name": "baz", "type": "boolean", "required": false}], "schema-id": 1, "identifier-field-ids": [2]}"""
+        """{"type": "struct", "fields": [{"id": 1, "name": "foo", "type": "string", "required": false, "doc": "foo doc", "initial-default": "foo initial", "write-default": "foo write"}, {"id": 2, "name": "bar", "type": "int", "required": true, "doc": "bar doc", "initial-default": 42, "write-default": 43}, {"id": 3, "name": "baz", "type": "boolean", "required": false, "doc": "baz doc", "initial-default": true, "write-default": false}], "schema-id": 1, "identifier-field-ids": [2]}"""
     )
-    expected = table_schema_simple
+    expected = table_schema_with_full_nested_fields
     assert actual == expected
 
 


### PR DESCRIPTION
Ensures that these attributes are correctly applied to the NestedField when reading an Iceberg schema json file.

Fixes #1431 