### PR TITLE
Fix: Remove Metadata from Map Key/Value Fields in as_arrow Conversion

### DIFF
--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -613,8 +613,8 @@ class _ConvertToArrowSchema(SchemaVisitorPerPrimitiveType[pa.DataType]):
         return pa.large_list(value_type=element_field)
 
     def map(self, map_type: MapType, key_result: pa.DataType, value_result: pa.DataType) -> pa.DataType:
-        key_field = self.field(map_type.key_field, key_result)
-        value_field = self.field(map_type.value_field, value_result)
+        key_field = pa.field("key", key_result, nullable=map_type.key_field.optional)
+        value_field = pa.field("value", value_result, nullable=map_type.value_field.optional)
         return pa.map_(key_type=key_field, item_type=value_field)
 
     def visit_fixed(self, fixed_type: FixedType) -> pa.DataType:

--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -613,8 +613,8 @@ class _ConvertToArrowSchema(SchemaVisitorPerPrimitiveType[pa.DataType]):
         return pa.large_list(value_type=element_field)
 
     def map(self, map_type: MapType, key_result: pa.DataType, value_result: pa.DataType) -> pa.DataType:
-        key_field = pa.field("key", key_result, nullable=map_type.key_field.optional)
-        value_field = pa.field("value", value_result, nullable=map_type.value_field.optional)
+        key_field = self.field("key", key_result, nullable=map_type.key_field.optional)
+        value_field = self.field("value", value_result, nullable=map_type.value_field.optional)
         return pa.map_(key_type=key_field, item_type=value_field)
 
     def visit_fixed(self, fixed_type: FixedType) -> pa.DataType:


### PR DESCRIPTION
This change modifies the _ConvertToArrowSchema.map method to create map key and value fields without attaching extra metadata (such as field IDs). By directly constructing the key and value fields using pa.field("key", ...) and pa.field("value", ...), the resulting PyArrow schema now matches the plain schema expected by the write process, resolving the schema mismatch error when appending data with map fields.