### PR TITLE
feat: refresh table when committing append ops to support concurrent appends

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -918,6 +918,15 @@ class Table:
         self.metadata_location = fresh.metadata_location
         return self
 
+    def check_and_refresh_table(self) -> Optional[Table]:
+        fresh = self.catalog.load_table(self._identifier)
+        if self.metadata.current_snapshot_id != fresh.metadata.current_snapshot_id:
+            self.metadata = fresh.metadata
+            self.io = fresh.io
+            self.metadata_location = fresh.metadata_location
+            return fresh
+        return None
+
     def name(self) -> Identifier:
         """Return the identifier of this table.
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
Support for Concurrent Append Operations

Refresh Table

1. If changes in the table's metadata are detected (indicating that other transactions have been committed during this period), update the table's metadata and the current parent_snapshot_id.

2. If no changes are detected, proceed with the normal commit.
# Are these changes tested?
UT
# Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
