### PR TITLE
Fix creation of Bucket Transforms with pydantic>=2.11.0

### DIFF
--- a/pyiceberg/transforms.py
+++ b/pyiceberg/transforms.py
@@ -234,8 +234,8 @@ class BucketTransform(Transform[S, int]):
     _num_buckets: PositiveInt = PrivateAttr()
 
     def __init__(self, num_buckets: int, **data: Any) -> None:
-        self._num_buckets = num_buckets
         super().__init__(f"bucket[{num_buckets}]", **data)
+        self._num_buckets = num_buckets
 
     @property
     def num_buckets(self) -> int:


### PR DESCRIPTION
## Rationale For This Change

When using pydantic>=2.11.0, we get an error when creating bucket transforms. In this version, it's illegal to access self before calling super. To fix this, we just need to ensure we call `super().__init__` before setting field properties on `self`.

---

## Before

Using `pydantic==2.11.0` the test `test_transforms.py::test_bucket_hash_values` fails

```python
tests/test_transforms.py:None (tests/test_transforms.py)
test_transforms.py:179: in <module>
    (BucketTransform(2).transform(IntegerType()), 0, 0),
../pyiceberg/transforms.py:237: in __init__
    self._num_buckets = num_buckets
../../../miniforge3/envs/pyiceberg/lib/python3.12/site-packages/pydantic/main.py:991: in __setattr__
    setattr_handler(self, name, value)  # call here to not memo on possibly unknown fields
../../../miniforge3/envs/pyiceberg/lib/python3.12/site-packages/pydantic/main.py:105: in <lambda>
    'private': lambda model, name, val: model.__pydantic_private__.__setitem__(name, val),  # pyright: ignore[reportOptionalMemberAccess]
E   AttributeError: 'NoneType' object has no attribute '__setitem__'. Did you mean: '__setattr__'?
```

---

## After

Using `pydantic==2.11.0` the test `test_transforms.py::test_bucket_hash_values` succeeds.

---

✅ Are these changes tested?

Yes

- No test was added to reproduce the bug because it is already reproducible with the existing test