### PR TITLE
[infra] refactor release github workflow

### DIFF
--- a/.github/workflows/pypi-build-artifacts.yml
+++ b/.github/workflows/pypi-build-artifacts.yml
@@ -1,3 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 name: "Build PyPI Artifacts"
 
 on:

--- a/.github/workflows/pypi-build-artifacts.yml
+++ b/.github/workflows/pypi-build-artifacts.yml
@@ -8,7 +8,7 @@ on:
         type: string
       RC:
         required: true
-        type: number
+        type: string
 
 jobs:
   pypi-build-artifacts:

--- a/.github/workflows/pypi-build-artifacts.yml
+++ b/.github/workflows/pypi-build-artifacts.yml
@@ -1,0 +1,86 @@
+name: "Build PyPI Artifacts"
+
+on:
+  workflow_call:
+    inputs:
+      VERSION:
+        required: true
+        type: string
+      RC:
+        required: true
+        type: number
+
+jobs:
+  pypi-build-artifacts:
+    name: Build artifacts for PyPi on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-22.04, windows-2022, macos-13, macos-14, macos-15 ]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: |
+            3.9
+            3.10
+            3.11
+            3.12
+
+      - name: Install poetry
+        run: make install-poetry
+
+      - name: Set version with RC
+        env:
+          VERSION: ${{ inputs.VERSION }}
+          RC: ${{ inputs.RC }}
+        run: python -m poetry version "${{ env.VERSION }}rc${{ env.RC }}" # e.g., 0.8.0rc1
+
+      # Publish the source distribution with the version that's in
+      # the repository, otherwise the tests will fail
+      - name: Compile source distribution
+        run: python3 -m poetry build --format=sdist
+        if: startsWith(matrix.os, 'ubuntu')
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.22.0
+        with:
+          output-dir: wheelhouse
+          config-file: "pyproject.toml"
+        env:
+          # Ignore 32 bit architectures
+          CIBW_ARCHS: "auto64"
+          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9,<3.13"
+          CIBW_TEST_REQUIRES: "pytest==7.4.2 moto==5.0.1"
+          CIBW_TEST_EXTRAS: "s3fs,glue"
+          CIBW_TEST_COMMAND: "pytest {project}/tests/avro/test_decoder.py"
+          # There is an upstream issue with installing on MacOSX
+          # https://github.com/pypa/cibuildwheel/issues/1603
+          # Ignore tests for pypy since not all dependencies are compiled for it
+          # and would require a local rust build chain
+          CIBW_TEST_SKIP: "pp* *macosx*"
+
+      - name: Add source distribution
+        if: startsWith(matrix.os, 'ubuntu')
+        run: ls -lah dist/* && cp dist/* wheelhouse/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: "pypi-release-candidate-${{ matrix.os }}"
+          path: ./wheelhouse/*
+
+  pypi-merge-artifacts:
+    runs-on: ubuntu-latest
+    needs:
+      - pypi-build-artifacts
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: "pypi-release-candidate-${{ inputs.VERSION }}rc${{ inputs.RC }}"
+          pattern: pypi-release-candidate*
+          delete-merged: true

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -116,152 +116,20 @@ jobs:
 
   # SVN
   svn-build-artifacts:
-    name: Build artifacts for SVN on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
     needs:
       - validate-inputs
       - validate-library-version
-    strategy:
-      matrix:
-        os: [ ubuntu-22.04, windows-2022, macos-13, macos-14, macos-15 ]
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: |
-            3.9
-            3.10
-            3.11
-            3.12
-
-      - name: Install poetry
-        run: make install-poetry
-
-      # Publish the source distribution with the version that's in
-      # the repository, otherwise the tests will fail
-      - name: Compile source distribution
-        run: python3 -m poetry build --format=sdist
-        if: startsWith(matrix.os, 'ubuntu')
-
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22.0
-        with:
-          output-dir: wheelhouse
-          config-file: "pyproject.toml"
-        env:
-          # Ignore 32 bit architectures
-          CIBW_ARCHS: "auto64"
-          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9,<3.13"
-          CIBW_TEST_REQUIRES: "pytest==7.4.2 moto==5.0.1"
-          CIBW_TEST_EXTRAS: "s3fs,glue"
-          CIBW_TEST_COMMAND: "pytest {project}/tests/avro/test_decoder.py"
-          # There is an upstream issue with installing on MacOSX
-          # https://github.com/pypa/cibuildwheel/issues/1603
-          # Ignore tests for pypy since not all dependencies are compiled for it
-          # and would require a local rust build chain
-          CIBW_TEST_SKIP: "pp* *macosx*"
-
-      - name: Add source distribution
-        if: startsWith(matrix.os, 'ubuntu')
-        run: ls -lah dist/* && cp dist/* wheelhouse/
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: "svn-release-candidate-${{ matrix.os }}"
-          path: ./wheelhouse/*
-
-  svn-merge-artifacts:
-    runs-on: ubuntu-latest
-    needs:
-      - validate-inputs
-      - svn-build-artifacts
-    steps:
-      - name: Merge Artifacts
-        uses: actions/upload-artifact/merge@v4
-        with:
-          name: "svn-release-candidate-${{ needs.validate-inputs.outputs.VERSION }}rc${{ needs.validate-inputs.outputs.RC }}"
-          pattern: svn-release-candidate*
-          delete-merged: true
+    uses: ./.github/workflows/svn-build-artifacts.yml
+    with:
+      version: ${{ needs.validate-inputs.outputs.VERSION }}
+      rc: ${{ needs.validate-inputs.outputs.RC }}
 
   # PyPi
   pypi-build-artifacts:
-    name: Build artifacts for PyPi on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
     needs:
       - validate-inputs
       - validate-library-version
-    strategy:
-      matrix:
-        os: [ ubuntu-22.04, windows-2022, macos-13, macos-14, macos-15 ]
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: |
-            3.9
-            3.10
-            3.11
-            3.12
-
-      - name: Install poetry
-        run: make install-poetry
-
-      - name: Set version with RC
-        env:
-          VERSION: ${{ needs.validate-inputs.outputs.VERSION }}
-          RC: ${{ needs.validate-inputs.outputs.RC }}
-        run: python -m poetry version "${{ env.VERSION }}rc${{ env.RC }}" # e.g., 0.8.0rc1
-
-      # Publish the source distribution with the version that's in
-      # the repository, otherwise the tests will fail
-      - name: Compile source distribution
-        run: python3 -m poetry build --format=sdist
-        if: startsWith(matrix.os, 'ubuntu')
-
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22.0
-        with:
-          output-dir: wheelhouse
-          config-file: "pyproject.toml"
-        env:
-          # Ignore 32 bit architectures
-          CIBW_ARCHS: "auto64"
-          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9,<3.13"
-          CIBW_TEST_REQUIRES: "pytest==7.4.2 moto==5.0.1"
-          CIBW_TEST_EXTRAS: "s3fs,glue"
-          CIBW_TEST_COMMAND: "pytest {project}/tests/avro/test_decoder.py"
-          # There is an upstream issue with installing on MacOSX
-          # https://github.com/pypa/cibuildwheel/issues/1603
-          # Ignore tests for pypy since not all dependencies are compiled for it
-          # and would require a local rust build chain
-          CIBW_TEST_SKIP: "pp* *macosx*"
-
-      - name: Add source distribution
-        if: startsWith(matrix.os, 'ubuntu')
-        run: ls -lah dist/* && cp dist/* wheelhouse/
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: "pypi-release-candidate-${{ matrix.os }}"
-          path: ./wheelhouse/*
-
-  pypi-merge-artifacts:
-    runs-on: ubuntu-latest
-    needs:
-      - validate-inputs
-      - pypi-build-artifacts
-    steps:
-      - name: Merge Artifacts
-        uses: actions/upload-artifact/merge@v4
-        with:
-          name: "pypi-release-candidate-${{ needs.validate-inputs.outputs.VERSION }}rc${{ needs.validate-inputs.outputs.RC }}"
-          pattern: pypi-release-candidate*
-          delete-merged: true
+    uses: ./.github/workflows/pypi-build-artifacts.yml
+    with:
+      version: ${{ needs.validate-inputs.outputs.VERSION }}
+      rc: ${{ needs.validate-inputs.outputs.RC }}

--- a/.github/workflows/svn-build-artifacts.yml
+++ b/.github/workflows/svn-build-artifacts.yml
@@ -8,7 +8,7 @@ on:
         type: string
       RC:
         required: true
-        type: number
+        type: string
 
 jobs:
   svn-build-artifacts:

--- a/.github/workflows/svn-build-artifacts.yml
+++ b/.github/workflows/svn-build-artifacts.yml
@@ -1,0 +1,80 @@
+name: "Build SVN Artifacts"
+
+on:
+  workflow_call:
+    inputs:
+      VERSION:
+        required: true
+        type: string
+      RC:
+        required: true
+        type: number
+
+jobs:
+  svn-build-artifacts:
+    name: Build artifacts for SVN on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-22.04, windows-2022, macos-13, macos-14, macos-15 ]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: |
+            3.9
+            3.10
+            3.11
+            3.12
+
+      - name: Install poetry
+        run: make install-poetry
+
+      # Publish the source distribution with the version that's in
+      # the repository, otherwise the tests will fail
+      - name: Compile source distribution
+        run: python3 -m poetry build --format=sdist
+        if: startsWith(matrix.os, 'ubuntu')
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.22.0
+        with:
+          output-dir: wheelhouse
+          config-file: "pyproject.toml"
+        env:
+          # Ignore 32 bit architectures
+          CIBW_ARCHS: "auto64"
+          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9,<3.13"
+          CIBW_TEST_REQUIRES: "pytest==7.4.2 moto==5.0.1"
+          CIBW_TEST_EXTRAS: "s3fs,glue"
+          CIBW_TEST_COMMAND: "pytest {project}/tests/avro/test_decoder.py"
+          # There is an upstream issue with installing on MacOSX
+          # https://github.com/pypa/cibuildwheel/issues/1603
+          # Ignore tests for pypy since not all dependencies are compiled for it
+          # and would require a local rust build chain
+          CIBW_TEST_SKIP: "pp* *macosx*"
+
+      - name: Add source distribution
+        if: startsWith(matrix.os, 'ubuntu')
+        run: ls -lah dist/* && cp dist/* wheelhouse/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: "svn-release-candidate-${{ matrix.os }}"
+          path: ./wheelhouse/*
+
+  svn-merge-artifacts:
+    runs-on: ubuntu-latest
+    needs:
+      - svn-build-artifacts
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: "svn-release-candidate-${{ inputs.VERSION }}rc${{ inputs.RC }}"
+          pattern: svn-release-candidate*
+          delete-merged: true

--- a/.github/workflows/svn-build-artifacts.yml
+++ b/.github/workflows/svn-build-artifacts.yml
@@ -1,3 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 name: "Build SVN Artifacts"
 
 on:


### PR DESCRIPTION
Moved `svn-build-artifacts` and `svn-merge-artifacts` into `.github/workflows/svn-build-artifacts.yml`
Moved `pypi-build-artifacts` and `pypi-merge-artifacts` into `.github/workflows/pypi-build-artifacts.yml`

Test run: https://github.com/kevinjqliu/iceberg-python/actions/runs/13102665689
Still generates the same artifacts
* `svn-release-candidate-${VERSION}rc${RC}` for SVN
* `pypi-release-candidate-${VERSION}rc${RC}` for PyPi

This is so can run pypi artifacts nightly.
