### PR TITLE
Feature/enhance types

### DIFF
--- a/pyiceberg/types.py
+++ b/pyiceberg/types.py
@@ -162,6 +162,7 @@ class IcebergType(IcebergBaseModel):
                 element_type_str = v[5:-1].strip()
                 # For simplicity, use -1 as placeholder ID that should be assigned later
                 element_type = IcebergType.handle_primitive_type(element_type_str, None)
+                # The 'element' parameter in the ListType constructor maps to the 'element_type' attribute
                 return ListType(element_id=-1, element=element_type, element_required=True)
 
             if v.startswith("map<") and v.endswith(">"):


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

This PR enhances type handling capabilities in PyIceberg by extending the `handle_primitive_type` method to support parsing complex types from string literals. The changes allow users to define and work with `list`, `map`, `fixed`, and `decimal` types using a more intuitive string-based syntax, improving the developer experience when working with PyIceberg schemas.

# Are these changes tested?

Yes, comprehensive tests have been added in `tests/test_types.py` with a new `test_string_based_types` function that validates:
- Parsing of primitive types from strings
- Correct handling of decimal types with precision and scale parameters
- Support for list types with various element types
- Map type parsing with proper key-value type definitions
- Nested complex types (e.g., maps within maps)
- Integration with `NestedField` objects

The test suite ensures all new functionality works as expected and maintains compatibility with existing code.

# Are there any user-facing changes?

Yes, this PR introduces user-facing improvements:
- Users can now define complex types using string literals (e.g., `list<string>`, `map<string, int>`)
- More intuitive syntax for decimal and fixed types
- Better error messages for invalid type definitions

These changes enhance the schema definition experience in PyIceberg applications.