### PR TITLE
[docs] Link community contributing guidelines

### DIFF
--- a/mkdocs/docs/contributing.md
+++ b/mkdocs/docs/contributing.md
@@ -30,7 +30,7 @@ If you would like to discuss your proposed change before contributing, we encour
 
 For first-time contributors, feel free to check out our [good first issues](https://github.com/apache/iceberg-python/issues/?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22) for an easy way to get started.
 
-## Contributing to the Iceberg Python library
+## Contributing to PyIceberg
 
 The PyIceberg Project is hosted on GitHub at <https://github.com/apache/iceberg-python>.
 

--- a/mkdocs/docs/contributing.md
+++ b/mkdocs/docs/contributing.md
@@ -22,7 +22,19 @@ hide:
   - under the License.
   -->
 
-# Contributing to the Iceberg Python library
+# Contributing
+
+We welcome contributions to Apache Iceberg! To learn more about contributing to Apache Iceberg, please refer to the [official Iceberg contribution guidelines](https://iceberg.apache.org/contribute/). These guidelines are intended as helpful suggestions to make the contribution process as seamless as possible, and are not strict rules.
+
+If you would like to discuss your proposed change before contributing, we encourage you to visit our [Community](https://iceberg.apache.org/community/) page. There, you will find various ways to connect with the community, including Slack and our mailing lists. Alternatively, you can open a [new issue](https://github.com/apache/iceberg-python/issues) directly in the GitHub repository.
+
+For first-time contributors, feel free to check out our [good first issues](https://github.com/apache/iceberg-python/issues/?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22) for an easy way to get started.
+
+
+## Contributing to the Iceberg Python library
+
+The PyIceberg Project is hosted on GitHub at <https://github.com/apache/iceberg-python>.
+
 
 For the development, Poetry is used for packing and dependency management. You can install this using:
 

--- a/mkdocs/docs/contributing.md
+++ b/mkdocs/docs/contributing.md
@@ -30,11 +30,9 @@ If you would like to discuss your proposed change before contributing, we encour
 
 For first-time contributors, feel free to check out our [good first issues](https://github.com/apache/iceberg-python/issues/?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22) for an easy way to get started.
 
-
 ## Contributing to the Iceberg Python library
 
 The PyIceberg Project is hosted on GitHub at <https://github.com/apache/iceberg-python>.
-
 
 For the development, Poetry is used for packing and dependency management. You can install this using:
 


### PR DESCRIPTION
Closes #970

This PR links community guideline on contribution, https://iceberg.apache.org/contribute/

![Screenshot 2025-01-26 at 1 47 41 PM](https://github.com/user-attachments/assets/3a56456e-1f3c-44f9-8d58-9b2b3e1da99b)
