### PR TITLE
[infra] Update pyspark java iceberg library to 1.6.0

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -36,6 +36,7 @@ ENV PYTHONPATH=$SPARK_HOME/python:$SPARK_HOME/python/lib/py4j-0.10.9.7-src.zip:$
 RUN mkdir -p ${HADOOP_HOME} && mkdir -p ${SPARK_HOME} && mkdir -p /home/iceberg/spark-events
 WORKDIR ${SPARK_HOME}
 
+# Remember to also update `tests/conftest`'s spark setting 
 ENV SPARK_VERSION=3.5.3
 ENV ICEBERG_SPARK_RUNTIME_VERSION=3.5_2.12
 ENV ICEBERG_VERSION=1.6.0

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -36,7 +36,7 @@ ENV PYTHONPATH=$SPARK_HOME/python:$SPARK_HOME/python/lib/py4j-0.10.9.7-src.zip:$
 RUN mkdir -p ${HADOOP_HOME} && mkdir -p ${SPARK_HOME} && mkdir -p /home/iceberg/spark-events
 WORKDIR ${SPARK_HOME}
 
-# Remember to also update `tests/conftest`'s spark setting 
+# Remember to also update `tests/conftest`'s spark setting
 ENV SPARK_VERSION=3.5.3
 ENV ICEBERG_SPARK_RUNTIME_VERSION=3.5_2.12
 ENV ICEBERG_VERSION=1.6.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2242,7 +2242,7 @@ def spark() -> "SparkSession":
 
     spark_version = ".".join(importlib.metadata.version("pyspark").split(".")[:2])
     scala_version = "2.12"
-    iceberg_version = "1.4.3"
+    iceberg_version = "1.6.0"
 
     os.environ["PYSPARK_SUBMIT_ARGS"] = (
         f"--packages org.apache.iceberg:iceberg-spark-runtime-{spark_version}_{scala_version}:{iceberg_version},"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2240,6 +2240,7 @@ def spark() -> "SparkSession":
 
     from pyspark.sql import SparkSession
 
+    # Remember to also update `dev/Dockerfile`
     spark_version = ".".join(importlib.metadata.version("pyspark").split(".")[:2])
     scala_version = "2.12"
     iceberg_version = "1.6.0"


### PR DESCRIPTION
Integration test dockerfile is using version `1.6.0`
https://github.com/apache/iceberg-python/blob/325c8a55d455e479813bdfa831c450991f9c4d36/dev/Dockerfile#L39-L41
Also fixed tests since https://github.com/apache/iceberg/issues/10122 is fixed in new versions

We should figure out a way to keep this in sync. 

