### PR TITLE
[infra] clean up cibuildwheel build

### DIFF
--- a/.github/workflows/pypi-build-artifacts.yml
+++ b/.github/workflows/pypi-build-artifacts.yml
@@ -75,13 +75,10 @@ jobs:
           CIBW_ARCHS: "auto64"
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9,<3.13"
           CIBW_TEST_REQUIRES: "pytest==7.4.2 moto==5.0.1"
-          CIBW_TEST_EXTRAS: "s3fs,glue"
           CIBW_TEST_COMMAND: "pytest {project}/tests/avro/test_decoder.py"
-          # There is an upstream issue with installing on MacOSX
-          # https://github.com/pypa/cibuildwheel/issues/1603
           # Ignore tests for pypy since not all dependencies are compiled for it
           # and would require a local rust build chain
-          CIBW_TEST_SKIP: "pp* *macosx*"
+          CIBW_TEST_SKIP: "pp*"
 
       - name: Add source distribution
         if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/svn-build-artifacts.yml
+++ b/.github/workflows/svn-build-artifacts.yml
@@ -69,13 +69,10 @@ jobs:
           CIBW_ARCHS: "auto64"
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9,<3.13"
           CIBW_TEST_REQUIRES: "pytest==7.4.2 moto==5.0.1"
-          CIBW_TEST_EXTRAS: "s3fs,glue"
           CIBW_TEST_COMMAND: "pytest {project}/tests/avro/test_decoder.py"
-          # There is an upstream issue with installing on MacOSX
-          # https://github.com/pypa/cibuildwheel/issues/1603
           # Ignore tests for pypy since not all dependencies are compiled for it
           # and would require a local rust build chain
-          CIBW_TEST_SKIP: "pp* *macosx*"
+          CIBW_TEST_SKIP: "pp*"
 
       - name: Add source distribution
         if: startsWith(matrix.os, 'ubuntu')


### PR DESCRIPTION
Removes `CIBW_TEST_EXTRAS: "s3fs,glue" since we dont need the extra dependencies for tests 

Removes skipping MacOS build in `CIBW_TEST_SKIP`


Test run on fork of release candidate on https://github.com/kevinjqliu/iceberg-python/actions/runs/13117565428