### PR TITLE
UpdateSchema does not respect transaction abort

### DIFF
--- a/tests/integration/test_rest_schema.py
+++ b/tests/integration/test_rest_schema.py
@@ -96,6 +96,22 @@ def test_add_already_exists(catalog: Catalog, table_schema_nested: Schema) -> No
     assert "already exists: location.latitude" in str(exc_info.value)
 
 
+# @pytest.mark.integration
+def test_abort_transaction(catalog: Catalog, table_schema_nested: Schema) -> None:
+    table = _create_table_with_schema(catalog, table_schema_nested)
+    old_schema = table.schema()
+
+    with pytest.raises(ValueError) as exc_info:
+        with table.update_schema() as update:
+            update.add_column("123", IntegerType())  # "123" can be added succesfully
+            update.add_column("foo", IntegerType())
+    assert "already exists: foo" in str(exc_info.value)
+    # transaction raised, but "123" column is still added
+    print(f"Original Schema: {old_schema}")
+    print(f"New Schema: {table.schema()}")
+    assert old_schema == table.schema()
+
+
 @pytest.mark.integration
 def test_add_to_non_struct_type(catalog: Catalog, table_schema_simple: Schema) -> None:
     table = _create_table_with_schema(catalog, table_schema_simple)


### PR DESCRIPTION
Closes #1253

While looking at #1433, i noticed that `UpdateSchema` does not respect the transaction semantic, i.e. it does not abort the whole transaction when any update in the transaction fails. 

This is similar to #1246 and we had a discussion around it then. I raised #1253 to track. 

To reproduce, run test with 
```
poetry run pytest tests/integration/test_rest_schema.py::test_abort_transaction -s -vvv
```