### PR TITLE
fix: remove check-docstring-first pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,6 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
-      - id: check-docstring-first
       - id: debug-statements
       - id: check-yaml
       - id: check-ast


### PR DESCRIPTION
This check gives false positives on attribute docstrings with warnings
such as:

- "Multiple module docstrings (first docstring on line N)", or
- "Module docstring appears after code (code seen on line N)"

For details, see:

https://github.com/pre-commit/pre-commit-hooks/issues/159
