### PR TITLE
Add support for `Transaction.update_statistics()`

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -438,6 +438,15 @@ class Transaction:
         """
         return UpdateSnapshot(self, io=self._table.io, snapshot_properties=snapshot_properties)
 
+    def update_statistics(self) -> UpdateStatistics:
+        """
+        Create a new UpdateStatistics to update the statistics of the table.
+
+        Returns:
+            A new UpdateStatistics
+        """
+        return UpdateStatistics(transaction=self)
+
     def append(self, df: pa.Table, snapshot_properties: Dict[str, str] = EMPTY_DICT) -> None:
         """
         Shorthand API for appending a PyArrow table to a table transaction.

--- a/tests/integration/test_statistics_operations.py
+++ b/tests/integration/test_statistics_operations.py
@@ -82,3 +82,10 @@ def test_manage_statistics(catalog: "Catalog", arrow_table_with_null: "pa.Table"
         update.remove_statistics(add_snapshot_id_1)
 
     assert len(tbl.metadata.statistics) == 1
+
+    with tbl.transaction() as txn:
+        with txn.update_statistics() as update:
+            update.set_statistics(statistics_file_snap_1)
+            update.set_statistics(statistics_file_snap_2)
+
+    assert len(tbl.metadata.statistics) == 2


### PR DESCRIPTION
# Rationale for this change

Addd a new API `Transaction.update_statistics()` to use the existing transaction instead of a brand new one.

# Are these changes tested?

I extended `tests/integration/test_statistics_operations.py::test_manage_statistics` to test the new API.

# Are there any user-facing changes?

Users can now update statistics files within an ongoing transaction.
