### PR TITLE
feat: search current working directory for config file

### DIFF
--- a/mkdocs/docs/api.md
+++ b/mkdocs/docs/api.md
@@ -49,7 +49,7 @@ catalog:
 
 and loaded in python by calling `load_catalog(name="hive")` and `load_catalog(name="rest")`.
 
-This information must be placed inside a file called `.pyiceberg.yaml` located either in the `$HOME` or `%USERPROFILE%` directory (depending on whether the operating system is Unix-based or Windows-based, respectively) or in the `$PYICEBERG_HOME` directory (if the corresponding environment variable is set).
+This information must be placed inside a file called `.pyiceberg.yaml` located either in the `$HOME` or `%USERPROFILE%` directory (depending on whether the operating system is Unix-based or Windows-based, respectively), in the current working directory, or in the `$PYICEBERG_HOME` directory (if the corresponding environment variable is set).
 
 For more details on possible configurations refer to the [specific page](https://py.iceberg.apache.org/configuration/).
 

--- a/mkdocs/docs/cli.md
+++ b/mkdocs/docs/cli.md
@@ -26,7 +26,7 @@ hide:
 
 Pyiceberg comes with a CLI that's available after installing the `pyiceberg` package.
 
-You can pass the path to the Catalog using the `--uri` and `--credential` argument, but it is recommended to setup a `~/.pyiceberg.yaml` or `./.pyiceberg.yaml` config as described in the [Catalog](configuration.md) section.
+You can pass the path to the Catalog using the `--uri` and `--credential` argument, but it is recommended to setup a `~/.pyiceberg.yaml` config as described in the [Catalog](configuration.md) section.
 
 ```sh
 ➜  pyiceberg --help

--- a/mkdocs/docs/cli.md
+++ b/mkdocs/docs/cli.md
@@ -26,7 +26,7 @@ hide:
 
 Pyiceberg comes with a CLI that's available after installing the `pyiceberg` package.
 
-You can pass the path to the Catalog using the `--uri` and `--credential` argument, but it is recommended to setup a `~/.pyiceberg.yaml` config as described in the [Catalog](configuration.md) section.
+You can pass the path to the Catalog using the `--uri` and `--credential` argument, but it is recommended to setup a `~/.pyiceberg.yaml` or `./.pyiceberg.yaml` config as described in the [Catalog](configuration.md) section.
 
 ```sh
 ➜  pyiceberg --help

--- a/mkdocs/docs/configuration.md
+++ b/mkdocs/docs/configuration.md
@@ -28,7 +28,7 @@ hide:
 
 There are three ways to pass in configuration:
 
-- Using the `~/.pyiceberg.yaml` configuration file
+- Using the `.pyiceberg.yaml` configuration file stored in either the directory specified by the `PYICEBERG_HOME` environment variable, the home directory, or current working directory.
 - Through environment variables
 - By passing in credentials through the CLI or the Python API
 

--- a/mkdocs/docs/configuration.md
+++ b/mkdocs/docs/configuration.md
@@ -28,11 +28,11 @@ hide:
 
 There are three ways to pass in configuration:
 
-- Using the `.pyiceberg.yaml` configuration file stored in either the directory specified by the `PYICEBERG_HOME` environment variable, the home directory, or current working directory.
+- Using the `.pyiceberg.yaml` configuration file (Recommended)
 - Through environment variables
 - By passing in credentials through the CLI or the Python API
 
-The configuration file is recommended since that's the easiest way to manage the credentials.
+The configuration file can be stored in either the directory specified by the `PYICEBERG_HOME` environment variable, the home directory, or current working directory (in this order).
 
 To change the path searched for the `.pyiceberg.yaml`, you can overwrite the `PYICEBERG_HOME` environment variable.
 

--- a/pyiceberg/utils/config.py
+++ b/pyiceberg/utils/config.py
@@ -84,12 +84,13 @@ class Config:
                     return file_config_lowercase
             return None
 
-        # Give priority to the PYICEBERG_HOME directory
-        if pyiceberg_home_config := _load_yaml(os.environ.get(PYICEBERG_HOME)):
-            return pyiceberg_home_config
-        # Look into the home directory
-        if pyiceberg_home_config := _load_yaml(os.path.expanduser("~")):
-            return pyiceberg_home_config
+        # Directories to search for the configuration file
+        search_dirs = [os.environ.get(PYICEBERG_HOME), os.path.expanduser("~"), os.getcwd()]
+
+        for directory in search_dirs:
+            if config := _load_yaml(directory):
+                return config
+
         # Didn't find a config
         return None
 

--- a/pyiceberg/utils/config.py
+++ b/pyiceberg/utils/config.py
@@ -85,6 +85,7 @@ class Config:
             return None
 
         # Directories to search for the configuration file
+        # The current search order is: PYICEBERG_HOME, home directory, then current directory
         search_dirs = [os.environ.get(PYICEBERG_HOME), os.path.expanduser("~"), os.getcwd()]
 
         for directory in search_dirs:

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -146,6 +146,7 @@ def test_config_lookup_order(
     """
     Test that the configuration lookup prioritizes PYICEBERG_HOME, then home (~), then cwd.
     """
+
     def create_config_file(path: str, uri: Optional[str]) -> None:
         if uri:
             config_file_path = os.path.join(path, ".pyiceberg.yaml")
@@ -172,5 +173,5 @@ def test_config_lookup_order(
     # Perform the lookup and validate the result
     result = Config()._from_configuration_files()
     assert (
-        result["catalog"]["default"]["uri"] if result else None
+        result["catalog"]["default"]["uri"] if result else None  # type: ignore
     ) == expected_result, f"Unexpected configuration result. Expected: {expected_result}, Actual: {result}"

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import os
+from typing import Any, Dict, Optional
 from unittest import mock
 
 import pytest
@@ -117,9 +118,13 @@ def test_from_configuration_files_get_typed_value(tmp_path_factory: pytest.TempP
     ],
 )
 def test_from_multiple_configuration_files(
-    monkeypatch: pytest.MonkeyPatch, tmp_path_factory: pytest.TempPathFactory, config_location, config_content, expected_result
-):
-    def create_config_file(directory: str, content: dict) -> None:
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path_factory: pytest.TempPathFactory,
+    config_location: str,
+    config_content: Optional[Dict[str, Any]],
+    expected_result: Optional[Dict[str, Any]],
+) -> None:
+    def create_config_file(directory: str, content: Optional[Dict[str, Any]]) -> None:
         config_file_path = os.path.join(directory, ".pyiceberg.yaml")
         with open(config_file_path, "w", encoding="utf-8") as file:
             yaml_str = as_document(content).as_yaml() if content else ""
@@ -144,6 +149,6 @@ def test_from_multiple_configuration_files(
     if config_location == "current":
         monkeypatch.chdir(current_path)
 
-    assert (
-        Config()._from_configuration_files() == expected_result
-    ), f"Unexpected configuration result for content: {config_content}"
+    assert Config()._from_configuration_files() == expected_result, (
+        f"Unexpected configuration result for content: {config_content}"
+    )

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -164,6 +164,6 @@ def test_from_multiple_configuration_files(
     if config_setup.get("config_location") in ["current", "both"]:
         monkeypatch.chdir(paths["current"])
 
-    assert Config()._from_configuration_files() == expected_result, (
-        f"Unexpected configuration result for content: {expected_result}"
-    )
+    assert (
+        Config()._from_configuration_files() == expected_result
+    ), f"Unexpected configuration result for content: {expected_result}"


### PR DESCRIPTION
Resolves #1333 

Adds the current working directory to the search path for the `.pyiceberg.yaml` file. 

As it is now, the file is searched in the following order:
1. the `PYICEBERG_HOME` environment variable
2. ~/
3. ./

I'm unsure if people would like to have 2 and 3 swapped. In either case, users can still override this with the environment variable. 