### PR TITLE
Repo: Set status checks to strict

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -34,6 +34,10 @@ github:
     rebase: true
   protected_branches:
     main:
+      required_status_checks:
+        # strict means "Require branches to be up to date before merging".
+        strict: true
+
       required_pull_request_reviews:
         required_approving_review_count: 1
 


### PR DESCRIPTION
We just had an issue with merging a stale branch, which fixed @kevinjqliu right away in https://github.com/apache/iceberg-python/pull/1638

In `iceberg-rust` they have this nice button:

<img width="920" alt="image" src="https://github.com/user-attachments/assets/194fef4a-89aa-407c-a113-4253fc5ad04b" />

I think this is the result of the following config:

https://github.com/apache/iceberg-rust/blob/63545895d2c35db0f0c550cb1c08acd52a9f5b4c/.asf.yaml#L36C10-L39C21

I don't think it would work well for Java because of the activity there, and the time it takes to run the Spark integration tests, but I would love to have this button here.