### PR TITLE
FIX: retry REST catalog on 401 UnauthorizedError with refresh token

### DIFF
--- a/pyiceberg/catalog/rest.py
+++ b/pyiceberg/catalog/rest.py
@@ -149,7 +149,7 @@ def _retry_hook(retry_state: RetryCallState) -> None:
 
 
 _RETRY_ARGS = {
-    "retry": retry_if_exception_type(AuthorizationExpiredError),
+    "retry": retry_if_exception_type((AuthorizationExpiredError, UnauthorizedError)),
     "stop": stop_after_attempt(2),
     "before_sleep": _retry_hook,
     "reraise": True,


### PR DESCRIPTION
Some REST catalog implementations (including the Snowflake Polaris catalog) return a 401 when a token is expired, raising an `UnauthorizedError` within pyiceberg. Refreshing the token, as is done for 419 responses, resolves the issue.

This commit adds `UnauthorizedError` to the retry exception types for REST catalog calls, such that the token will be refreshed and the call retried.