### PR TITLE
Use `ObjectStoreLocationProvider` by default

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -190,7 +190,7 @@ class TableProperties:
     WRITE_PY_LOCATION_PROVIDER_IMPL = "write.py-location-provider.impl"
 
     OBJECT_STORE_ENABLED = "write.object-storage.enabled"
-    OBJECT_STORE_ENABLED_DEFAULT = False
+    OBJECT_STORE_ENABLED_DEFAULT = True  # Differs from the Java implementation
 
     WRITE_OBJECT_STORE_PARTITIONED_PATHS = "write.object-storage.partitioned-paths"
     WRITE_OBJECT_STORE_PARTITIONED_PATHS_DEFAULT = True

--- a/tests/integration/test_writes/test_partitioned_writes.py
+++ b/tests/integration/test_writes/test_partitioned_writes.py
@@ -297,8 +297,8 @@ def test_object_storage_location_provider_excludes_partition_path(
     tbl = _create_table(
         session_catalog=session_catalog,
         identifier=f"default.arrow_table_v{format_version}_with_null_partitioned_on_col_{part_col}",
-        # write.object-storage.partitioned-paths defaults to True
-        properties={"format-version": str(format_version), TableProperties.OBJECT_STORE_ENABLED: True},
+        # Both write.object-storage.enabled and write.object-storage.partitioned-paths default to True
+        properties={"format-version": str(format_version)},
         data=[arrow_table_with_null],
         partition_spec=partition_spec,
     )

--- a/tests/table/test_locations.py
+++ b/tests/table/test_locations.py
@@ -39,7 +39,7 @@ class CustomLocationProvider(LocationProvider):
 
 
 def test_default_location_provider() -> None:
-    provider = load_location_provider(table_location="table_location", table_properties=EMPTY_DICT)
+    provider = load_location_provider(table_location="table_location", table_properties={"write.object-storage.enabled": "false"})
 
     assert provider.new_data_location("my_file") == "table_location/data/my_file"
 
@@ -66,7 +66,7 @@ def test_custom_location_provider_not_found() -> None:
 
 
 def test_object_storage_injects_entropy() -> None:
-    provider = load_location_provider(table_location="table_location", table_properties={"write.object-storage.enabled": "true"})
+    provider = load_location_provider(table_location="table_location", table_properties=EMPTY_DICT)
 
     location = provider.new_data_location("test.parquet")
     parts = location.split("/")
@@ -104,7 +104,6 @@ def test_object_storage_partitioned_paths_disabled(partition_key: Optional[Parti
     provider = load_location_provider(
         table_location="table_location",
         table_properties={
-            "write.object-storage.enabled": "true",
             "write.object-storage.partitioned-paths": "false",
         },
     )
@@ -125,6 +124,6 @@ def test_object_storage_partitioned_paths_disabled(partition_key: Optional[Parti
     ],
 )
 def test_hash_injection(data_file_name: str, expected_hash: str) -> None:
-    provider = load_location_provider(table_location="table_location", table_properties={"write.object-storage.enabled": "true"})
+    provider = load_location_provider(table_location="table_location", table_properties=EMPTY_DICT)
 
     assert provider.new_data_location(data_file_name) == f"table_location/data/{expected_hash}/{data_file_name}"


### PR DESCRIPTION
Following the discussion in https://github.com/apache/iceberg-python/pull/1452#discussion_r1899070323, this PR proposes diverging from the historical, Java-side preference of disabling object storage location provision by default, and proposes setting the `OBJECT_STORE_ENABLED_DEFAULT` table property default to `True` in PyIceberg.