### PR TITLE
fix in-memory

### DIFF
--- a/pyiceberg/catalog/__init__.py
+++ b/pyiceberg/catalog/__init__.py
@@ -252,7 +252,7 @@ def load_catalog(name: Optional[str] = None, **properties: Optional[str]) -> Cat
 
     catalog_type = None
     if provided_catalog_type and isinstance(provided_catalog_type, str):
-        catalog_type = CatalogType[provided_catalog_type.upper()]
+        catalog_type = CatalogType(provided_catalog_type.lower())
     elif not provided_catalog_type:
         catalog_type = infer_catalog_type(name, conf)
 

--- a/tests/catalog/test_base.py
+++ b/tests/catalog/test_base.py
@@ -88,6 +88,10 @@ def given_catalog_has_a_table(
     )
 
 
+def test_load_catalog_in_memory() -> None:
+    assert load_catalog("catalog", **{"type": "in-memory"})
+
+
 def test_load_catalog_impl_not_full_path() -> None:
     with pytest.raises(ValueError) as exc_info:
         load_catalog("catalog", **{"py-catalog-impl": "CustomCatalog"})


### PR DESCRIPTION
Previously `CatalogType` was fetched by key, `CatalogType[provided_catalog_type.upper()]` (note the bracket)
This PR changes `CatalogType` to be fetched by value, `CatalogType(provided_catalog_type.lower())` (note the parenthesis)

https://stackoverflow.com/questions/29799235/python-enum-value2member-map-accessor

This fix loading `in-memory` catalog, `load_catalog("catalog", **{"type": "in-memory"})`.
Previously, `in-memory` was a key error because its key is `IN_MEMORY`. Note the `-` and `_`.

https://github.com/apache/iceberg-python/blob/1d24e71041e35e26e126aa4508ed7384e8aa031c/pyiceberg/catalog/__init__.py#L113-L119
