### PR TITLE
Remove `version` from `docker-compose`

### DIFF
--- a/dev/docker-compose-azurite.yml
+++ b/dev/docker-compose-azurite.yml
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-version: "3"
 
 services:
   azurite:

--- a/dev/docker-compose-gcs-server.yml
+++ b/dev/docker-compose-gcs-server.yml
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-version: "3"
 
 services:
   gcs-server:

--- a/dev/docker-compose-integration.yml
+++ b/dev/docker-compose-integration.yml
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-version: "3"
 
 services:
   spark-iceberg:

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-version: "3"
 
 services:
   minio:


### PR DESCRIPTION
Seeing this in the logs:

```
time="2024-12-09T14:41:56Z" level=warning msg="/home/runner/work/iceberg-python/iceberg-python/dev/docker-compose-gcs-server.yml: `version` is obsolete"
```

Less is more!