### PR TITLE
Upsert: Align codestyle

### DIFF
--- a/pyiceberg/table/upsert_util.py
+++ b/pyiceberg/table/upsert_util.py
@@ -16,7 +16,6 @@
 # under the License.
 import functools
 import operator
-from typing import List, cast
 
 import pyarrow as pa
 from pyarrow import Table as pyarrow_table
@@ -24,11 +23,9 @@ from pyarrow import compute as pc
 
 from pyiceberg.expressions import (
     AlwaysFalse,
-    And,
     BooleanExpression,
     EqualTo,
     In,
-    Or,
 )
 
 
@@ -38,16 +35,11 @@ def create_match_filter(df: pyarrow_table, join_cols: list[str]) -> BooleanExpre
     if len(join_cols) == 1:
         return In(join_cols[0], unique_keys[0].to_pylist())
     else:
-        filters: List[BooleanExpression] = [
-            cast(BooleanExpression, And(*[EqualTo(col, row[col]) for col in join_cols])) for row in unique_keys.to_pylist()
+        filters = [
+            functools.reduce(operator.and_, [EqualTo(col, row[col]) for col in join_cols]) for row in unique_keys.to_pylist()
         ]
 
-        if len(filters) == 0:
-            return AlwaysFalse()
-        elif len(filters) == 1:
-            return filters[0]
-        else:
-            return functools.reduce(lambda a, b: Or(a, b), filters)
+        return AlwaysFalse() if len(filters) == 0 else functools.reduce(operator.or_, filters)
 
 
 def has_duplicate_rows(df: pyarrow_table, join_cols: list[str]) -> bool:


### PR DESCRIPTION
Now we have the syntactic sugar (https://github.com/apache/iceberg-python/pull/1697), we don't need Lambda's anymore and can use the `operator.{and_,or_}` functions.

Also, the reduce is okay with just having a single argument, while `And(*[EqualTo('a', 22)])` would fail.
```
python3
Python 3.10.14 (main, Mar 19 2024, 21:46:16) [Clang 15.0.0 (clang-1500.3.9.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import functools
>>> functools.reduce(lambda a, b: a + b, [1])
1
>>> functools.reduce(lambda a, b: a + b, [1, 2])
3
```