### PR TITLE
fix adlss properties processing

### DIFF
--- a/pyiceberg/io/fsspec.py
+++ b/pyiceberg/io/fsspec.py
@@ -191,7 +191,7 @@ def _adls(properties: Properties) -> AbstractFileSystem:
     for key, sas_token in {
         key.replace(f"{ADLS_SAS_TOKEN}.", ""): value
         for key, value in properties.items()
-        if key.startswith(ADLS_SAS_TOKEN) and key.endswith(".windows.net")
+        if key.startswith(ADLS_SAS_TOKEN)
     }.items():
         if ADLS_ACCOUNT_NAME not in properties:
             properties[ADLS_ACCOUNT_NAME] = key.split(".")[0]

--- a/pyiceberg/io/fsspec.py
+++ b/pyiceberg/io/fsspec.py
@@ -189,9 +189,7 @@ def _adls(properties: Properties) -> AbstractFileSystem:
     from adlfs import AzureBlobFileSystem
 
     for key, sas_token in {
-        key.replace(f"{ADLS_SAS_TOKEN}.", ""): value
-        for key, value in properties.items()
-        if key.startswith(ADLS_SAS_TOKEN)
+        key.replace(f"{ADLS_SAS_TOKEN}.", ""): value for key, value in properties.items() if key.startswith(ADLS_SAS_TOKEN)
     }.items():
         if ADLS_ACCOUNT_NAME not in properties:
             properties[ADLS_ACCOUNT_NAME] = key.split(".")[0]


### PR DESCRIPTION
We observed that the property with token returned by Polaris is `adls.sas-token.<account name>` and the extra condition causes is to be ignored