### PR TITLE
Fix ci

### DIFF
--- a/tests/io/test_pyarrow.py
+++ b/tests/io/test_pyarrow.py
@@ -1145,6 +1145,7 @@ def test_identity_transform_column_projection(tmp_path: str, catalog: InMemoryCa
         PartitionField(2, 1000, IdentityTransform(), "partition_id"),
     )
 
+    catalog.create_namespace("default")
     table = catalog.create_table(
         "default.test_projection_partition",
         schema=schema,
@@ -1206,6 +1207,7 @@ def test_identity_transform_columns_projection(tmp_path: str, catalog: InMemoryC
         PartitionField(3, 1001, IdentityTransform(), "field_3"),
     )
 
+    catalog.create_namespace("default")
     table = catalog.create_table(
         "default.test_projection_partitions",
         schema=schema,


### PR DESCRIPTION
CI is failing on main branch 
https://github.com/apache/iceberg-python/actions/runs/13247077313/job/36976096982

Caused by merge conflict after #1140. `InMemoryCatalog` now does not automatically create the namespace. 

