### PR TITLE
Log exception when FileIO import fails

### DIFF
--- a/pyiceberg/catalog/__init__.py
+++ b/pyiceberg/catalog/__init__.py
@@ -298,8 +298,8 @@ def _import_catalog(name: str, catalog_impl: str, properties: Properties) -> Opt
         module = importlib.import_module(module_name)
         class_ = getattr(module, class_name)
         return class_(name, **properties)
-    except ModuleNotFoundError:
-        logger.warning("Could not initialize Catalog: %s", catalog_impl)
+    except ModuleNotFoundError as exc:
+        logger.warning(f"Could not initialize Catalog: {catalog_impl}", exc_info=exc)
         return None
 
 

--- a/pyiceberg/io/__init__.py
+++ b/pyiceberg/io/__init__.py
@@ -315,8 +315,8 @@ def _import_file_io(io_impl: str, properties: Properties) -> Optional[FileIO]:
         module = importlib.import_module(module_name)
         class_ = getattr(module, class_name)
         return class_(properties)
-    except ModuleNotFoundError:
-        logger.warning("Could not initialize FileIO: %s", io_impl, exc_info=True)
+    except ModuleNotFoundError as exc:
+        logger.warning(f"Could not initialize FileIO: {io_impl}", exc_info=exc)
         return None
 
 

--- a/pyiceberg/io/__init__.py
+++ b/pyiceberg/io/__init__.py
@@ -316,7 +316,7 @@ def _import_file_io(io_impl: str, properties: Properties) -> Optional[FileIO]:
         class_ = getattr(module, class_name)
         return class_(properties)
     except ModuleNotFoundError:
-        logger.warning("Could not initialize FileIO: %s", io_impl)
+        logger.warning("Could not initialize FileIO: %s", io_impl, exc_info=True)
         return None
 
 

--- a/pyiceberg/table/locations.py
+++ b/pyiceberg/table/locations.py
@@ -129,8 +129,8 @@ def _import_location_provider(
         module = importlib.import_module(module_name)
         class_ = getattr(module, class_name)
         return class_(table_location, table_properties)
-    except ModuleNotFoundError:
-        logger.warning("Could not initialize LocationProvider: %s", location_provider_impl)
+    except ModuleNotFoundError as exc:
+        logger.warning(f"Could not initialize LocationProvider: {location_provider_impl}", exc_info=exc)
         return None
 
 

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -18,6 +18,7 @@
 import os
 import pickle
 import tempfile
+from typing import Any
 
 import pytest
 
@@ -279,6 +280,11 @@ def test_import_file_io() -> None:
 
 def test_import_file_io_does_not_exist() -> None:
     assert _import_file_io("pyiceberg.does.not.exist.FileIO", {}) is None
+
+
+def test_import_file_io_logs_exception(caplog: Any) -> None:
+    _import_file_io("pyiceberg.does.not.exist.FileIO", {})
+    assert "ModuleNotFoundError: No module named 'pyiceberg.does'" in caplog.text
 
 
 def test_load_file() -> None:

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -278,12 +278,8 @@ def test_import_file_io() -> None:
     assert isinstance(_import_file_io(ARROW_FILE_IO, {}), PyArrowFileIO)
 
 
-def test_import_file_io_does_not_exist() -> None:
+def test_import_file_io_does_not_exist(caplog: Any) -> None:
     assert _import_file_io("pyiceberg.does.not.exist.FileIO", {}) is None
-
-
-def test_import_file_io_logs_exception(caplog: Any) -> None:
-    _import_file_io("pyiceberg.does.not.exist.FileIO", {})
     assert "ModuleNotFoundError: No module named 'pyiceberg.does'" in caplog.text
 
 

--- a/tests/table/test_locations.py
+++ b/tests/table/test_locations.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Optional
+from typing import Any, Optional
 
 import pytest
 
@@ -64,11 +64,12 @@ def test_custom_location_provider_single_path() -> None:
         load_location_provider(table_location="table_location", table_properties={"write.py-location-provider.impl": "not_found"})
 
 
-def test_custom_location_provider_not_found() -> None:
+def test_custom_location_provider_not_found(caplog: Any) -> None:
     with pytest.raises(ValueError, match=r"Could not initialize LocationProvider"):
         load_location_provider(
             table_location="table_location", table_properties={"write.py-location-provider.impl": "module.not_found"}
         )
+    assert "ModuleNotFoundError: No module named 'module'" in caplog.text
 
 
 def test_object_storage_no_partition() -> None:


### PR DESCRIPTION
Closes #1577.

Log the underlying exception when a FileIO import fails.