### PR TITLE
Add pull-request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+<!--
+Thanks for opening a pull request!
+-->
+
+<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
+<!-- Closes #${GITHUB_ISSUE_ID} -->
+
+# Rationale for this change
+
+# Are these changes tested?
+
+# Are there any user-facing changes?
+
+<!-- In the case of user-facing changes, please add the changelog label. -->

--- a/dev/.rat-excludes
+++ b/dev/.rat-excludes
@@ -1,6 +1,6 @@
+.github/*
 .rat-excludes
 build
 .git
 .gitignore
 poetry.lock
-.github/pull_request_template.md

--- a/dev/.rat-excludes
+++ b/dev/.rat-excludes
@@ -3,3 +3,4 @@ build
 .git
 .gitignore
 poetry.lock
+.github/pull_request_template.md

--- a/mkdocs/docs/how-to-release.md
+++ b/mkdocs/docs/how-to-release.md
@@ -379,6 +379,8 @@ Then, select the previous release version as the **Previous tag** to use the dif
 
 **Set as the latest release** and **Publish**.
 
+Make sure to check the `changelog` label on GitHub to see if anything needs to be highlighted.
+
 ### Release the docs
 
 Run the [`Release Docs` Github Action](https://github.com/apache/iceberg-python/actions/workflows/python-release-docs.yml).


### PR DESCRIPTION
While @kevinjqliu did an amazing job summarizing the new stuff in 0.9.0 in the GitHub release (https://github.com/apache/iceberg-python/releases/tag/pyiceberg-0.9.0), I think it would be good to formalize this a bit.

This also came up in https://github.com/apache/iceberg-python/pull/1669 where we introduced a behavioral change. cc @sungwy 

I think it would be good to allow users to populate the changelog section to ensure they know about any relevant changes.

The template is pretty minimal now to avoid being a big barrier to opening a PR.