### PR TITLE
Fix thrift client connection for Kerberos Hive Client 

### DIFF
--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -168,6 +168,10 @@ class _HiveClient:
         self._client = Client(protocol)
 
     def __enter__(self) -> Client:
+        # If the transport is closed, reinitialize it
+        if not self._transport.isOpen():
+            self._init_thrift_client()
+
         self._transport.open()
         if self._ugi:
             self._client.set_ugi(*self._ugi)

--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -166,9 +166,10 @@ class _HiveClient:
         return client
 
     def __enter__(self) -> Client:
-        """Reinitialize transport if was closed."""
-        if self._transport and not self._transport.isOpen():
+        """Make sure the transport is initialized and open."""
+        if not self._transport:
             self._transport = self._init_thrift_transport()
+        if not self._transport.isOpen():
             self._transport.open()
         return self._client
 

--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -147,6 +147,7 @@ class _HiveClient:
         self._uri = uri
         self._kerberos_auth = kerberos_auth
         self._ugi = ugi.split(":") if ugi else None
+        self._transport = self._init_thrift_transport()
 
     def _init_thrift_transport(self) -> TTransport:
         url_parts = urlparse(self._uri)
@@ -158,7 +159,6 @@ class _HiveClient:
 
     @cached_property
     def _client(self) -> Client:
-        self._transport = self._init_thrift_transport()
         protocol = TBinaryProtocol.TBinaryProtocol(self._transport)
         client = Client(protocol)
         if self._ugi:
@@ -169,6 +169,7 @@ class _HiveClient:
         """Reinitialize transport if was closed."""
         if self._transport and not self._transport.isOpen():
             self._transport = self._init_thrift_transport()
+            self._transport.open()
         return self._client
 
     def __exit__(


### PR DESCRIPTION
Closes #1744

`TSaslClientTransport` cannot be reopen. This PR changes the behavior to recreate a `TSaslClientTransport` when its already closed. 

Note, `_HiveClient` should be used with context manager, but can be used without. 