### PR TITLE
Remove parsing table name in `row_filter`

### DIFF
--- a/pyiceberg/expressions/parser.py
+++ b/pyiceberg/expressions/parser.py
@@ -66,7 +66,6 @@ from pyiceberg.expressions.literals import (
 )
 from pyiceberg.typedef import L
 from pyiceberg.types import strtobool
-from pyiceberg.utils.deprecated import deprecation_message
 
 ParserElement.enablePackrat()
 

--- a/pyiceberg/expressions/parser.py
+++ b/pyiceberg/expressions/parser.py
@@ -90,13 +90,7 @@ like_regex = r"(?P<valid_wildcard>(?<!\\)%$)|(?P<invalid_wildcard>(?<!\\)%)"
 @column.set_parse_action
 def _(result: ParseResults) -> Reference:
     if len(result.column) > 1:
-        deprecation_message(
-            deprecated_in="0.8.0",
-            removed_in="0.9.0",
-            help_message="Parsing expressions with table name is deprecated. Only provide field names in the row_filter.",
-        )
-    # TODO: Once this is removed, we will no longer take just the last index of parsed column result
-    # And introduce support for parsing filter expressions with nested fields.
+        raise ValueError(f"Cannot parse expressions with table names or nested fields, got: {".".join(result.column)}")
     return Reference(result.column[-1])
 
 

--- a/pyiceberg/expressions/parser.py
+++ b/pyiceberg/expressions/parser.py
@@ -88,9 +88,7 @@ like_regex = r"(?P<valid_wildcard>(?<!\\)%$)|(?P<invalid_wildcard>(?<!\\)%)"
 
 @column.set_parse_action
 def _(result: ParseResults) -> Reference:
-    if len(result.column) > 1:
-        raise ValueError(f"Cannot parse expressions with table names or nested fields, got: {".".join(result.column)}")
-    return Reference(result.column[-1])
+    return Reference(".".join(result.column))
 
 
 boolean = one_of(["true", "false"], caseless=True).set_results_name("boolean")

--- a/tests/expressions/test_expressions.py
+++ b/tests/expressions/test_expressions.py
@@ -1172,6 +1172,12 @@ def test_bind_dot_name() -> None:
     assert IsNull(Reference("foo.bar")).bind(schema) == bound
 
 
+def test_nested_bind_with_dot_name() -> None:
+    schema = Schema(NestedField(1, "foo.bar", StructType(NestedField(2, "baz", StringType()))), schema_id=1)
+    bound = BoundIsNull(BoundReference(schema.find_field(2), schema.accessor_for_field(2)))
+    assert IsNull(Reference("foo.bar.baz")).bind(schema) == bound
+
+
 def test_bind_ambiguous_name() -> None:
     with pytest.raises(ValueError) as exc_info:
         Schema(

--- a/tests/expressions/test_expressions.py
+++ b/tests/expressions/test_expressions.py
@@ -1160,6 +1160,28 @@ def test_eq_bound_expression(bound_reference_str: BoundReference[str]) -> None:
     )
 
 
+def test_nested_bind() -> None:
+    schema = Schema(NestedField(1, "foo", StructType(NestedField(2, "bar", StringType()))), schema_id=1)
+    bound = BoundIsNull(BoundReference(schema.find_field(2), schema.accessor_for_field(2)))
+    assert IsNull(Reference("foo.bar")).bind(schema) == bound
+
+
+def test_bind_dot_name() -> None:
+    schema = Schema(NestedField(1, "foo.bar", StringType()), schema_id=1)
+    bound = BoundIsNull(BoundReference(schema.find_field(1), schema.accessor_for_field(1)))
+    assert IsNull(Reference("foo.bar")).bind(schema) == bound
+
+
+def test_bind_ambiguous_name() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        Schema(
+            NestedField(1, "foo", StructType(NestedField(2, "bar", StringType()))),
+            NestedField(3, "foo.bar", StringType()),
+            schema_id=1,
+        )
+    assert "Invalid schema, multiple fields for name foo.bar: 2 and 3" in str(exc_info)
+
+
 #   __  __      ___
 #  |  \/  |_  _| _ \_  _
 #  | |\/| | || |  _/ || |

--- a/tests/expressions/test_parser.py
+++ b/tests/expressions/test_parser.py
@@ -222,5 +222,17 @@ def test_with_function() -> None:
 
 
 def test_nested_fields() -> None:
-    assert EqualTo("foo.bar", "value") == parser.parse("foo.bar = 'value'")
+    assert EqualTo("foo.bar", "data") == parser.parse("foo.bar = 'data'")
     assert LessThan("location.x", DecimalLiteral(Decimal(52.00))) == parser.parse("location.x < 52.00")
+
+
+def test_quoted_column_with_dots() -> None:
+    with pytest.raises(ParseException) as exc_info:
+        parser.parse("\"foo.bar\".baz = 'data'")
+
+    assert "Expected '\"', found '.'" in str(exc_info.value)
+
+    with pytest.raises(ParseException) as exc_info:
+        parser.parse("'foo.bar'.baz = 'data'")
+
+    assert "Expected <= | <> | < | >= | > | == | = | !=, found '.'" in str(exc_info.value)

--- a/tests/expressions/test_parser.py
+++ b/tests/expressions/test_parser.py
@@ -14,6 +14,8 @@
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
+from decimal import Decimal
+
 import pytest
 from pyparsing import ParseException
 
@@ -39,6 +41,7 @@ from pyiceberg.expressions import (
     Or,
     StartsWith,
 )
+from pyiceberg.expressions.literals import DecimalLiteral
 
 
 def test_always_true() -> None:
@@ -218,13 +221,6 @@ def test_with_function() -> None:
     assert "Expected end of text, found 'and'" in str(exc_info)
 
 
-def test_table_and_nested_fields_in_expression() -> None:
-    message = "Cannot parse expressions with table names or nested fields"
-
-    with pytest.raises(ValueError) as exc_info:
-        parser.parse("table.foo = 'bar'")
-    assert message in str(exc_info)
-
-    with pytest.raises(ValueError) as exc_info:
-        parser.parse("foo.bar.baz = 'qux'")
-    assert message in str(exc_info)
+def test_nested_fields() -> None:
+    assert EqualTo("foo.bar", "value") == parser.parse("foo.bar = 'value'")
+    assert LessThan("location.x", DecimalLiteral(Decimal(52.00))) == parser.parse("location.x < 52.00")

--- a/tests/expressions/test_parser.py
+++ b/tests/expressions/test_parser.py
@@ -216,3 +216,15 @@ def test_with_function() -> None:
         parser.parse("foo = 1 and lower(bar) = '2'")
 
     assert "Expected end of text, found 'and'" in str(exc_info)
+
+
+def test_table_and_nested_fields_in_expression() -> None:
+    message = "Cannot parse expressions with table names or nested fields"
+
+    with pytest.raises(ValueError) as exc_info:
+        parser.parse("table.foo = 'bar'")
+    assert message in str(exc_info)
+
+    with pytest.raises(ValueError) as exc_info:
+        parser.parse("foo.bar.baz = 'qux'")
+    assert message in str(exc_info)


### PR DESCRIPTION
This PR deprecates one of the three items that were planned for the 0.9.0 release. 

All items marked for removal:
- [x]  Table name reference in scan expression 
<https://github.com/apache/iceberg-python/blob/efc8b5ac0f16717f776e034ecf9a9e9bdabd8424/pyiceberg/expressions/parser.py#L95>

- [x]  REST catalog client AUTH_URL (#1691)
<https://github.com/apache/iceberg-python/blob/efc8b5ac0f16717f776e034ecf9a9e9bdabd8424/pyiceberg/catalog/rest.py#L324>

- [x] botocore session (#1692)
<https://github.com/apache/iceberg-python/blob/efc8b5ac0f16717f776e034ecf9a9e9bdabd8424/pyiceberg/catalog/__init__.py#L790>

Currently there are three items marked for release. However, based on the ongoing [discussion](https://lists.apache.org/thread/rr8lcf96jl6079dz6vfkwr5spbvlxzpm), it appears that the other two items. have not yet been replaced with a proper solution. As a result, this PR only addresses the deprecation of `Table name reference in scan expression` while we await further resolution on the others.

cc: @Fokko @kevinjqliu @HonahX 