### PR TITLE
Change dot notation in add column documentation to tuple

### DIFF
--- a/mkdocs/docs/api.md
+++ b/mkdocs/docs/api.md
@@ -964,7 +964,7 @@ Renaming a field in an Iceberg table is simple:
 with table.update_schema() as update:
     update.rename_column("retries", "num_retries")
     # This will rename `confirmed_by` to `exchange` in the `details` struct
-    update.rename_column("details", "confirmed_by"), "exchange")
+    update.rename_column(("details", "confirmed_by"), ("detail", "exchange"))
 ```
 
 ### Move column
@@ -977,7 +977,7 @@ with table.update_schema() as update:
     # This will move `bid` after `ask`
     update.move_after("bid", "ask")
     # This will move `confirmed_by` before `exchange` in the `details` struct
-    update.move_before("details", "confirmed_by"), ("details", "exchange"))
+    update.move_before(("details", "confirmed_by"), ("details", "exchange"))
 ```
 
 ### Update column
@@ -1010,7 +1010,7 @@ Delete a field, careful this is a incompatible change (readers/writers might exp
 with table.update_schema(allow_incompatible_changes=True) as update:
     update.delete_column("some_field")
     # In a struct
-    update.delete_column("details", "confirmed_by"))
+    update.delete_column(("details", "confirmed_by"))
 ```
 
 ## Partition evolution

--- a/mkdocs/docs/api.md
+++ b/mkdocs/docs/api.md
@@ -954,7 +954,7 @@ with table.update_schema() as update:
     update.add_column("details", StructType())
     update.add_column(("details", "confirmed_by"), StringType(), "Name of the exchange")
 ```
-A complex type must exist before columns can added to it. Fields in complex types are added in a tuple.
+A complex type must exist before columns can be added to it. Fields in complex types are added in a tuple.
 
 ### Rename column
 

--- a/mkdocs/docs/api.md
+++ b/mkdocs/docs/api.md
@@ -963,8 +963,8 @@ Renaming a field in an Iceberg table is simple:
 ```python
 with table.update_schema() as update:
     update.rename_column("retries", "num_retries")
-    # This will rename `confirmed_by` to `exchange` in the `details` struct
-    update.rename_column(("details", "confirmed_by"), ("detail", "exchange"))
+    # This will rename `confirmed_by` to `processed_by` in the `details` struct
+    update.rename_column(("details", "confirmed_by"), ("detail", "processed_by"))
 ```
 
 ### Move column

--- a/mkdocs/docs/api.md
+++ b/mkdocs/docs/api.md
@@ -950,9 +950,11 @@ Using `add_column` you can add a column, without having to worry about the field
 ```python
 with table.update_schema() as update:
     update.add_column("retries", IntegerType(), "Number of retries to place the bid")
-    # In a struct - a struct must exist before columns can added to it 
+    # In a struct
+    update.add_column("details", StructType())
     update.add_column(("details", "confirmed_by"), StringType(), "Name of the exchange")
 ```
+A complex type must exist before columns can added to it. Fields in complex types are added in a tuple.
 
 ### Rename column
 
@@ -961,20 +963,21 @@ Renaming a field in an Iceberg table is simple:
 ```python
 with table.update_schema() as update:
     update.rename_column("retries", "num_retries")
-    # This will rename `confirmed_by` to `exchange`
-    update.rename_column("properties.confirmed_by", "exchange")
+    # This will rename `confirmed_by` to `exchange` in the `details` struct
+    update.rename_column("details", "confirmed_by"), "exchange")
 ```
 
 ### Move column
 
-Move a field inside of struct:
+Move order of fields:
 
 ```python
 with table.update_schema() as update:
     update.move_first("symbol")
+    # This will move `bid` after `ask`
     update.move_after("bid", "ask")
-    # This will move `confirmed_by` before `exchange`
-    update.move_before("details.created_by", "details.exchange")
+    # This will move `confirmed_by` before `exchange` in the `details` struct
+    update.move_before("details", "confirmed_by"), ("details", "exchange"))
 ```
 
 ### Update column
@@ -1006,6 +1009,8 @@ Delete a field, careful this is a incompatible change (readers/writers might exp
 ```python
 with table.update_schema(allow_incompatible_changes=True) as update:
     update.delete_column("some_field")
+    # In a struct
+    update.delete_column("details", "confirmed_by"))
 ```
 
 ## Partition evolution

--- a/mkdocs/docs/api.md
+++ b/mkdocs/docs/api.md
@@ -950,8 +950,8 @@ Using `add_column` you can add a column, without having to worry about the field
 ```python
 with table.update_schema() as update:
     update.add_column("retries", IntegerType(), "Number of retries to place the bid")
-    # In a struct
-    update.add_column("details.confirmed_by", StringType(), "Name of the exchange")
+    # In a struct - a struct must exist before columns can added to it 
+    update.add_column(("details", "confirmed_by"), StringType(), "Name of the exchange")
 ```
 
 ### Rename column


### PR DESCRIPTION
A tuple must be used to make columns in structs as described in add_column: 
"Because "." may be interpreted as a column path separator or may be used in field names, it is not allowed to add nested column by passing in a string. To add to nested structures or to add fields with names that contain "." use a tuple instead to indicate the path."
This PR corrects the documentation to use tuples instead of dot notation. 

From [issue 1407 ](https://github.com/apache/iceberg-python/issues/1407)