### PR TITLE
Remove top-level import of `pyarrow`

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -62,7 +62,6 @@ from pyiceberg.expressions.visitors import (
     manifest_evaluator,
 )
 from pyiceberg.io import FileIO, load_file_io
-from pyiceberg.io.pyarrow import ArrowScan, expression_to_pyarrow, schema_to_pyarrow
 from pyiceberg.manifest import (
     POSITIONAL_DELETE_SCHEMA,
     DataFile,
@@ -1150,6 +1149,7 @@ class Table:
         Returns:
             An UpsertResult class (contains details of rows updated and inserted)
         """
+        from pyiceberg.io.pyarrow import expression_to_pyarrow
         from pyiceberg.table import upsert_util
 
         if join_cols is None:
@@ -1770,7 +1770,7 @@ class DataScan(TableScan):
         """
         import pyarrow as pa
 
-        from pyiceberg.io.pyarrow import ArrowScan
+        from pyiceberg.io.pyarrow import ArrowScan, schema_to_pyarrow
 
         target_schema = schema_to_pyarrow(self.projection())
         batches = ArrowScan(
@@ -1828,6 +1828,8 @@ class DataScan(TableScan):
         return result
 
     def count(self) -> int:
+        from pyiceberg.io.pyarrow import ArrowScan
+
         # Usage: Calculates the total number of records in a Scan that haven't had positional deletes.
         res = 0
         # every task is a FileScanTask

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -1149,6 +1149,11 @@ class Table:
         Returns:
             An UpsertResult class (contains details of rows updated and inserted)
         """
+        try:
+            import pyarrow as pa
+        except ModuleNotFoundError as e:
+            raise ModuleNotFoundError("For writes PyArrow needs to be installed") from e
+
         from pyiceberg.io.pyarrow import expression_to_pyarrow
         from pyiceberg.table import upsert_util
 

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -1150,7 +1150,7 @@ class Table:
             An UpsertResult class (contains details of rows updated and inserted)
         """
         try:
-            import pyarrow as pa
+            import pyarrow as pa  # noqa: F401
         except ModuleNotFoundError as e:
             raise ModuleNotFoundError("For writes PyArrow needs to be installed") from e
 


### PR DESCRIPTION
The [release candidate artifact build environment](https://github.com/apache/iceberg-python/blob/a58f099aa501f6fd4345a331295d81fe0133554f/.github/workflows/pypi-build-artifacts.yml#L72-L74) does not automatically install `pyarrow`. So when the import requires `pyarrow`, it fails. See run https://github.com/apache/iceberg-python/actions/runs/13464626812/job/37627644985

Import is via `conftest`
```
  ImportError while loading conftest '/project/tests/conftest.py'.
  /project/tests/conftest.py:52: in <module>
      from pyiceberg.catalog import Catalog, load_catalog
  ../venv/lib/python3.9/site-packages/pyiceberg/catalog/__init__.py:51: in <module>
      from pyiceberg.serializers import ToOutputFile
  ../venv/lib/python3.9/site-packages/pyiceberg/serializers.py:25: in <module>
      from pyiceberg.table.metadata import TableMetadata, TableMetadataUtil
  ../venv/lib/python3.9/site-packages/pyiceberg/table/__init__.py:65: in <module>
      from pyiceberg.io.pyarrow import ArrowScan, expression_to_pyarrow, schema_to_pyarrow
  ../venv/lib/python3.9/site-packages/pyiceberg/io/pyarrow.py:62: in <module>
      import pyarrow as pa
  E   ModuleNotFoundError: No module named 'pyarrow'
```

This isnt caught in CI since we install all extra deps by default, including `pyarrow`


Tested in the release candidate build action on my fork: https://github.com/kevinjqliu/iceberg-python/actions/runs/13465085426 ✅ 

cc @geruh 
