### PR TITLE
Adds support for creating a GlueCatalog with own client

### DIFF
--- a/pyiceberg/catalog/glue.py
+++ b/pyiceberg/catalog/glue.py
@@ -303,10 +303,16 @@ def _register_glue_catalog_id_with_glue_client(glue: GlueClient, glue_catalog_id
 
 
 class GlueCatalog(MetastoreCatalog):
-    def __init__(self, name: str, **properties: Any):
+    glue: GlueClient
+
+    def __init__(self, name: str, client: GlueClient | None = None, **properties: Any):
         super().__init__(name, **properties)
 
         retry_mode_prop_value = get_first_property_value(properties, GLUE_RETRY_MODE)
+
+        if client:
+            self.glue = client
+            return
 
         session = boto3.Session(
             profile_name=properties.get(GLUE_PROFILE_NAME),

--- a/tests/catalog/test_glue.py
+++ b/tests/catalog/test_glue.py
@@ -932,3 +932,11 @@ def test_glue_endpoint_override(_bucket_initialize: None, moto_endpoint_url: str
         catalog_name, **{"s3.endpoint": moto_endpoint_url, "warehouse": f"s3://{BUCKET_NAME}", "glue.endpoint": test_endpoint}
     )
     assert test_catalog.glue.meta.endpoint_url == test_endpoint
+
+
+@mock_aws
+def test_glue_client_override() -> None:
+    catalog_name = "glue"
+    test_client = boto3.client("glue", region_name="us-west-2")
+    test_catalog = GlueCatalog(catalog_name, test_client)
+    assert test_catalog.glue is test_client


### PR DESCRIPTION
Closes #1910 

# Rationale for this change

When working with the GlueCatalog, I may already have a GlueClient that I've instantiated from elsewhere, and perhaps wish to keep. This allows passing our client to the GlueCatalog constructor so that we aren't forced into getting a new client.

This is slightly interesting because it's the only catalog that now has a different constructor signature. Also it may be odd for users to pass a client, but then none of their properties (which may have retry configs) are applied.

An alternative to consider is having a `from_client` or `with_client` staticmethod, but I did not see precedence elsewhere. I will leave it to the maintainers to decide which they prefer and will update accordingly. Similarly, I can do the same for dynamodb 🙂 

I've also skipped the event_handler for a user-provided client because I wouldn't want to impede on their existing events, also the param is optional. Something to consider is using the [unique_id arg](https://github.com/boto/botocore/blob/aaa6690e45c8dabcde3a8d2d1aa34b5fd399fba7/botocore/hooks.py#L89) when registering an event. 

> If a ``unique_id`` is given, the handler will not be registered
> if a handler with the ``unique_id`` has already been registered.


# Are these changes tested?

Basic unit test to assert the client passed is the client used.

# Are there any user-facing changes?

I believe so since this is an addition to the public API.
