### PR TITLE
[docs] add docs about nightly build

### DIFF
--- a/mkdocs/docs/SUMMARY.md
+++ b/mkdocs/docs/SUMMARY.md
@@ -29,8 +29,8 @@
 - Releases
     - [Verify a release](verify-release.md)
     - [How to release](how-to-release.md)
-    - [Nightly Build](nightly-build.md)
     - [Release Notes](https://github.com/apache/iceberg-python/releases)
+    - [Nightly Build](nightly-build.md)
 - [Code Reference](reference/)
 
 <!-- markdown-link-check-enable-->

--- a/mkdocs/docs/SUMMARY.md
+++ b/mkdocs/docs/SUMMARY.md
@@ -29,6 +29,7 @@
 - Releases
     - [Verify a release](verify-release.md)
     - [How to release](how-to-release.md)
+    - [Nightly Build](nightly-build.md)
     - [Release Notes](https://github.com/apache/iceberg-python/releases)
 - [Code Reference](reference/)
 

--- a/mkdocs/docs/nightly-build.md
+++ b/mkdocs/docs/nightly-build.md
@@ -21,7 +21,8 @@
 
 A nightly build of PyIceberg is available on testpypi, [https://test.pypi.org/project/pyiceberg/](https://test.pypi.org/project/pyiceberg/).
 
-To install the nightly build, 
-```
+To install the nightly build,
+
+```shell
 pip install -i https://test.pypi.org/simple/ --pre pyiceberg
 ```

--- a/mkdocs/docs/nightly-build.md
+++ b/mkdocs/docs/nightly-build.md
@@ -1,0 +1,27 @@
+<!--
+  - Licensed to the Apache Software Foundation (ASF) under one
+  - or more contributor license agreements.  See the NOTICE file
+  - distributed with this work for additional information
+  - regarding copyright ownership.  The ASF licenses this file
+  - to you under the Apache License, Version 2.0 (the
+  - "License"); you may not use this file except in compliance
+  - with the License.  You may obtain a copy of the License at
+  -
+  -   http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing,
+  - software distributed under the License is distributed on an
+  - "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  - KIND, either express or implied.  See the License for the
+  - specific language governing permissions and limitations
+  - under the License.
+  -->
+
+# Nightly Build
+
+A nightly build of PyIceberg is available on testpypi, [https://test.pypi.org/project/pyiceberg/](https://test.pypi.org/project/pyiceberg/).
+
+To install the nightly build, 
+```
+pip install -i https://test.pypi.org/simple/ --pre pyiceberg
+```

--- a/mkdocs/docs/nightly-build.md
+++ b/mkdocs/docs/nightly-build.md
@@ -26,3 +26,10 @@ To install the nightly build,
 ```shell
 pip install -i https://test.pypi.org/simple/ --pre pyiceberg
 ```
+
+<!-- prettier-ignore-start -->
+
+!!! warning "For Testing Purposes Only"
+    Nightly builds are for testing purposes only and have not been validated. Please use at your own risk, as they may contain untested changes, potential bugs, or incomplete features. Additionally, ensure compliance with any applicable licenses, as these builds may include changes that have not been reviewed for legal or licensing implications.
+
+<!-- prettier-ignore-end -->


### PR DESCRIPTION
Nightly testpypi build was added in #1601
This PR adds a subpage under "Releases" about the nightly build.

Running `make docs-serve` locally,
![Screenshot 2025-02-17 at 9 24 59 AM](https://github.com/user-attachments/assets/c3bfacf1-ad4b-4635-b5d7-df3ae41a153d)
