### PR TITLE
Add tests for optimistic concurrency

### DIFF
--- a/tests/integration/test_writes/test_optimistic_concurrency.py
+++ b/tests/integration/test_writes/test_optimistic_concurrency.py
@@ -30,7 +30,7 @@ def test_conflict_delete_delete(
     spark: SparkSession, session_catalog: Catalog, arrow_table_with_null: pa.Table, format_version: int
 ) -> None:
     identifier = "default.test_conflict"
-    tbl1 = _create_table(session_catalog, identifier, {"format-version": "1"}, [arrow_table_with_null])
+    tbl1 = _create_table(session_catalog, identifier, {"format-version": format_version}, [arrow_table_with_null])
     tbl2 = session_catalog.load_table(identifier)
 
     tbl1.delete("string == 'z'")
@@ -46,7 +46,7 @@ def test_conflict_delete_append(
     spark: SparkSession, session_catalog: Catalog, arrow_table_with_null: pa.Table, format_version: int
 ) -> None:
     identifier = "default.test_conflict"
-    tbl1 = _create_table(session_catalog, identifier, {"format-version": "1"}, [arrow_table_with_null])
+    tbl1 = _create_table(session_catalog, identifier, {"format-version": format_version}, [arrow_table_with_null])
     tbl2 = session_catalog.load_table(identifier)
 
     # This is allowed
@@ -63,7 +63,7 @@ def test_conflict_append_delete(
     spark: SparkSession, session_catalog: Catalog, arrow_table_with_null: pa.Table, format_version: int
 ) -> None:
     identifier = "default.test_conflict"
-    tbl1 = _create_table(session_catalog, identifier, {"format-version": "1"}, [arrow_table_with_null])
+    tbl1 = _create_table(session_catalog, identifier, {"format-version": format_version}, [arrow_table_with_null])
     tbl2 = session_catalog.load_table(identifier)
 
     tbl1.delete("string == 'z'")
@@ -79,7 +79,7 @@ def test_conflict_append_append(
     spark: SparkSession, session_catalog: Catalog, arrow_table_with_null: pa.Table, format_version: int
 ) -> None:
     identifier = "default.test_conflict"
-    tbl1 = _create_table(session_catalog, identifier, {"format-version": "1"}, [arrow_table_with_null])
+    tbl1 = _create_table(session_catalog, identifier, {"format-version": format_version}, [arrow_table_with_null])
     tbl2 = session_catalog.load_table(identifier)
 
     tbl1.append(arrow_table_with_null)

--- a/tests/integration/test_writes/test_optimistic_concurrency.py
+++ b/tests/integration/test_writes/test_optimistic_concurrency.py
@@ -29,6 +29,7 @@ from utils import _create_table
 def test_conflict_delete_delete(
     spark: SparkSession, session_catalog: Catalog, arrow_table_with_null: pa.Table, format_version: int
 ) -> None:
+    """This test should start passing once optimistic concurrency control has been implemented."""
     identifier = "default.test_conflict"
     tbl1 = _create_table(session_catalog, identifier, {"format-version": format_version}, [arrow_table_with_null])
     tbl2 = session_catalog.load_table(identifier)
@@ -45,6 +46,7 @@ def test_conflict_delete_delete(
 def test_conflict_delete_append(
     spark: SparkSession, session_catalog: Catalog, arrow_table_with_null: pa.Table, format_version: int
 ) -> None:
+    """This test should start passing once optimistic concurrency control has been implemented."""
     identifier = "default.test_conflict"
     tbl1 = _create_table(session_catalog, identifier, {"format-version": format_version}, [arrow_table_with_null])
     tbl2 = session_catalog.load_table(identifier)
@@ -62,6 +64,7 @@ def test_conflict_delete_append(
 def test_conflict_append_delete(
     spark: SparkSession, session_catalog: Catalog, arrow_table_with_null: pa.Table, format_version: int
 ) -> None:
+    """This test should start passing once optimistic concurrency control has been implemented."""
     identifier = "default.test_conflict"
     tbl1 = _create_table(session_catalog, identifier, {"format-version": format_version}, [arrow_table_with_null])
     tbl2 = session_catalog.load_table(identifier)
@@ -78,6 +81,7 @@ def test_conflict_append_delete(
 def test_conflict_append_append(
     spark: SparkSession, session_catalog: Catalog, arrow_table_with_null: pa.Table, format_version: int
 ) -> None:
+    """This test should start passing once optimistic concurrency control has been implemented."""
     identifier = "default.test_conflict"
     tbl1 = _create_table(session_catalog, identifier, {"format-version": format_version}, [arrow_table_with_null])
     tbl2 = session_catalog.load_table(identifier)

--- a/tests/integration/test_writes/test_optimistic_concurrency.py
+++ b/tests/integration/test_writes/test_optimistic_concurrency.py
@@ -1,0 +1,89 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pyarrow as pa
+import pytest
+from pyspark.sql import SparkSession
+
+from pyiceberg.catalog import Catalog
+from pyiceberg.exceptions import CommitFailedException
+from utils import _create_table
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("format_version", [1, 2])
+def test_conflict_delete_delete(
+    spark: SparkSession, session_catalog: Catalog, arrow_table_with_null: pa.Table, format_version: int
+) -> None:
+    identifier = "default.test_conflict"
+    tbl1 = _create_table(session_catalog, identifier, {"format-version": "1"}, [arrow_table_with_null])
+    tbl2 = session_catalog.load_table(identifier)
+
+    tbl1.delete("string == 'z'")
+
+    with pytest.raises(CommitFailedException, match="(branch main has changed: expected id ).*"):
+        # tbl2 isn't aware of the commit by tbl1
+        tbl2.delete("string == 'z'")
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("format_version", [1, 2])
+def test_conflict_delete_append(
+    spark: SparkSession, session_catalog: Catalog, arrow_table_with_null: pa.Table, format_version: int
+) -> None:
+    identifier = "default.test_conflict"
+    tbl1 = _create_table(session_catalog, identifier, {"format-version": "1"}, [arrow_table_with_null])
+    tbl2 = session_catalog.load_table(identifier)
+
+    # This is allowed
+    tbl1.delete("string == 'z'")
+
+    with pytest.raises(CommitFailedException, match="(branch main has changed: expected id ).*"):
+        # tbl2 isn't aware of the commit by tbl1
+        tbl2.append(arrow_table_with_null)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("format_version", [1, 2])
+def test_conflict_append_delete(
+    spark: SparkSession, session_catalog: Catalog, arrow_table_with_null: pa.Table, format_version: int
+) -> None:
+    identifier = "default.test_conflict"
+    tbl1 = _create_table(session_catalog, identifier, {"format-version": "1"}, [arrow_table_with_null])
+    tbl2 = session_catalog.load_table(identifier)
+
+    tbl1.delete("string == 'z'")
+
+    with pytest.raises(CommitFailedException, match="(branch main has changed: expected id ).*"):
+        # tbl2 isn't aware of the commit by tbl1
+        tbl2.delete("string == 'z'")
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("format_version", [1, 2])
+def test_conflict_append_append(
+    spark: SparkSession, session_catalog: Catalog, arrow_table_with_null: pa.Table, format_version: int
+) -> None:
+    identifier = "default.test_conflict"
+    tbl1 = _create_table(session_catalog, identifier, {"format-version": "1"}, [arrow_table_with_null])
+    tbl2 = session_catalog.load_table(identifier)
+
+    tbl1.append(arrow_table_with_null)
+
+    with pytest.raises(CommitFailedException, match="(branch main has changed: expected id ).*"):
+        # tbl2 isn't aware of the commit by tbl1
+        tbl2.append(arrow_table_with_null)

--- a/tests/integration/test_writes/test_writes.py
+++ b/tests/integration/test_writes/test_writes.py
@@ -687,6 +687,7 @@ def test_summaries_with_only_nulls(
 
 
 @pytest.mark.integration
+@pytest.mark.skip(reason="Reported the issue: https://github.com/duckdb/duckdb-iceberg/issues/185")
 def test_duckdb_url_import(warehouse: Path, arrow_table_with_null: pa.Table) -> None:
     os.environ["TZ"] = "Etc/UTC"
     time.tzset()


### PR DESCRIPTION
I think it would be great to also have integration tests that make it easy to replicate certain scenarios.

Added some simple ones, but we can extend by having two tables that modify a different partition etc.

<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

# Are these changes tested?

# Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
