### PR TITLE
[infra] download Spark from `archive.apache.org`

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -42,7 +42,7 @@ ENV ICEBERG_SPARK_RUNTIME_VERSION=3.5_2.12
 ENV ICEBERG_VERSION=1.6.0
 ENV PYICEBERG_VERSION=0.8.1
 
-RUN curl --retry 5 -s -C - https://dlcdn.apache.org/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz -o spark-${SPARK_VERSION}-bin-hadoop3.tgz \
+RUN curl --retry 5 -s -C - https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz -o spark-${SPARK_VERSION}-bin-hadoop3.tgz \
  && tar xzf spark-${SPARK_VERSION}-bin-hadoop3.tgz --directory /opt/spark --strip-components 1 \
  && rm -rf spark-${SPARK_VERSION}-bin-hadoop3.tgz
 


### PR DESCRIPTION
Use `archive.apache.org` to download Spark since version `3.5.3` has been removed from https://dlcdn.apache.org/spark/
, replaced with the latest patch `3.5.4`. I guess this will happen on every patch release. 

We can't upgrade to `3.5.4` yet per this comment https://github.com/apache/iceberg-python/pull/1461#issuecomment-2572498850. This will be unblocked with the upcoming 1.7.2 release. 

Note, this PR essentially reverts the work done in #1425 but will unblock CI 