### PR TITLE
Reorder `validation_history` parameters to be more idiomatic

### DIFF
--- a/pyiceberg/table/snapshots.py
+++ b/pyiceberg/table/snapshots.py
@@ -438,7 +438,7 @@ def ancestors_of(current_snapshot: Optional[Snapshot], table_metadata: TableMeta
 
 
 def ancestors_between(
-    to_snapshot: Snapshot, from_snapshot: Optional[Snapshot], table_metadata: TableMetadata
+    from_snapshot: Optional[Snapshot], to_snapshot: Snapshot, table_metadata: TableMetadata
 ) -> Iterable[Snapshot]:
     """Get the ancestors of and including the given snapshot between the to and from snapshots."""
     if from_snapshot is not None:

--- a/pyiceberg/table/update/validate.py
+++ b/pyiceberg/table/update/validate.py
@@ -23,8 +23,8 @@ from pyiceberg.table.snapshots import Operation, Snapshot, ancestors_between
 
 def validation_history(
     table: Table,
-    to_snapshot: Snapshot,
     from_snapshot: Snapshot,
+    to_snapshot: Snapshot,
     matching_operations: set[Operation],
     manifest_content_filter: ManifestContent,
 ) -> tuple[list[ManifestFile], set[int]]:
@@ -32,8 +32,8 @@ def validation_history(
 
     Args:
         table: Table to get the history from
-        to_snapshot: Starting snapshot
         from_snapshot: Parent snapshot to get the history from
+        to_snapshot: Starting snapshot
         matching_operations: Operations to match on
         manifest_content_filter: Manifest content type to filter
 
@@ -47,7 +47,7 @@ def validation_history(
     snapshots: set[int] = set()
 
     last_snapshot = None
-    for snapshot in ancestors_between(to_snapshot, from_snapshot, table.metadata):
+    for snapshot in ancestors_between(from_snapshot, to_snapshot, table.metadata):
         last_snapshot = snapshot
         summary = snapshot.summary
         if summary is None:

--- a/tests/table/test_snapshots.py
+++ b/tests/table/test_snapshots.py
@@ -426,8 +426,8 @@ def test_ancestors_between(table_v2_with_extensive_snapshots: Table) -> None:
         len(
             list(
                 ancestors_between(
-                    current_snapshot,
                     oldest_snapshot,
+                    current_snapshot,
                     table_v2_with_extensive_snapshots.metadata,
                 )
             )

--- a/tests/table/test_validate.py
+++ b/tests/table/test_validate.py
@@ -71,8 +71,8 @@ def test_validation_history(table_v2_with_extensive_snapshots_and_manifests: tup
     with patch("pyiceberg.table.snapshots.Snapshot.manifests", new=mock_read_manifest_side_effect):
         manifests, snapshots = validation_history(
             table,
-            newest_snapshot,
             oldest_snapshot,
+            newest_snapshot,
             {Operation.APPEND},
             ManifestContent.DATA,
         )
@@ -101,8 +101,8 @@ def test_validation_history_fails_on_snapshot_with_no_summary(
         with pytest.raises(ValidationException):
             validation_history(
                 table,
-                newest_snapshot,
                 oldest_snapshot,
+                newest_snapshot,
                 {Operation.APPEND},
                 ManifestContent.DATA,
             )
@@ -131,8 +131,8 @@ def test_validation_history_fails_on_from_snapshot_not_matching_last_snapshot(
             with pytest.raises(ValidationException):
                 validation_history(
                     table,
-                    newest_snapshot,
                     oldest_snapshot,
+                    newest_snapshot,
                     {Operation.APPEND},
                     ManifestContent.DATA,
                 )


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

Nit: the current order (`to_snapshot` before `from_snapshot`) is unexpected and [error-prone](https://github.com/apache/iceberg-python/pull/1938/files#r2070985497).

This PR proposes to reorder these parameters in `validation_history` and `ancestors_between` so that it is more idiomatic.
# Are these changes tested?

Yes, through integration and unit tests

# Are there any user-facing changes?

Yes, but these functions were just introduced (no releases were made yet with these functions)
<!-- In the case of user-facing changes, please add the changelog label. -->
