### PR TITLE
Remove `row-lineage` field in V3 metadata

### DIFF
--- a/pyiceberg/table/metadata.py
+++ b/pyiceberg/table/metadata.py
@@ -549,13 +549,6 @@ class TableMetadataV3(TableMetadataCommonFields, IcebergBaseModel):
     """The table’s highest assigned sequence number, a monotonically
     increasing long that tracks the order of snapshots in a table."""
 
-    row_lineage: bool = Field(alias="row-lineage", default=False)
-    """Indicates that row-lineage is enabled on the table
-
-    For more information:
-    https://iceberg.apache.org/spec/?column-projection#row-lineage
-    """
-
     next_row_id: Optional[int] = Field(alias="next-row-id", default=None)
     """A long higher than all assigned row IDs; the next snapshot's `first-row-id`."""
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

Closes #1974.

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

See https://github.com/apache/iceberg-python/issues/1974 description.

# Are these changes tested?

N/A.

# Are there any user-facing changes?

I don't think we need to consider user-facing changes because it involves V3 which is liable to change.