### PR TITLE
feat: support datetime objects in literal instantiation

### DIFF
--- a/pyiceberg/expressions/literals.py
+++ b/pyiceberg/expressions/literals.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import struct
 from abc import ABC, abstractmethod
+from datetime import datetime
 from decimal import ROUND_HALF_UP, Decimal
 from functools import singledispatchmethod
 from math import isnan
@@ -49,6 +50,7 @@ from pyiceberg.types import (
 )
 from pyiceberg.utils.datetime import (
     date_str_to_days,
+    datetime_to_micros,
     micros_to_days,
     time_str_to_micros,
     timestamp_to_micros,
@@ -145,6 +147,8 @@ def literal(value: L) -> Literal[L]:
         return BinaryLiteral(value)
     elif isinstance(value, Decimal):
         return DecimalLiteral(value)
+    elif isinstance(value, datetime):
+        return TimestampLiteral(datetime_to_micros(value))
     else:
         raise TypeError(f"Invalid literal value: {repr(value)}")
 

--- a/pyiceberg/expressions/literals.py
+++ b/pyiceberg/expressions/literals.py
@@ -148,7 +148,7 @@ def literal(value: L) -> Literal[L]:
     elif isinstance(value, Decimal):
         return DecimalLiteral(value)
     elif isinstance(value, datetime):
-        return TimestampLiteral(datetime_to_micros(value))
+        return TimestampLiteral(datetime_to_micros(value))  # type: ignore
     else:
         raise TypeError(f"Invalid literal value: {repr(value)}")
 

--- a/pyiceberg/typedef.py
+++ b/pyiceberg/typedef.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from datetime import datetime
 from decimal import Decimal
 from functools import lru_cache
 from typing import (
@@ -78,7 +79,7 @@ Properties = Dict[str, Any]
 RecursiveDict = Dict[str, Union[str, "RecursiveDict"]]
 
 # Represents the literal value
-L = TypeVar("L", str, bool, int, float, bytes, UUID, Decimal, covariant=True)
+L = TypeVar("L", str, bool, int, float, bytes, UUID, Decimal, datetime, covariant=True)
 
 
 @runtime_checkable

--- a/tests/expressions/test_literals.py
+++ b/tests/expressions/test_literals.py
@@ -906,6 +906,10 @@ def test_uuid_to_binary() -> None:
     assert isinstance(binary_literal, BinaryLiteral)  # type: ignore
 
 
+def test_literal_from_datetime() -> None:
+    assert isinstance(literal(datetime.datetime.now()), TimestampLiteral)
+
+
 #   __  __      ___
 #  |  \/  |_  _| _ \_  _
 #  | |\/| | || |  _/ || |

--- a/tests/integration/test_reads.py
+++ b/tests/integration/test_reads.py
@@ -19,7 +19,7 @@
 import math
 import time
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import PosixPath
 from urllib.parse import urlparse
 
@@ -957,5 +957,24 @@ def test_read_from_s3_and_local_fs(catalog: Catalog, tmp_path: PosixPath) -> Non
 @pytest.mark.parametrize("catalog", [pytest.lazy_fixture("session_catalog_hive"), pytest.lazy_fixture("session_catalog")])
 def test_scan_with_datetime(catalog: Catalog) -> None:
     table = create_table(catalog)
-    # test that this doesn't raise an exception...
-    table.scan(row_filter=GreaterThanOrEqual("datetime", datetime.now())).to_pandas()
+
+    yesterday = datetime.now() - timedelta(days=1)
+    table.append(
+        pa.Table.from_pylist(
+            [
+                {
+                    "str": "foo",
+                    "int": 1,
+                    "bool": True,
+                    "datetime": yesterday,
+                }
+            ],
+            schema=table.schema().as_arrow(),
+        ),
+    )
+
+    df = table.scan(row_filter=GreaterThanOrEqual("datetime", yesterday)).to_pandas()
+    assert len(df) == 1
+
+    df = table.scan(row_filter=LessThan("datetime", yesterday)).to_pandas()
+    assert len(df) == 0

--- a/tests/integration/test_reads.py
+++ b/tests/integration/test_reads.py
@@ -19,6 +19,7 @@
 import math
 import time
 import uuid
+from datetime import datetime
 from pathlib import PosixPath
 from urllib.parse import urlparse
 
@@ -950,3 +951,11 @@ def test_read_from_s3_and_local_fs(catalog: Catalog, tmp_path: PosixPath) -> Non
 
     result_table = tbl.scan().to_arrow()
     assert result_table["colA"].to_pylist() == ["one", "one"]
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("catalog", [pytest.lazy_fixture("session_catalog_hive"), pytest.lazy_fixture("session_catalog")])
+def test_scan_with_datetime(catalog: Catalog) -> None:
+    table = create_table(catalog)
+    # test that this doesn't raise an exception...
+    table.scan(row_filter=GreaterThanOrEqual("datetime", datetime.now())).to_pandas()


### PR DESCRIPTION
Support `datetime` objects being passed into the `literal` function.

Allows situations like the following: 
```py
from datetime import datetime
...
row_filter=And(
            GreaterThanOrEqual("my_timestamp_column", datetime.now()),
        ),
```

Which previously failed


Closes #1456 
