### PR TITLE
Fix: `SqlCatalog` list_namespaces() should return only sub-namespaces

### DIFF
--- a/pyiceberg/catalog/sql.py
+++ b/pyiceberg/catalog/sql.py
@@ -635,8 +635,9 @@ class SqlCatalog(MetastoreCatalog):
 
             if namespace:
                 namespace_tuple = Catalog.identifier_to_tuple(namespace)
+                namespace_level_length = len(namespace_tuple)
                 # exclude fuzzy matches when `namespace` contains `%` or `_`
-                namespaces = [ns for ns in namespaces if ns[: len(namespace_tuple)] == namespace_tuple]
+                namespaces = [ns for ns in namespaces if ns[:namespace_level_length] == namespace_tuple]
 
             return namespaces
 

--- a/tests/catalog/test_base.py
+++ b/tests/catalog/test_base.py
@@ -314,7 +314,7 @@ def test_rename_table(catalog: InMemoryCatalog) -> None:
     assert table._identifier == Catalog.identifier_to_tuple(new_table)
 
     # And
-    assert ("new", "namespace") in catalog.list_namespaces()
+    assert ("new",) in catalog.list_namespaces()
 
     # And
     with pytest.raises(NoSuchTableError, match=NO_SUCH_TABLE_ERROR):
@@ -338,7 +338,7 @@ def test_rename_table_from_self_identifier(catalog: InMemoryCatalog) -> None:
     assert new_table._identifier == Catalog.identifier_to_tuple(new_table_name)
 
     # And
-    assert ("new", "namespace") in catalog.list_namespaces()
+    assert ("new",) in catalog.list_namespaces()
 
     # And
     with pytest.raises(NoSuchTableError, match=NO_SUCH_TABLE_ERROR):
@@ -352,7 +352,7 @@ def test_create_namespace(catalog: InMemoryCatalog) -> None:
     catalog.create_namespace(TEST_TABLE_NAMESPACE, TEST_TABLE_PROPERTIES)
 
     # Then
-    assert TEST_TABLE_NAMESPACE in catalog.list_namespaces()
+    assert TEST_TABLE_NAMESPACE[:1] in catalog.list_namespaces()
     assert TEST_TABLE_PROPERTIES == catalog.load_namespace_properties(TEST_TABLE_NAMESPACE)
 
 
@@ -375,7 +375,7 @@ def test_list_namespaces(catalog: InMemoryCatalog) -> None:
     # When
     namespaces = catalog.list_namespaces()
     # Then
-    assert TEST_TABLE_NAMESPACE in namespaces
+    assert TEST_TABLE_NAMESPACE[:1] in namespaces
 
 
 def test_drop_namespace(catalog: InMemoryCatalog) -> None:
@@ -384,7 +384,7 @@ def test_drop_namespace(catalog: InMemoryCatalog) -> None:
     # When
     catalog.drop_namespace(TEST_TABLE_NAMESPACE)
     # Then
-    assert TEST_TABLE_NAMESPACE not in catalog.list_namespaces()
+    assert TEST_TABLE_NAMESPACE[:1] not in catalog.list_namespaces()
 
 
 def test_drop_namespace_raises_error_when_namespace_does_not_exist(catalog: InMemoryCatalog) -> None:
@@ -433,7 +433,7 @@ def test_update_namespace_metadata(catalog: InMemoryCatalog) -> None:
     summary = catalog.update_namespace_properties(TEST_TABLE_NAMESPACE, updates=new_metadata)
 
     # Then
-    assert TEST_TABLE_NAMESPACE in catalog.list_namespaces()
+    assert TEST_TABLE_NAMESPACE[:1] in catalog.list_namespaces()
     assert new_metadata.items() <= catalog.load_namespace_properties(TEST_TABLE_NAMESPACE).items()
     assert summary.removed == []
     assert sorted(summary.updated) == ["key3", "key4"]
@@ -450,7 +450,7 @@ def test_update_namespace_metadata_removals(catalog: InMemoryCatalog) -> None:
     summary = catalog.update_namespace_properties(TEST_TABLE_NAMESPACE, remove_metadata, new_metadata)
 
     # Then
-    assert TEST_TABLE_NAMESPACE in catalog.list_namespaces()
+    assert TEST_TABLE_NAMESPACE[:1] in catalog.list_namespaces()
     assert new_metadata.items() <= catalog.load_namespace_properties(TEST_TABLE_NAMESPACE).items()
     assert remove_metadata.isdisjoint(catalog.load_namespace_properties(TEST_TABLE_NAMESPACE).keys())
     assert summary.removed == ["key1"]

--- a/tests/catalog/test_base.py
+++ b/tests/catalog/test_base.py
@@ -314,7 +314,7 @@ def test_rename_table(catalog: InMemoryCatalog) -> None:
     assert table._identifier == Catalog.identifier_to_tuple(new_table)
 
     # And
-    assert ("new",) in catalog.list_namespaces()
+    assert catalog._namespace_exists(table._identifier[:-1])
 
     # And
     with pytest.raises(NoSuchTableError, match=NO_SUCH_TABLE_ERROR):
@@ -338,7 +338,7 @@ def test_rename_table_from_self_identifier(catalog: InMemoryCatalog) -> None:
     assert new_table._identifier == Catalog.identifier_to_tuple(new_table_name)
 
     # And
-    assert ("new",) in catalog.list_namespaces()
+    assert catalog._namespace_exists(new_table._identifier[:-1])
 
     # And
     with pytest.raises(NoSuchTableError, match=NO_SUCH_TABLE_ERROR):
@@ -352,7 +352,7 @@ def test_create_namespace(catalog: InMemoryCatalog) -> None:
     catalog.create_namespace(TEST_TABLE_NAMESPACE, TEST_TABLE_PROPERTIES)
 
     # Then
-    assert TEST_TABLE_NAMESPACE[:1] in catalog.list_namespaces()
+    assert catalog._namespace_exists(TEST_TABLE_NAMESPACE)
     assert TEST_TABLE_PROPERTIES == catalog.load_namespace_properties(TEST_TABLE_NAMESPACE)
 
 
@@ -377,6 +377,11 @@ def test_list_namespaces(catalog: InMemoryCatalog) -> None:
     # Then
     assert TEST_TABLE_NAMESPACE[:1] in namespaces
 
+    # When
+    namespaces = catalog.list_namespaces(TEST_TABLE_NAMESPACE)
+    # Then
+    assert not namespaces
+
 
 def test_drop_namespace(catalog: InMemoryCatalog) -> None:
     # Given
@@ -384,7 +389,7 @@ def test_drop_namespace(catalog: InMemoryCatalog) -> None:
     # When
     catalog.drop_namespace(TEST_TABLE_NAMESPACE)
     # Then
-    assert TEST_TABLE_NAMESPACE[:1] not in catalog.list_namespaces()
+    assert not catalog._namespace_exists(TEST_TABLE_NAMESPACE)
 
 
 def test_drop_namespace_raises_error_when_namespace_does_not_exist(catalog: InMemoryCatalog) -> None:
@@ -433,7 +438,7 @@ def test_update_namespace_metadata(catalog: InMemoryCatalog) -> None:
     summary = catalog.update_namespace_properties(TEST_TABLE_NAMESPACE, updates=new_metadata)
 
     # Then
-    assert TEST_TABLE_NAMESPACE[:1] in catalog.list_namespaces()
+    assert catalog._namespace_exists(TEST_TABLE_NAMESPACE)
     assert new_metadata.items() <= catalog.load_namespace_properties(TEST_TABLE_NAMESPACE).items()
     assert summary.removed == []
     assert sorted(summary.updated) == ["key3", "key4"]
@@ -450,7 +455,7 @@ def test_update_namespace_metadata_removals(catalog: InMemoryCatalog) -> None:
     summary = catalog.update_namespace_properties(TEST_TABLE_NAMESPACE, remove_metadata, new_metadata)
 
     # Then
-    assert TEST_TABLE_NAMESPACE[:1] in catalog.list_namespaces()
+    assert catalog._namespace_exists(TEST_TABLE_NAMESPACE)
     assert new_metadata.items() <= catalog.load_namespace_properties(TEST_TABLE_NAMESPACE).items()
     assert remove_metadata.isdisjoint(catalog.load_namespace_properties(TEST_TABLE_NAMESPACE).keys())
     assert summary.removed == ["key1"]

--- a/tests/catalog/test_sql.py
+++ b/tests/catalog/test_sql.py
@@ -1136,26 +1136,19 @@ def test_namespace_exists(catalog: SqlCatalog) -> None:
     ],
 )
 def test_list_namespaces(catalog: SqlCatalog) -> None:
-    namespace_list = ["db", "db.ns1", "db.ns1.ns2", "db.ns2", "db2", "db2.ns1", "db%"]
+    namespace_list = ["db", "db.ns1", "db.ns1.ns2", "db.ns2", "db2", "db2.ns1", "db%", "db.ns1X.ns3"]
     for namespace in namespace_list:
         catalog.create_namespace(namespace)
 
     ns_list = catalog.list_namespaces()
-    expected_list: list[tuple[str, ...]] = [("db",), ("db2",), ("db%",)]
-    for ns in expected_list:
+    for ns in [("db",), ("db%",), ("db2",)]:
         assert ns in ns_list
 
     ns_list = catalog.list_namespaces("db")
-    expected_list = [("db", "ns1"), ("db", "ns2")]
-    assert len(ns_list) == len(expected_list)
-    for ns in expected_list:
-        assert ns in ns_list
+    assert sorted(ns_list) == [("db", "ns1"), ("db", "ns1X"), ("db", "ns2")]
 
     ns_list = catalog.list_namespaces("db.ns1")
-    expected_list = [("db", "ns1", "ns2")]
-    assert len(ns_list) == len(expected_list)
-    for ns in expected_list:
-        assert ns in ns_list
+    assert sorted(ns_list) == [("db", "ns1", "ns2")]
 
     ns_list = catalog.list_namespaces("db.ns1.ns2")
     assert len(ns_list) == 0

--- a/tests/catalog/test_sql.py
+++ b/tests/catalog/test_sql.py
@@ -1141,7 +1141,7 @@ def test_list_namespaces(catalog: SqlCatalog) -> None:
         catalog.create_namespace(namespace)
 
     ns_list = catalog.list_namespaces()
-    expected_list = [("db",), ("db2",), ("db%",)]
+    expected_list: list[tuple[str, ...]] = [("db",), ("db2",), ("db%",)]
     assert len(ns_list) == len(expected_list)
     for ns in expected_list:
         assert ns in ns_list

--- a/tests/catalog/test_sql.py
+++ b/tests/catalog/test_sql.py
@@ -1138,7 +1138,8 @@ def test_namespace_exists(catalog: SqlCatalog) -> None:
 def test_list_namespaces(catalog: SqlCatalog) -> None:
     namespace_list = ["db", "db.ns1", "db.ns1.ns2", "db.ns2", "db2", "db2.ns1", "db%", "db.ns1X.ns3"]
     for namespace in namespace_list:
-        catalog.create_namespace(namespace)
+        if not catalog._namespace_exists(namespace):
+            catalog.create_namespace(namespace)
 
     ns_list = catalog.list_namespaces()
     for ns in [("db",), ("db%",), ("db2",)]:
@@ -1183,13 +1184,13 @@ def test_list_non_existing_namespaces(catalog: SqlCatalog) -> None:
 def test_drop_namespace(catalog: SqlCatalog, table_schema_nested: Schema, table_identifier: Identifier) -> None:
     namespace = Catalog.namespace_from(table_identifier)
     catalog.create_namespace(namespace)
-    assert namespace[:1] in catalog.list_namespaces()
+    assert catalog._namespace_exists(namespace)
     catalog.create_table(table_identifier, table_schema_nested)
     with pytest.raises(NamespaceNotEmptyError):
         catalog.drop_namespace(namespace)
     catalog.drop_table(table_identifier)
     catalog.drop_namespace(namespace)
-    assert namespace[:1] not in catalog.list_namespaces()
+    assert not catalog._namespace_exists(namespace)
 
 
 @pytest.mark.parametrize(

--- a/tests/catalog/test_sql.py
+++ b/tests/catalog/test_sql.py
@@ -1027,7 +1027,7 @@ def test_create_namespace_if_not_exists(catalog: SqlCatalog, database_name: str)
 @pytest.mark.parametrize("namespace", [lazy_fixture("database_name"), lazy_fixture("hierarchical_namespace_name")])
 def test_create_namespace(catalog: SqlCatalog, namespace: str) -> None:
     catalog.create_namespace(namespace)
-    assert (Catalog.identifier_to_tuple(namespace)) in catalog.list_namespaces()
+    assert (Catalog.identifier_to_tuple(namespace)[:1]) in catalog.list_namespaces()
 
 
 @pytest.mark.parametrize(
@@ -1074,7 +1074,7 @@ def test_create_namespace_with_comment_and_location(catalog: SqlCatalog, namespa
     }
     catalog.create_namespace(namespace=namespace, properties=test_properties)
     loaded_database_list = catalog.list_namespaces()
-    assert Catalog.identifier_to_tuple(namespace) in loaded_database_list
+    assert Catalog.identifier_to_tuple(namespace)[:1] in loaded_database_list
     properties = catalog.load_namespace_properties(namespace)
     assert properties["comment"] == "this is a test description"
     assert properties["location"] == test_location
@@ -1142,7 +1142,6 @@ def test_list_namespaces(catalog: SqlCatalog) -> None:
 
     ns_list = catalog.list_namespaces()
     expected_list: list[tuple[str, ...]] = [("db",), ("db2",), ("db%",)]
-    assert len(ns_list) == len(expected_list)
     for ns in expected_list:
         assert ns in ns_list
 
@@ -1191,13 +1190,13 @@ def test_list_non_existing_namespaces(catalog: SqlCatalog) -> None:
 def test_drop_namespace(catalog: SqlCatalog, table_schema_nested: Schema, table_identifier: Identifier) -> None:
     namespace = Catalog.namespace_from(table_identifier)
     catalog.create_namespace(namespace)
-    assert namespace in catalog.list_namespaces()
+    assert namespace[:1] in catalog.list_namespaces()
     catalog.create_table(table_identifier, table_schema_nested)
     with pytest.raises(NamespaceNotEmptyError):
         catalog.drop_namespace(namespace)
     catalog.drop_table(table_identifier)
     catalog.drop_namespace(namespace)
-    assert namespace not in catalog.list_namespaces()
+    assert namespace[:1] not in catalog.list_namespaces()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Resolves: https://github.com/apache/iceberg-python/issues/1627