### PR TITLE
Add syntactic sugar for `and` and `or` operation

### DIFF
--- a/pyiceberg/expressions/__init__.py
+++ b/pyiceberg/expressions/__init__.py
@@ -64,6 +64,20 @@ class BooleanExpression(ABC):
     def __invert__(self) -> BooleanExpression:
         """Transform the Expression into its negated version."""
 
+    def __and__(self, other: BooleanExpression) -> BooleanExpression:
+        """Perform and operation on another expression."""
+        if not isinstance(other, BooleanExpression):
+            raise ValueError(f"Expected BooleanExpression, got: {other}")
+
+        return And(self, other)
+
+    def __or__(self, other: BooleanExpression) -> BooleanExpression:
+        """Perform or operation on another expression."""
+        if not isinstance(other, BooleanExpression):
+            raise ValueError(f"Expected BooleanExpression, got: {other}")
+
+        return Or(self, other)
+
 
 class Term(Generic[L], ABC):
     """A simple expression that evaluates to a value."""

--- a/tests/expressions/test_expressions.py
+++ b/tests/expressions/test_expressions.py
@@ -698,20 +698,34 @@ def test_and() -> None:
     null = IsNull(Reference("a"))
     nan = IsNaN(Reference("b"))
     and_ = And(null, nan)
+
+    # Some syntactic sugar
+    assert and_ == null & nan
+
     assert str(and_) == f"And(left={str(null)}, right={str(nan)})"
     assert repr(and_) == f"And(left={repr(null)}, right={repr(nan)})"
     assert and_ == eval(repr(and_))
     assert and_ == pickle.loads(pickle.dumps(and_))
+
+    with pytest.raises(ValueError, match="Expected BooleanExpression, got: abc"):
+        null & "abc"  # type: ignore
 
 
 def test_or() -> None:
     null = IsNull(Reference("a"))
     nan = IsNaN(Reference("b"))
     or_ = Or(null, nan)
+
+    # Some syntactic sugar
+    assert or_ == null | nan
+
     assert str(or_) == f"Or(left={str(null)}, right={str(nan)})"
     assert repr(or_) == f"Or(left={repr(null)}, right={repr(nan)})"
     assert or_ == eval(repr(or_))
     assert or_ == pickle.loads(pickle.dumps(or_))
+
+    with pytest.raises(ValueError, match="Expected BooleanExpression, got: abc"):
+        null | "abc"  # type: ignore
 
 
 def test_not() -> None:


### PR DESCRIPTION
I got inspired by Arrow that also allows for this.