### PR TITLE
AWS: Undeprecate `botocore_session`

### DIFF
--- a/pyiceberg/catalog/__init__.py
+++ b/pyiceberg/catalog/__init__.py
@@ -72,8 +72,6 @@ from pyiceberg.typedef import (
     RecursiveDict,
 )
 from pyiceberg.utils.config import Config, merge_config
-from pyiceberg.utils.deprecated import deprecated as deprecated
-from pyiceberg.utils.deprecated import deprecation_message
 from pyiceberg.utils.properties import property_as_bool
 
 if TYPE_CHECKING:
@@ -98,6 +96,7 @@ METADATA = "metadata"
 URI = "uri"
 LOCATION = "location"
 EXTERNAL_TABLE = "EXTERNAL_TABLE"
+BOTOCORE_SESSION = "botocore_session"
 
 TABLE_METADATA_FILE_NAME_REGEX = re.compile(
     r"""
@@ -109,8 +108,6 @@ TABLE_METADATA_FILE_NAME_REGEX = re.compile(
     """,
     re.X,
 )
-
-DEPRECATED_BOTOCORE_SESSION = "botocore_session"
 
 
 class CatalogType(Enum):
@@ -783,13 +780,6 @@ class Catalog(ABC):
 class MetastoreCatalog(Catalog, ABC):
     def __init__(self, name: str, **properties: str):
         super().__init__(name, **properties)
-
-        if self.properties.get(DEPRECATED_BOTOCORE_SESSION):
-            deprecation_message(
-                deprecated_in="0.8.0",
-                removed_in="0.9.0",
-                help_message=f"The property {DEPRECATED_BOTOCORE_SESSION} is deprecated and will be removed.",
-            )
 
     def create_table_transaction(
         self,

--- a/pyiceberg/catalog/dynamodb.py
+++ b/pyiceberg/catalog/dynamodb.py
@@ -30,7 +30,7 @@ from typing import (
 import boto3
 
 from pyiceberg.catalog import (
-    DEPRECATED_BOTOCORE_SESSION,
+    BOTOCORE_SESSION,
     ICEBERG,
     METADATA_LOCATION,
     PREVIOUS_METADATA_LOCATION,
@@ -100,7 +100,7 @@ class DynamoDbCatalog(MetastoreCatalog):
         session = boto3.Session(
             profile_name=properties.get(DYNAMODB_PROFILE_NAME),
             region_name=get_first_property_value(properties, DYNAMODB_REGION, AWS_REGION),
-            botocore_session=properties.get(DEPRECATED_BOTOCORE_SESSION),
+            botocore_session=properties.get(BOTOCORE_SESSION),
             aws_access_key_id=get_first_property_value(properties, DYNAMODB_ACCESS_KEY_ID, AWS_ACCESS_KEY_ID),
             aws_secret_access_key=get_first_property_value(properties, DYNAMODB_SECRET_ACCESS_KEY, AWS_SECRET_ACCESS_KEY),
             aws_session_token=get_first_property_value(properties, DYNAMODB_SESSION_TOKEN, AWS_SESSION_TOKEN),

--- a/pyiceberg/catalog/glue.py
+++ b/pyiceberg/catalog/glue.py
@@ -41,7 +41,7 @@ from mypy_boto3_glue.type_defs import (
 )
 
 from pyiceberg.catalog import (
-    DEPRECATED_BOTOCORE_SESSION,
+    BOTOCORE_SESSION,
     EXTERNAL_TABLE,
     ICEBERG,
     LOCATION,
@@ -311,7 +311,7 @@ class GlueCatalog(MetastoreCatalog):
         session = boto3.Session(
             profile_name=properties.get(GLUE_PROFILE_NAME),
             region_name=get_first_property_value(properties, GLUE_REGION, AWS_REGION),
-            botocore_session=properties.get(DEPRECATED_BOTOCORE_SESSION),
+            botocore_session=properties.get(BOTOCORE_SESSION),
             aws_access_key_id=get_first_property_value(properties, GLUE_ACCESS_KEY_ID, AWS_ACCESS_KEY_ID),
             aws_secret_access_key=get_first_property_value(properties, GLUE_SECRET_ACCESS_KEY, AWS_SECRET_ACCESS_KEY),
             aws_session_token=get_first_property_value(properties, GLUE_SESSION_TOKEN, AWS_SESSION_TOKEN),


### PR DESCRIPTION
We've deprecated this a while ago, because as the configuration should only pass in strings, and not Python objects.

However, it was pretty complex to find a reasonable alternative for this. For example: https://github.com/apache/iceberg-python/pull/1299

Therefore, I think we should undo this deprecation for now.