### PR TITLE
[ci] fix `make lint`

### DIFF
--- a/mkdocs/docs/api.md
+++ b/mkdocs/docs/api.md
@@ -1077,6 +1077,7 @@ with table.update_schema() as update:
 with table.update_schema() as update:
     update.add_column(("details", "confirmed_by"), StringType(), "Name of the exchange")
 ```
+
 A complex type must exist before columns can be added to it. Fields in complex types are added in a tuple.
 
 ### Rename column


### PR DESCRIPTION
Ran `make lint` locally

I think this is due to the [last commit](https://github.com/apache/iceberg-python/commit/a95f9ee6e231104319c01493cb3ada59d9e782d0). Not sure why it wasn't cause by CI at PR time