### PR TITLE
Improve `LocationProvider` unit tests

### DIFF
--- a/tests/table/test_locations.py
+++ b/tests/table/test_locations.py
@@ -71,7 +71,7 @@ def test_custom_location_provider_not_found() -> None:
         )
 
 
-def test_object_storage_injects_entropy() -> None:
+def test_object_storage_no_partition() -> None:
     provider = load_location_provider(table_location="table_location", table_properties={"write.object-storage.enabled": "true"})
 
     location = provider.new_data_location("test.parquet")


### PR DESCRIPTION
See https://github.com/apache/iceberg-python/pull/1509#issuecomment-2585391350 for context/motivation.

This PR better highlights location provider behaviour in the presence of partitions in unit tests. It tests related behaviour more carefully - e.g. it tests that partition values **and** entropy included in paths when object storage location provision is used (without partitioned paths disabled) that can be confusing. It also tests the injected hash itself in this scenario because it's the hash method of *both* the file name and the partition key - this matches the Java implementation and I've tested that the Java code produces the same output for this case (https://github.com/apache/iceberg/blob/main/core/src/test/java/org/apache/iceberg/TestLocationProvider.java has no tests for this as of now).

@kevinjqliu maybe, mind taking a look?