### PR TITLE
Implement column projection 

### DIFF
--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -1256,7 +1256,11 @@ def _task_to_record_batches(
                 if isinstance(partition_field.transform, IdentityTransform) and task.file.partition is not None:
                     projected_missing_fields = (partition_field.name, task.file.partition[0])
 
-            if nested_field := projected_schema.find_field(field_id) and projected_missing_fields is None and task.file.partition is None:
+            if (
+                nested_field := projected_schema.find_field(field_id)
+                and projected_missing_fields is None
+                and task.file.partition is None
+            ):
                 if nested_field.initial_default is not None:
                     projected_missing_fields(nested_field.name, nested_field)
 

--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -1241,15 +1241,15 @@ def _get_column_projection_values(
     for field_id in project_schema_diff:
         for partition_field in partition_spec.fields_by_source_id(field_id):
             if isinstance(partition_field.transform, IdentityTransform):
-                accesor = accessors.get(partition_field.field_id)
+                accessor = accessors.get(partition_field.field_id)
 
-                if accesor is None:
+                if accessor is None:
                     continue
 
                 # The partition field may not exist in the partition record of the data file.
                 # This can happen when new partition fields are introduced after the file was written.
                 try:
-                    if partition_value := accesor.get(file.partition):
+                    if partition_value := accessor.get(file.partition):
                         projected_missing_fields[partition_field.name] = partition_value
                 except IndexError:
                     continue

--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -1226,7 +1226,7 @@ def _task_to_record_batches(
     case_sensitive: bool,
     name_mapping: Optional[NameMapping] = None,
     use_large_types: bool = True,
-    partition_spec: PartitionSpec = None,
+    partition_spec: Optional[PartitionSpec] = None,
 ) -> Iterator[pa.RecordBatch]:
     _, _, path = _parse_location(task.file.file_path)
     arrow_format = ds.ParquetFileFormat(pre_buffer=True, buffer_size=(ONE_MEGABYTE * 8))
@@ -1250,19 +1250,17 @@ def _task_to_record_batches(
 
         # Apply column projection rules for missing partitions and default values
         # https://iceberg.apache.org/spec/#column-projection
-
         file_project_schema = prune_columns(file_schema, projected_field_ids, select_full_types=False)
         projected_missing_fields = {}
 
         for field_id in projected_field_ids.difference(file_project_schema.field_ids):
-            for partition_field in partition_spec.fields_by_source_id(field_id):
-                if isinstance(partition_field.transform, IdentityTransform) and task.file.partition is not None:
-                    projected_missing_fields[partition_field.name] = task.file.partition[0]
-                    continue
-
             if nested_field := projected_schema.find_field(field_id):
                 if nested_field.initial_default is not None:
                     projected_missing_fields[nested_field.name] = nested_field.initial_default
+            if partition_spec is not None:
+                for partition_field in partition_spec.fields_by_source_id(field_id):
+                    if isinstance(partition_field.transform, IdentityTransform) and task.file.partition is not None:
+                        projected_missing_fields[partition_field.name] = task.file.partition[0]
 
         fragment_scanner = ds.Scanner.from_fragment(
             fragment=fragment,

--- a/tests/io/test_pyarrow.py
+++ b/tests/io/test_pyarrow.py
@@ -1123,7 +1123,7 @@ def test_projection_concat_files(schema_int: Schema, file_int: str) -> None:
     assert repr(result_table.schema) == "id: int32"
 
 
-def test_projection_partition_inference(tmp_path: str):
+def test_projection_partition_inference(tmp_path: str) -> None:
     schema = Schema(
         NestedField(1, "partition_field", IntegerType(), required=False),
         NestedField(2, "other_field", StringType(), required=False),


### PR DESCRIPTION
This is a fix for issue #1401. In which table scans needed to infer partition column by following the column projection [rules](https://iceberg.apache.org/spec/#column-projection)

Fixes https://github.com/apache/iceberg-python/issues/1401