### PR TITLE
CI: Limit parallelism

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2433,6 +2433,8 @@ def spark() -> "SparkSession":
     spark = (
         SparkSession.builder.appName("PyIceberg integration test")
         .config("spark.sql.session.timeZone", "UTC")
+        .config("spark.sql.shuffle.partitions", "1")
+        .config("spark.default.parallelism", "1")
         .config("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions")
         .config("spark.sql.catalog.integration", "org.apache.iceberg.spark.SparkCatalog")
         .config("spark.sql.catalog.integration.catalog-impl", "org.apache.iceberg.rest.RESTCatalog")


### PR DESCRIPTION
For the tests, we want to limit parallelism to avoid creating 1-row Parquet files.