### PR TITLE
Modified exception objects being thrown when converting Pyarrow tables

### DIFF
--- a/pyiceberg/exceptions.py
+++ b/pyiceberg/exceptions.py
@@ -133,11 +133,3 @@ class UnsupportedPyArrowTypeException(Exception):
     def __init__(self, field: pa.Field, *args: Any):
         self.field = field
         super().__init__(*args)
-
-
-class UnsupportedPyArrowIntegerTypeException(UnsupportedPyArrowTypeException):
-    """Cannot convert PyArrow integer type to corresponding Iceberg type."""
-
-
-class UnsupportedPyArrowTimestampTypeException(UnsupportedPyArrowTypeException):
-    """Cannot convert PyArrow timestamp type to corresponding Iceberg type."""

--- a/pyiceberg/exceptions.py
+++ b/pyiceberg/exceptions.py
@@ -14,9 +14,6 @@
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-from typing import Any
-
-import pyarrow as pa
 
 
 class TableAlreadyExistsError(Exception):
@@ -125,11 +122,3 @@ class CommitStateUnknownException(RESTError):
 
 class WaitingForLockException(Exception):
     """Need to wait for a lock, try again."""
-
-
-class UnsupportedPyArrowTypeException(Exception):
-    """Cannot convert PyArrow type to corresponding Iceberg type."""
-
-    def __init__(self, field: pa.Field, *args: Any):
-        self.field = field
-        super().__init__(*args)

--- a/pyiceberg/exceptions.py
+++ b/pyiceberg/exceptions.py
@@ -14,6 +14,9 @@
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
+from typing import Any
+
+import pyarrow as pa
 
 
 class TableAlreadyExistsError(Exception):
@@ -122,3 +125,19 @@ class CommitStateUnknownException(RESTError):
 
 class WaitingForLockException(Exception):
     """Need to wait for a lock, try again."""
+
+
+class UnsupportedPyArrowTypeException(Exception):
+    """Cannot convert PyArrow type to corresponding Iceberg type."""
+
+    def __init__(self, field: pa.Field, *args: Any):
+        self.field = field
+        super().__init__(*args)
+
+
+class UnsupportedPyArrowIntegerTypeException(UnsupportedPyArrowTypeException):
+    """Cannot convert PyArrow integer type to corresponding Iceberg type."""
+
+
+class UnsupportedPyArrowTimestampTypeException(UnsupportedPyArrowTypeException):
+    """Cannot convert PyArrow timestamp type to corresponding Iceberg type."""

--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -1102,10 +1102,8 @@ class _ConvertToIceberg(PyArrowSchemaVisitor[Union[IcebergType, Schema]]):
     """Converts PyArrowSchema to Iceberg Schema. Applies the IDs from name_mapping if provided."""
 
     _field_names: List[str]
-    _field: Optional[pa.Field]
 
     def __init__(self, downcast_ns_timestamp_to_us: bool = False) -> None:
-        self._field = None
         self._field_names = []
         self._downcast_ns_timestamp_to_us = downcast_ns_timestamp_to_us
 
@@ -1200,11 +1198,9 @@ class _ConvertToIceberg(PyArrowSchemaVisitor[Union[IcebergType, Schema]]):
 
     def before_field(self, field: pa.Field) -> None:
         self._field_names.append(field.name)
-        self._field = field
 
     def after_field(self, field: pa.Field) -> None:
         self._field_names.pop()
-        self._field = None
 
     def before_list_element(self, element: pa.Field) -> None:
         self._field_names.append(LIST_ELEMENT_NAME)

--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -72,10 +72,7 @@ from pyarrow.fs import (
 from sortedcontainers import SortedList
 
 from pyiceberg.conversions import to_bytes
-from pyiceberg.exceptions import (
-    ResolveError,
-    UnsupportedPyArrowTypeException,
-)
+from pyiceberg.exceptions import ResolveError
 from pyiceberg.expressions import AlwaysTrue, BooleanExpression, BoundIsNaN, BoundIsNull, BoundTerm, Not, Or
 from pyiceberg.expressions.literals import Literal
 from pyiceberg.expressions.visitors import (
@@ -190,6 +187,14 @@ DOC = "doc"
 UTC_ALIASES = {"UTC", "+00:00", "Etc/UTC", "Z"}
 
 T = TypeVar("T")
+
+
+class UnsupportedPyArrowTypeException(Exception):
+    """Cannot convert PyArrow type to corresponding Iceberg type."""
+
+    def __init__(self, field: pa.Field, *args: Any):
+        self.field = field
+        super().__init__(*args)
 
 
 class PyArrowLocalFileSystem(pyarrow.fs.LocalFileSystem):

--- a/tests/integration/test_add_files.py
+++ b/tests/integration/test_add_files.py
@@ -28,9 +28,9 @@ from pyspark.sql import SparkSession
 from pytest_mock.plugin import MockerFixture
 
 from pyiceberg.catalog import Catalog
-from pyiceberg.exceptions import NoSuchTableError, UnsupportedPyArrowTypeException
+from pyiceberg.exceptions import NoSuchTableError
 from pyiceberg.io import FileIO
-from pyiceberg.io.pyarrow import _pyarrow_schema_ensure_large_types
+from pyiceberg.io.pyarrow import UnsupportedPyArrowTypeException, _pyarrow_schema_ensure_large_types
 from pyiceberg.partitioning import UNPARTITIONED_PARTITION_SPEC, PartitionField, PartitionSpec
 from pyiceberg.schema import Schema
 from pyiceberg.table import Table

--- a/tests/integration/test_add_files.py
+++ b/tests/integration/test_add_files.py
@@ -28,7 +28,7 @@ from pyspark.sql import SparkSession
 from pytest_mock.plugin import MockerFixture
 
 from pyiceberg.catalog import Catalog
-from pyiceberg.exceptions import NoSuchTableError
+from pyiceberg.exceptions import NoSuchTableError, UnsupportedPyArrowTypeException
 from pyiceberg.io import FileIO
 from pyiceberg.io.pyarrow import _pyarrow_schema_ensure_large_types
 from pyiceberg.partitioning import UNPARTITIONED_PARTITION_SPEC, PartitionField, PartitionSpec
@@ -616,12 +616,17 @@ def test_add_files_with_timestamp_tz_ns_fails(session_catalog: Catalog, format_v
 
     # add the parquet files as data files
     with pytest.raises(
-        TypeError,
-        match=re.escape(
-            "Iceberg does not yet support 'ns' timestamp precision. Use 'downcast-ns-timestamp-to-us-on-write' configuration property to automatically downcast 'ns' to 'us' on write."
-        ),
-    ):
+        UnsupportedPyArrowTypeException,
+        match=re.escape("Column 'quux' has an unsupported type: timestamp[ns, tz=UTC]"),
+    ) as exc_info:
         tbl.add_files(file_paths=[file_path])
+
+    exception_cause = exc_info.value.__cause__
+    assert isinstance(exception_cause, TypeError)
+    assert (
+        "Iceberg does not yet support 'ns' timestamp precision. Use 'downcast-ns-timestamp-to-us-on-write' configuration property to automatically downcast 'ns' to 'us' on write."
+        in exception_cause.args[0]
+    )
 
 
 @pytest.mark.integration

--- a/tests/io/test_pyarrow_visitor.py
+++ b/tests/io/test_pyarrow_visitor.py
@@ -584,76 +584,128 @@ def test_pyarrow_schema_to_schema_fresh_ids_nested_schema(
     assert visit_pyarrow(pyarrow_schema_nested_without_ids, _ConvertToIcebergWithoutIDs()) == iceberg_schema_nested_no_ids
 
 
-def test_pyarrow_schema_unsupported_type() -> None:
-    lat_field = pa.field("latitude", pa.decimal256(20, 26), nullable=False)
-    schema = pa.schema(
+def test_pyarrow_schema_ensure_large_types(pyarrow_schema_nested_without_ids: pa.Schema) -> None:
+    expected_schema = pa.schema(
         [
-            pa.field("foo", pa.string(), nullable=False),
+            pa.field("foo", pa.large_string(), nullable=False),
+            pa.field("bar", pa.int32(), nullable=False),
+            pa.field("baz", pa.bool_(), nullable=True),
+            pa.field("qux", pa.large_list(pa.large_string()), nullable=False),
+            pa.field(
+                "quux",
+                pa.map_(
+                    pa.large_string(),
+                    pa.map_(pa.large_string(), pa.int32()),
+                ),
+                nullable=False,
+            ),
             pa.field(
                 "location",
                 pa.large_list(
                     pa.struct(
                         [
-                            lat_field,
+                            pa.field("latitude", pa.float32(), nullable=False),
                             pa.field("longitude", pa.float32(), nullable=False),
                         ]
                     ),
                 ),
                 nullable=False,
             ),
+            pa.field(
+                "person",
+                pa.struct(
+                    [
+                        pa.field("name", pa.large_string(), nullable=True),
+                        pa.field("age", pa.int32(), nullable=False),
+                    ]
+                ),
+                nullable=True,
+            ),
         ]
+    )
+    assert _pyarrow_schema_ensure_large_types(pyarrow_schema_nested_without_ids) == expected_schema
+
+
+def test_pyarrow_schema_unsupported_type() -> None:
+    unsupported_field = pa.field("latitude", pa.decimal256(20, 26), nullable=False, metadata={"PARQUET:field_id": "2"})
+    schema = pa.schema(
+        [
+            pa.field("foo", pa.string(), nullable=False, metadata={"PARQUET:field_id": "1"}),
+            pa.field(
+                "location",
+                pa.large_list(
+                    pa.field(
+                        "item",
+                        pa.struct(
+                            [
+                                unsupported_field,
+                                pa.field("longitude", pa.float32(), nullable=False, metadata={"PARQUET:field_id": "3"}),
+                            ]
+                        ),
+                        metadata={"PARQUET:field_id": "4"},
+                    )
+                ),
+                nullable=False,
+                metadata={"PARQUET:field_id": "5"},
+            ),
+        ],
+        metadata={"PARQUET:field_id": "6"},
     )
     with pytest.raises(
         UnsupportedPyArrowTypeException, match=re.escape("Column 'latitude' has an unsupported type: decimal256(20, 26)")
     ) as exc_info:
-        visit_pyarrow(schema, _ConvertToIcebergWithoutIDs())
-    assert exc_info.value.field == lat_field
+        pyarrow_to_schema(schema)
+    assert exc_info.value.field == unsupported_field
     exception_cause = exc_info.value.__cause__
     assert isinstance(exception_cause, TypeError)
     assert "Unsupported type: decimal256(20, 26)" in exception_cause.args[0]
 
-    quux_field = pa.field(
+    unsupported_field = pa.field(
         "quux",
         pa.map_(
-            pa.field("key", pa.string(), nullable=False, metadata={"PARQUET:field_id": "7"}),
+            pa.field("key", pa.string(), nullable=False, metadata={"PARQUET:field_id": "2"}),
             pa.field(
                 "value",
-                pa.map_(pa.field("key", pa.string(), nullable=False), pa.field("value", pa.decimal256(2, 3))),
+                pa.map_(
+                    pa.field("key", pa.string(), nullable=False, metadata={"PARQUET:field_id": "5"}),
+                    pa.field("value", pa.decimal256(2, 3), metadata={"PARQUET:field_id": "6"}),
+                ),
                 nullable=False,
+                metadata={"PARQUET:field_id": "4"},
             ),
         ),
         nullable=False,
-        metadata={"PARQUET:field_id": "6", "doc": "quux doc"},
+        metadata={"PARQUET:field_id": "3"},
     )
     schema = pa.schema(
         [
-            pa.field("foo", pa.string(), nullable=False),
-            quux_field,
+            pa.field("foo", pa.string(), nullable=False, metadata={"PARQUET:field_id": "1"}),
+            unsupported_field,
         ]
     )
     with pytest.raises(
         UnsupportedPyArrowTypeException,
         match=re.escape("Column 'quux' has an unsupported type: map<string, map<string, decimal256(2, 3)>>"),
     ) as exc_info:
-        visit_pyarrow(schema, _ConvertToIcebergWithoutIDs())
-    assert exc_info.value.field == quux_field
+        pyarrow_to_schema(schema)
+    assert exc_info.value.field == unsupported_field
     exception_cause = exc_info.value.__cause__
     assert isinstance(exception_cause, TypeError)
     assert "Unsupported type: decimal256(2, 3)" in exception_cause.args[0]
 
-    foo_field = pa.field("foo", pa.timestamp(unit="ns"), nullable=False)
+    unsupported_field = pa.field("foo", pa.timestamp(unit="ns"), nullable=False, metadata={"PARQUET:field_id": "1"})
     schema = pa.schema(
         [
-            foo_field,
-            pa.field("bar", pa.int32(), nullable=False),
+            unsupported_field,
+            pa.field("bar", pa.int32(), nullable=False, metadata={"PARQUET:field_id": "2"}),
         ]
     )
     with pytest.raises(
         UnsupportedPyArrowTypeException,
         match=re.escape("Column 'foo' has an unsupported type: timestamp[ns]"),
     ) as exc_info:
-        visit_pyarrow(schema, _ConvertToIcebergWithoutIDs())
-    assert exc_info.value.field == foo_field
+        pyarrow_to_schema(schema)
+    assert exc_info.value.field == unsupported_field
     exception_cause = exc_info.value.__cause__
     assert isinstance(exception_cause, TypeError)
     assert "Iceberg does not yet support 'ns' timestamp precision" in exception_cause.args[0]

--- a/tests/io/test_pyarrow_visitor.py
+++ b/tests/io/test_pyarrow_visitor.py
@@ -21,7 +21,6 @@ from typing import Any
 import pyarrow as pa
 import pytest
 
-from pyiceberg.exceptions import UnsupportedPyArrowTypeException
 from pyiceberg.expressions import (
     And,
     BoundEqualTo,
@@ -34,6 +33,7 @@ from pyiceberg.expressions import (
 )
 from pyiceberg.expressions.literals import literal
 from pyiceberg.io.pyarrow import (
+    UnsupportedPyArrowTypeException,
     _ConvertToArrowSchema,
     _ConvertToIceberg,
     _ConvertToIcebergWithoutIDs,


### PR DESCRIPTION
This modifies the exception being thrown when converting PyArrow types to Iceberg types, it also now declares the field being involved, if applicable, and can also be accessed when catching the exception.

closes #860