### PR TITLE
Move from `types_extensions` to `types`

### DIFF
--- a/pyiceberg/partitioning.py
+++ b/pyiceberg/partitioning.py
@@ -21,16 +21,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import date, datetime, time
 from functools import cached_property, singledispatch
-from typing import (
-    Any,
-    Dict,
-    Generic,
-    List,
-    Optional,
-    Tuple,
-    TypeVar,
-    Union,
-)
+from typing import Annotated, Any, Dict, Generic, List, Optional, Tuple, TypeVar, Union
 from urllib.parse import quote_plus
 
 from pydantic import (
@@ -40,7 +31,6 @@ from pydantic import (
     WithJsonSchema,
     model_validator,
 )
-from typing_extensions import Annotated
 
 from pyiceberg.schema import Schema
 from pyiceberg.transforms import (

--- a/pyiceberg/table/metadata.py
+++ b/pyiceberg/table/metadata.py
@@ -19,18 +19,10 @@ from __future__ import annotations
 import datetime
 import uuid
 from copy import copy
-from typing import (
-    Any,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Union,
-)
+from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 
 from pydantic import Field, field_serializer, field_validator, model_validator
 from pydantic import ValidationError as PydanticValidationError
-from typing_extensions import Annotated
 
 from pyiceberg.exceptions import ValidationError
 from pyiceberg.partitioning import PARTITION_FIELD_ID_START, PartitionSpec, assign_fresh_partition_spec_ids

--- a/pyiceberg/table/refs.py
+++ b/pyiceberg/table/refs.py
@@ -15,10 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 from enum import Enum
-from typing import Optional
+from typing import Annotated, Optional
 
 from pydantic import Field, model_validator
-from typing_extensions import Annotated
 
 from pyiceberg.exceptions import ValidationError
 from pyiceberg.typedef import IcebergBaseModel

--- a/pyiceberg/table/sorting.py
+++ b/pyiceberg/table/sorting.py
@@ -16,14 +16,7 @@
 # under the License.
 # pylint: disable=keyword-arg-before-vararg
 from enum import Enum
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Union,
-)
+from typing import Annotated, Any, Callable, Dict, List, Optional, Union
 
 from pydantic import (
     BeforeValidator,
@@ -32,7 +25,6 @@ from pydantic import (
     WithJsonSchema,
     model_validator,
 )
-from typing_extensions import Annotated
 
 from pyiceberg.schema import Schema
 from pyiceberg.transforms import IdentityTransform, Transform, parse_transform

--- a/pyiceberg/table/update/__init__.py
+++ b/pyiceberg/table/update/__init__.py
@@ -20,10 +20,9 @@ import uuid
 from abc import ABC, abstractmethod
 from datetime import datetime
 from functools import singledispatch
-from typing import TYPE_CHECKING, Any, Dict, Generic, List, Literal, Optional, Tuple, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Annotated, Any, Dict, Generic, List, Literal, Optional, Tuple, TypeVar, Union, cast
 
 from pydantic import Field, field_validator, model_validator
-from typing_extensions import Annotated
 
 from pyiceberg.exceptions import CommitFailedException
 from pyiceberg.partitioning import PARTITION_FIELD_ID_START, PartitionSpec

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -18,7 +18,7 @@
 # pylint: disable=eval-used,protected-access,redefined-outer-name
 from datetime import date
 from decimal import Decimal
-from typing import Any, Callable, Optional, Union
+from typing import Annotated, Any, Callable, Optional, Union
 from uuid import UUID
 
 import mmh3 as mmh3
@@ -30,7 +30,6 @@ from pydantic import (
     RootModel,
     WithJsonSchema,
 )
-from typing_extensions import Annotated
 
 from pyiceberg.expressions import (
     AlwaysFalse,


### PR DESCRIPTION
`Annotated` has been part of `typing` since 3.9