### PR TITLE
Add `write_parquet` API for writing Parquet files without committing

### DIFF
--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -2353,7 +2353,8 @@ def data_file_statistics_from_parquet_metadata(
     )
 
 
-def write_file(io: FileIO, table_metadata: TableMetadata, tasks: Iterator[WriteTask]) -> Iterator[DataFile]:
+def write_file(io: FileIO, table_metadata: TableMetadata, tasks: Iterator[WriteTask], include_field_ids: bool = True
+               ) -> Iterator[DataFile]:
     from pyiceberg.table import DOWNCAST_NS_TIMESTAMP_TO_US_ON_WRITE, TableProperties
 
     parquet_writer_kwargs = _get_parquet_writer_kwargs(table_metadata.properties)
@@ -2380,7 +2381,7 @@ def write_file(io: FileIO, table_metadata: TableMetadata, tasks: Iterator[WriteT
                 file_schema=task.schema,
                 batch=batch,
                 downcast_ns_timestamp_to_us=downcast_ns_timestamp_to_us,
-                include_field_ids=True,
+                include_field_ids=include_field_ids,
             )
             for batch in task.record_batches
         ]
@@ -2549,6 +2550,7 @@ def _dataframe_to_data_files(
     io: FileIO,
     write_uuid: Optional[uuid.UUID] = None,
     counter: Optional[itertools.count[int]] = None,
+    include_field_ids: bool = True
 ) -> Iterable[DataFile]:
     """Convert a PyArrow table into a DataFile.
 
@@ -2578,6 +2580,7 @@ def _dataframe_to_data_files(
                     for batches in bin_pack_arrow_table(df, target_file_size)
                 ]
             ),
+            include_field_ids=include_field_ids
         )
     else:
         partitions = _determine_partitions(spec=table_metadata.spec(), schema=table_metadata.schema(), arrow_table=df)
@@ -2597,6 +2600,7 @@ def _dataframe_to_data_files(
                     for batches in bin_pack_arrow_table(partition.arrow_table_partition, target_file_size)
                 ]
             ),
+            include_field_ids=include_field_ids
         )
 
 

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -1262,7 +1262,7 @@ class Table:
         if df.shape[0] > 0:
             data_files = list(
                 _dataframe_to_data_files(
-                    table_metadata=self.table_metadata, write_uuid=append_files.commit_uuid, df=df,
+                    table_metadata=self.metadata, write_uuid=append_files.commit_uuid, df=df,
                     io=self.io
                 )
             )

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -1262,7 +1262,7 @@ class Table:
         if df.shape[0] > 0:
             data_files = list(
                 _dataframe_to_data_files(
-                    table_metadata=self.metadata, write_uuid=uuid.uuid4(), df=df, io=self.io
+                    table_metadata=self.metadata, write_uuid=uuid.uuid4(), df=df, io=self.io, include_field_ids=False
                 )
             )
 

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -1262,8 +1262,7 @@ class Table:
         if df.shape[0] > 0:
             data_files = list(
                 _dataframe_to_data_files(
-                    table_metadata=self.metadata, write_uuid=append_files.commit_uuid, df=df,
-                    io=self.io
+                    table_metadata=self.metadata, write_uuid=uuid.uuid4(), df=df, io=self.io
                 )
             )
 


### PR DESCRIPTION
This PR adds a new API method `write_parquet()` to the `Table` class, which allows writing a PyArrow table to Parquet files in Iceberg-compatible format without committing them to the table metadata. This provides a way to decouple the write and commit process, which is particularly useful in high-concurrency scenarios.

## Key features
 - `write_parquet(df)` writes Parquet files compatible with Iceberg table format
 - Returns a list of file paths to the written files
 - Files can later be committed using `add_files()` API
 - Helps manage concurrency by separating write operations from metadata commits

## Use case
This is especially useful for high-concurrency ingestion scenarios where multiple writers could be writing data to an Iceberg table simultaneously. By separating the write and commit phases, applications can implement a queue system where the commit process (which requires a lock) is handled separately from the data writing phase:

```python
# Write data but don't commit
file_paths = table.write_parquet(df)

# Later, commit the files to make them visible in queries
table.add_files(file_paths=file_paths)
```


## Documentation
Added comprehensive documentation to the API docs, including explanations and examples of how to use the new method alongside the existing add_files API.


## Seeking guidance
I would appreciate guidance from project maintainers on:
 1. Which test cases would be most appropriate for this new API
 2. Is there a preferred location or approach for testing this functionality?
 3. Should we add tests that specifically verify the interaction between write_parquet() and add_files()?
 4. Are there any performance considerations or edge cases that should be covered in testing?
 5. Any further documentation or API changes before this is ready for review


Closes #1737 