### PR TITLE
Tests: Set PySpark driver host to `localhost`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2254,6 +2254,7 @@ def spark() -> "SparkSession":
 
     spark = (
         SparkSession.builder.appName("PyIceberg integration test")
+        .config("spark.driver.host", "localhost")
         .config("spark.sql.session.timeZone", "UTC")
         .config("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions")
         .config("spark.sql.catalog.integration", "org.apache.iceberg.spark.SparkCatalog")


### PR DESCRIPTION
This let me (personally) run integration tests locally. Before, I was getting

```
py4j.protocol.Py4JJavaError: An error occurred while calling None.org.apache.spark.api.java.JavaSparkContext. [...]
E                   : java.io.IOException: Failed to connect to [IP-REDACTED]
E                   	at org.apache.spark.network.client.TransportClientFactory.createClient(TransportClientFactory.java:294)
E                   	at org.apache.spark.network.client.TransportClientFactory.createClient(TransportClientFactory.java:214)
...
```