### PR TITLE
[infra] add testpypi nightly build 

### DIFF
--- a/.github/workflows/nightly-pypi-build.yml
+++ b/.github/workflows/nightly-pypi-build.yml
@@ -26,6 +26,7 @@ on:
 
 jobs:
   set-version:
+    if: github.repository == 'apache/iceberg-python'  # Only run for apache repo
     runs-on: ubuntu-latest
     outputs:
       VERSION: ${{ steps.set-version.outputs.VERSION }}

--- a/.github/workflows/nightly-pypi-build.yml
+++ b/.github/workflows/nightly-pypi-build.yml
@@ -25,11 +25,40 @@ on:
   workflow_dispatch:  # Allows manual triggering
 
 jobs:
+  set-version:
+    runs-on: ubuntu-latest
+    outputs:
+      VERSION: ${{ steps.set-version.outputs.VERSION }}
+      RC: ${{ steps.set-version.outputs.RC }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      - name: Install Poetry
+        run: make install-poetry
+
+      - name: Extract version and rc
+        id: set-version
+        run: |
+          VERSION=$(poetry version --short)
+          RC="$(date +%Y%m%d)"
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "RC=$RC" >> "$GITHUB_OUTPUT"
+
+      - name: Debug version and rc
+        run: echo "Publishing version ${{ steps.set-version.outputs.VERSION }}rc${{ steps.set-version.outputs.RC }}"
+
   nightly-build:
-    uses: ./.github/workflows/pypi-build-artifacts.yml  # Reference the PyPI build workflow
+    needs: set-version
+    uses: ./.github/workflows/pypi-build-artifacts.yml
     with:
-      VERSION: "0.0.0"  # Generate nightly version
-      RC: "1"  # Reset RC for nightly builds
+      version: ${{ needs.set-version.outputs.VERSION }}  # i.e. 0.9.0
+      rc: ${{ needs.set-version.outputs.RC }}  # i.e. 20250203
 
   testpypi-publish:
     name: Publish to TestPypi
@@ -56,3 +85,4 @@ jobs:
       with:
         repository-url: https://test.pypi.org/legacy/
         skip-existing: true
+        verbose: true

--- a/.github/workflows/nightly-pypi-build.yml
+++ b/.github/workflows/nightly-pypi-build.yml
@@ -29,7 +29,7 @@ jobs:
     uses: ./.github/workflows/pypi-build-artifacts.yml  # Reference the PyPI build workflow
     with:
       VERSION: "0.0.0"  # Generate nightly version
-      RC: "0"  # Reset RC for nightly builds
+      RC: "1"  # Reset RC for nightly builds
 
   testpypi-publish:
     name: Publish to TestPypi
@@ -49,6 +49,8 @@ jobs:
       with:
         merge-multiple: true
         path: dist/
+    - name: List downloaded artifacts
+      run: ls -R dist/
     - name: Publish to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/nightly-pypi-build.yml
+++ b/.github/workflows/nightly-pypi-build.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: testpypi
-      url: https://test.pypi.org/p/pyiceberg-kevinliu
+      url: https://test.pypi.org/p/pyiceberg
 
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing

--- a/.github/workflows/nightly-pypi-build.yml
+++ b/.github/workflows/nightly-pypi-build.yml
@@ -30,7 +30,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       VERSION: ${{ steps.set-version.outputs.VERSION }}
-      RC: ${{ steps.set-version.outputs.RC }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -43,24 +42,21 @@ jobs:
       - name: Install Poetry
         run: make install-poetry
 
-      - name: Extract version and rc
+      - name: Set version
         id: set-version
         run: |
-          VERSION=$(poetry version --short)
-          RC="$(date +%Y%m%d)"
-          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "RC=$RC" >> "$GITHUB_OUTPUT"
+          CURRENT_VERSION=$(poetry version --short)
+          TIMESTAMP=$(date +%Y%m%d%H%M%S)
+          echo "VERSION=${CURRENT_VERSION}.dev${TIMESTAMP}" >> "$GITHUB_OUTPUT"
 
-      - name: Debug version and rc
-        run: echo "Publishing version ${{ steps.set-version.outputs.VERSION }}rc${{ steps.set-version.outputs.RC }}"
+      - name: Debug version
+        run: echo "Publishing version ${{ steps.set-version.outputs.VERSION }}"
 
   nightly-build:
     needs: set-version
     uses: ./.github/workflows/pypi-build-artifacts.yml
     with:
-      version: ${{ needs.set-version.outputs.VERSION }}  # i.e. 0.9.0
-      rc: ${{ needs.set-version.outputs.RC }}  # i.e. 20250203
-
+      version: ${{ needs.set-version.outputs.VERSION }}
   testpypi-publish:
     name: Publish to TestPypi
     needs:

--- a/.github/workflows/nightly-pypi-build.yml
+++ b/.github/workflows/nightly-pypi-build.yml
@@ -1,0 +1,56 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: "Nightly PyPI Build"
+
+on:
+  schedule:
+    - cron: "0 0 * * *"  # Runs at midnight UTC every day
+  workflow_dispatch:  # Allows manual triggering
+
+jobs:
+  nightly-build:
+    uses: ./.github/workflows/pypi-build-artifacts.yml  # Reference the PyPI build workflow
+    with:
+      VERSION: "0.0.0"  # Generate nightly version
+      RC: "0"  # Reset RC for nightly builds
+
+  testpypi-publish:
+    name: Publish to TestPypi
+    needs:
+      - nightly-build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/pyiceberg-kevinliu
+
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the artifacts
+      uses: actions/download-artifact@v4
+      with:
+        merge-multiple: true
+        path: dist/
+    - name: Publish to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        skip-existing: true

--- a/.github/workflows/pypi-build-artifacts.yml
+++ b/.github/workflows/pypi-build-artifacts.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-22.04, windows-2022, macos-13, macos-14, macos-15 ]
+        os: [ ubuntu-22.04, windows-2022, macos-13, macos-14 ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pypi-build-artifacts.yml
+++ b/.github/workflows/pypi-build-artifacts.yml
@@ -25,9 +25,6 @@ on:
       VERSION:
         required: true
         type: string
-      RC:
-        required: true
-        type: string
 
 jobs:
   pypi-build-artifacts:
@@ -56,8 +53,7 @@ jobs:
       - name: Set version with RC
         env:
           VERSION: ${{ inputs.VERSION }}
-          RC: ${{ inputs.RC }}
-        run: python -m poetry version "${{ env.VERSION }}rc${{ env.RC }}" # e.g., 0.8.0rc1
+        run: python -m poetry version "${{ env.VERSION }}"
 
       # Publish the source distribution with the version that's in
       # the repository, otherwise the tests will fail
@@ -97,6 +93,6 @@ jobs:
       - name: Merge Artifacts
         uses: actions/upload-artifact/merge@v4
         with:
-          name: "pypi-release-candidate-${{ inputs.VERSION }}rc${{ inputs.RC }}"
+          name: "pypi-release-candidate-${{ inputs.VERSION }}"
           pattern: pypi-release-candidate*
           delete-merged: true

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -121,8 +121,7 @@ jobs:
       - validate-library-version
     uses: ./.github/workflows/svn-build-artifacts.yml
     with:
-      version: ${{ needs.validate-inputs.outputs.VERSION }}
-      rc: ${{ needs.validate-inputs.outputs.RC }}
+      version: ${{ needs.validate-inputs.outputs.VERSION }}rc${{ needs.validate-inputs.outputs.RC }}
 
   # PyPi
   pypi-build-artifacts:
@@ -131,5 +130,4 @@ jobs:
       - validate-library-version
     uses: ./.github/workflows/pypi-build-artifacts.yml
     with:
-      version: ${{ needs.validate-inputs.outputs.VERSION }}
-      rc: ${{ needs.validate-inputs.outputs.RC }}
+      version: ${{ needs.validate-inputs.outputs.VERSION }}rc${{ needs.validate-inputs.outputs.RC }}

--- a/.github/workflows/svn-build-artifacts.yml
+++ b/.github/workflows/svn-build-artifacts.yml
@@ -25,9 +25,6 @@ on:
       VERSION:
         required: true
         type: string
-      RC:
-        required: true
-        type: string
 
 jobs:
   svn-build-artifacts:
@@ -91,6 +88,6 @@ jobs:
       - name: Merge Artifacts
         uses: actions/upload-artifact/merge@v4
         with:
-          name: "svn-release-candidate-${{ inputs.VERSION }}rc${{ inputs.RC }}"
+          name: "svn-release-candidate-${{ inputs.VERSION }}"
           pattern: svn-release-candidate*
           delete-merged: true

--- a/.github/workflows/svn-build-artifacts.yml
+++ b/.github/workflows/svn-build-artifacts.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-22.04, windows-2022, macos-13, macos-14, macos-15 ]
+        os: [ ubuntu-22.04, windows-2022, macos-13, macos-14 ]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 [tool.poetry]
-name = "pyiceberg-kevinliu"
+name = "pyiceberg"
 version = "0.9.0"
 readme = "README.md"
 homepage = "https://py.iceberg.apache.org/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 [tool.poetry]
-name = "pyiceberg"
+name = "pyiceberg-kevinliu"
 version = "0.9.0"
 readme = "README.md"
 homepage = "https://py.iceberg.apache.org/"


### PR DESCRIPTION
Closes #872

This PR adds the ability to run and publish pypi artifacts nightly to testpypi. It will publish as `pyiceberg` with new version under `0.9.0.dev${TIMESTAMP}`, i.e. `0.9.0.dev20250206050843`, adhering to PEP440 conversion.

Here's a [test run on my fork](https://github.com/kevinjqliu/iceberg-python/actions/runs/13172235318) which published to https://test.pypi.org/project/pyiceberg-kevinliu/

This requires setting up [Publishing to PyPI with a Trusted Publisher](https://docs.pypi.org/trusted-publishers/) on https://test.pypi.org/ and using example of publishing [pyiceberg_core](https://github.com/apache/iceberg-rust/blob/8714ffd69c411990a89e1c3f03b51c33670f18ec/.github/workflows/release_python.yml#L120-L146) to testpypi


Note, this PR also refactors `.github/workflows/python-release.yml`, i've [ran the workflow on my fork](https://github.com/kevinjqliu/iceberg-python/actions/runs/13172075517) and manually verified the version for both pypi and svn artifacts. 



Setup trusted publisher on testpypi for apache/iceberg-python repo https://test.pypi.org/manage/project/pyiceberg/settings/publishing/