### PR TITLE
Fix: REST Catalog should retry on 401 status code

### DIFF
--- a/pyiceberg/catalog/rest.py
+++ b/pyiceberg/catalog/rest.py
@@ -148,7 +148,7 @@ def _retry_hook(retry_state: RetryCallState) -> None:
 
 
 _RETRY_ARGS = {
-    "retry": retry_if_exception_type(AuthorizationExpiredError),
+    "retry": retry_if_exception_type((AuthorizationExpiredError, UnauthorizedError)),
     "stop": stop_after_attempt(2),
     "before_sleep": _retry_hook,
     "reraise": True,

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -558,7 +558,8 @@ def test_list_namespace_with_parent_200(rest_mock: Mocker) -> None:
 @pytest.mark.filterwarnings(
     "ignore:Deprecated in 0.8.0, will be removed in 1.0.0. Iceberg REST client is missing the OAuth2 server URI:DeprecationWarning"
 )
-def test_list_namespaces_token_expired(rest_mock: Mocker) -> None:
+@pytest.mark.parametrize("status_code", [401, 419])
+def test_list_namespaces_token_expired_success_on_retries(rest_mock: Mocker, status_code: int) -> None:
     new_token = "new_jwt_token"
     new_header = dict(TEST_HEADERS)
     new_header["Authorization"] = f"Bearer {new_token}"
@@ -568,12 +569,12 @@ def test_list_namespaces_token_expired(rest_mock: Mocker) -> None:
         f"{TEST_URI}v1/namespaces",
         [
             {
-                "status_code": 419,
+                "status_code": status_code,
                 "json": {
                     "error": {
                         "message": "Authorization expired.",
                         "type": "AuthorizationExpiredError",
-                        "code": 419,
+                        "code": status_code,
                     }
                 },
                 "headers": TEST_HEADERS,


### PR DESCRIPTION
This is a follow up item from a recent discussion on the mailing list[1], where the community decided that 401 response should be preferred over 419 response on token expiry.

[1] mailing list discussion: https://lists.apache.org/thread/443skhqr59j3fj0ovg4tyxh9d4f4gysc
[2] REST Catalog Spec update PR: https://github.com/apache/iceberg/pull/12376