### PR TITLE
Add Avro compression

### DIFF
--- a/pyiceberg/avro/codecs/__init__.py
+++ b/pyiceberg/avro/codecs/__init__.py
@@ -26,7 +26,7 @@ converting character sets (https://docs.python.org/3/library/codecs.html).
 
 from __future__ import annotations
 
-from typing import Dict, Optional, Type
+from typing import Dict, Literal, Optional, Type, TypeAlias
 
 from pyiceberg.avro.codecs.bzip2 import BZip2Codec
 from pyiceberg.avro.codecs.codec import Codec
@@ -34,7 +34,11 @@ from pyiceberg.avro.codecs.deflate import DeflateCodec
 from pyiceberg.avro.codecs.snappy_codec import SnappyCodec
 from pyiceberg.avro.codecs.zstandard_codec import ZStandardCodec
 
-KNOWN_CODECS: Dict[str, Optional[Type[Codec]]] = {
+AvroCompressionCodec: TypeAlias = Literal["null", "bzip2", "snappy", "zstandard", "deflate"]
+
+AVRO_CODEC_KEY = "avro.codec"
+
+KNOWN_CODECS: Dict[AvroCompressionCodec, Optional[Type[Codec]]] = {
     "null": None,
     "bzip2": BZip2Codec,
     "snappy": SnappyCodec,

--- a/pyiceberg/avro/file.py
+++ b/pyiceberg/avro/file.py
@@ -284,14 +284,9 @@ class AvroOutputFile(Generic[D]):
             codec = "deflate"
 
         json_schema = json.dumps(AvroSchemaConversion().iceberg_to_avro(self.file_schema, schema_name=self.schema_name))
-<<<<<<< Updated upstream
-        meta = {**self.metadata, _SCHEMA_KEY: json_schema, _CODEC_KEY: "null"}
+
+        meta = {**self.metadata, _SCHEMA_KEY: json_schema, AVRO_CODEC_KEY: codec}
         header = AvroFileHeader(MAGIC, meta, self.sync_bytes)
-=======
-        header = AvroFileHeader(
-            magic=MAGIC, meta={**self.metadata, _SCHEMA_KEY: json_schema, AVRO_CODEC_KEY: codec}, sync=self.sync_bytes
-        )
->>>>>>> Stashed changes
         construct_writer(META_SCHEMA).write(self.encoder, header)
 
     def compression_codec(self) -> Optional[Type[Codec]]:

--- a/pyiceberg/avro/file.py
+++ b/pyiceberg/avro/file.py
@@ -35,7 +35,7 @@ from typing import (
     TypeVar,
 )
 
-from pyiceberg.avro.codecs import KNOWN_CODECS
+from pyiceberg.avro.codecs import AVRO_CODEC_KEY, KNOWN_CODECS
 from pyiceberg.avro.codecs.codec import Codec
 from pyiceberg.avro.decoder import BinaryDecoder, new_decoder
 from pyiceberg.avro.encoder import BinaryEncoder
@@ -69,7 +69,6 @@ META_SCHEMA = StructType(
     NestedField(field_id=300, name="sync", field_type=FixedType(length=SYNC_SIZE), required=True),
 )
 
-_CODEC_KEY = "avro.codec"
 _SCHEMA_KEY = "avro.schema"
 
 
@@ -92,11 +91,13 @@ class AvroFileHeader(Record):
         In the case of a null codec, we return a None indicating that we
         don't need to compress/decompress.
         """
-        codec_name = self.meta.get(_CODEC_KEY, "null")
+        from pyiceberg.table import TableProperties
+
+        codec_name = self.meta.get(AVRO_CODEC_KEY, TableProperties.WRITE_AVRO_COMPRESSION_DEFAULT)
         if codec_name not in KNOWN_CODECS:
             raise ValueError(f"Unsupported codec: {codec_name}")
 
-        return KNOWN_CODECS[codec_name]
+        return KNOWN_CODECS[codec_name]  # type: ignore
 
     def get_schema(self) -> Schema:
         if _SCHEMA_KEY in self.meta:
@@ -276,10 +277,40 @@ class AvroOutputFile(Generic[D]):
         self.output_stream.close()
 
     def _write_header(self) -> None:
+        from pyiceberg.table import TableProperties
+
+        codec = self.metadata.get(AVRO_CODEC_KEY, TableProperties.WRITE_AVRO_COMPRESSION_DEFAULT)
+        if codec == "gzip":
+            codec = "deflate"
+
         json_schema = json.dumps(AvroSchemaConversion().iceberg_to_avro(self.file_schema, schema_name=self.schema_name))
+<<<<<<< Updated upstream
         meta = {**self.metadata, _SCHEMA_KEY: json_schema, _CODEC_KEY: "null"}
         header = AvroFileHeader(MAGIC, meta, self.sync_bytes)
+=======
+        header = AvroFileHeader(
+            magic=MAGIC, meta={**self.metadata, _SCHEMA_KEY: json_schema, AVRO_CODEC_KEY: codec}, sync=self.sync_bytes
+        )
+>>>>>>> Stashed changes
         construct_writer(META_SCHEMA).write(self.encoder, header)
+
+    def compression_codec(self) -> Optional[Type[Codec]]:
+        """Get the file's compression codec algorithm from the file's metadata.
+
+        In the case of a null codec, we return a None indicating that we
+        don't need to compress/decompress.
+        """
+        from pyiceberg.table import TableProperties
+
+        codec_name = self.metadata.get(AVRO_CODEC_KEY, TableProperties.WRITE_AVRO_COMPRESSION_DEFAULT)
+
+        if codec_name == "gzip":
+            codec_name = "deflate"
+
+        if codec_name not in KNOWN_CODECS:
+            raise ValueError(f"Unsupported codec: {codec_name}")
+
+        return KNOWN_CODECS[codec_name]  # type: ignore
 
     def write_block(self, objects: List[D]) -> None:
         in_memory = io.BytesIO()
@@ -289,6 +320,13 @@ class AvroOutputFile(Generic[D]):
         block_content = in_memory.getvalue()
 
         self.encoder.write_int(len(objects))
-        self.encoder.write_int(len(block_content))
-        self.encoder.write(block_content)
+
+        if codec := self.compression_codec():
+            content, content_length = codec.compress(block_content)
+            self.encoder.write_int(content_length)
+            self.encoder.write(content)
+        else:
+            self.encoder.write_int(len(block_content))
+            self.encoder.write(block_content)
+
         self.encoder.write(self.sync_bytes)

--- a/pyiceberg/manifest.py
+++ b/pyiceberg/manifest.py
@@ -799,7 +799,6 @@ class ManifestWriter(ABC):
     _deleted_rows: int
     _min_sequence_number: Optional[int]
     _partitions: List[Record]
-    _reused_entry_wrapper: ManifestEntry
     _compression: AvroCompressionCodec
 
     def __init__(
@@ -824,11 +823,7 @@ class ManifestWriter(ABC):
         self._deleted_rows = 0
         self._min_sequence_number = None
         self._partitions = []
-<<<<<<< Updated upstream
-=======
-        self._reused_entry_wrapper = ManifestEntry()
         self._compression = avro_compression
->>>>>>> Stashed changes
 
     def __enter__(self) -> ManifestWriter:
         """Open the writer."""

--- a/pyiceberg/serializers.py
+++ b/pyiceberg/serializers.py
@@ -19,12 +19,14 @@ from __future__ import annotations
 import codecs
 import gzip
 from abc import ABC, abstractmethod
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 from pyiceberg.io import InputFile, InputStream, OutputFile
-from pyiceberg.table.metadata import TableMetadata, TableMetadataUtil
 from pyiceberg.typedef import UTF8
 from pyiceberg.utils.config import Config
+
+if TYPE_CHECKING:
+    from pyiceberg.table.metadata import TableMetadata
 
 GZIP = "gzip"
 
@@ -79,7 +81,7 @@ class FromByteStream:
     @staticmethod
     def table_metadata(
         byte_stream: InputStream, encoding: str = UTF8, compression: Compressor = NOOP_COMPRESSOR
-    ) -> TableMetadata:
+    ) -> "TableMetadata":
         """Instantiate a TableMetadata object from a byte stream.
 
         Args:
@@ -92,6 +94,8 @@ class FromByteStream:
             json_bytes = reader(byte_stream)
             metadata = json_bytes.read()
 
+        from pyiceberg.table.metadata import TableMetadataUtil
+
         return TableMetadataUtil.parse_raw(metadata)
 
 
@@ -99,7 +103,7 @@ class FromInputFile:
     """A collection of methods that deserialize InputFiles into Iceberg objects."""
 
     @staticmethod
-    def table_metadata(input_file: InputFile, encoding: str = UTF8) -> TableMetadata:
+    def table_metadata(input_file: InputFile, encoding: str = UTF8) -> "TableMetadata":
         """Create a TableMetadata instance from an input file.
 
         Args:
@@ -120,7 +124,7 @@ class ToOutputFile:
     """A collection of methods that serialize Iceberg objects into files given an OutputFile instance."""
 
     @staticmethod
-    def table_metadata(metadata: TableMetadata, output_file: OutputFile, overwrite: bool = False) -> None:
+    def table_metadata(metadata: "TableMetadata", output_file: OutputFile, overwrite: bool = False) -> None:
         """Write a TableMetadata instance to an output file.
 
         Args:

--- a/pyiceberg/serializers.py
+++ b/pyiceberg/serializers.py
@@ -19,14 +19,12 @@ from __future__ import annotations
 import codecs
 import gzip
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Callable
+from typing import Callable
 
 from pyiceberg.io import InputFile, InputStream, OutputFile
+from pyiceberg.table.metadata import TableMetadata, TableMetadataUtil
 from pyiceberg.typedef import UTF8
 from pyiceberg.utils.config import Config
-
-if TYPE_CHECKING:
-    from pyiceberg.table.metadata import TableMetadata
 
 GZIP = "gzip"
 
@@ -81,7 +79,7 @@ class FromByteStream:
     @staticmethod
     def table_metadata(
         byte_stream: InputStream, encoding: str = UTF8, compression: Compressor = NOOP_COMPRESSOR
-    ) -> "TableMetadata":
+    ) -> TableMetadata:
         """Instantiate a TableMetadata object from a byte stream.
 
         Args:
@@ -94,8 +92,6 @@ class FromByteStream:
             json_bytes = reader(byte_stream)
             metadata = json_bytes.read()
 
-        from pyiceberg.table.metadata import TableMetadataUtil
-
         return TableMetadataUtil.parse_raw(metadata)
 
 
@@ -103,7 +99,7 @@ class FromInputFile:
     """A collection of methods that deserialize InputFiles into Iceberg objects."""
 
     @staticmethod
-    def table_metadata(input_file: InputFile, encoding: str = UTF8) -> "TableMetadata":
+    def table_metadata(input_file: InputFile, encoding: str = UTF8) -> TableMetadata:
         """Create a TableMetadata instance from an input file.
 
         Args:
@@ -124,7 +120,7 @@ class ToOutputFile:
     """A collection of methods that serialize Iceberg objects into files given an OutputFile instance."""
 
     @staticmethod
-    def table_metadata(metadata: "TableMetadata", output_file: OutputFile, overwrite: bool = False) -> None:
+    def table_metadata(metadata: TableMetadata, output_file: OutputFile, overwrite: bool = False) -> None:
         """Write a TableMetadata instance to an output file.
 
         Args:

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -192,6 +192,9 @@ class TableProperties:
     WRITE_TARGET_FILE_SIZE_BYTES = "write.target-file-size-bytes"
     WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT = 512 * 1024 * 1024  # 512 MB
 
+    WRITE_AVRO_COMPRESSION = "write.avro.compression-codec"
+    WRITE_AVRO_COMPRESSION_DEFAULT = "gzip"
+
     DEFAULT_WRITE_METRICS_MODE = "write.metadata.metrics.default"
     DEFAULT_WRITE_METRICS_MODE_DEFAULT = "truncate(16)"
 

--- a/pyiceberg/table/update/snapshot.py
+++ b/pyiceberg/table/update/snapshot.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Callable, Dict, Generic, List, Optional, Set, 
 
 from sortedcontainers import SortedList
 
+from pyiceberg.avro.codecs import AvroCompressionCodec
 from pyiceberg.expressions import (
     AlwaysFalse,
     BooleanExpression,
@@ -104,6 +105,7 @@ class _SnapshotProducer(UpdateTableMetadata[U], Generic[U]):
     _added_data_files: List[DataFile]
     _manifest_num_counter: itertools.count[int]
     _deleted_data_files: Set[DataFile]
+    _compression: AvroCompressionCodec
 
     def __init__(
         self,
@@ -126,6 +128,11 @@ class _SnapshotProducer(UpdateTableMetadata[U], Generic[U]):
         self._deleted_data_files = set()
         self.snapshot_properties = snapshot_properties
         self._manifest_num_counter = itertools.count(0)
+        from pyiceberg.table import TableProperties
+
+        self._compression = self._transaction.table_metadata.properties.get(  # type: ignore
+            TableProperties.WRITE_AVRO_COMPRESSION, TableProperties.WRITE_AVRO_COMPRESSION_DEFAULT
+        )
 
     def append_data_file(self, data_file: DataFile) -> _SnapshotProducer[U]:
         self._added_data_files.append(data_file)
@@ -154,6 +161,7 @@ class _SnapshotProducer(UpdateTableMetadata[U], Generic[U]):
                     schema=self._transaction.table_metadata.schema(),
                     output_file=self.new_manifest_output(),
                     snapshot_id=self._snapshot_id,
+                    avro_compression=self._compression,
                 ) as writer:
                     for data_file in self._added_data_files:
                         writer.add(
@@ -184,6 +192,7 @@ class _SnapshotProducer(UpdateTableMetadata[U], Generic[U]):
                         schema=self._transaction.table_metadata.schema(),
                         output_file=self.new_manifest_output(),
                         snapshot_id=self._snapshot_id,
+                        avro_compression=self._compression,
                     ) as writer:
                         for entry in entries:
                             writer.add_entry(entry)
@@ -249,12 +258,14 @@ class _SnapshotProducer(UpdateTableMetadata[U], Generic[U]):
         )
         location_provider = self._transaction._table.location_provider()
         manifest_list_file_path = location_provider.new_metadata_location(file_name)
+
         with write_manifest_list(
             format_version=self._transaction.table_metadata.format_version,
             output_file=self._io.new_output(manifest_list_file_path),
             snapshot_id=self._snapshot_id,
             parent_snapshot_id=self._parent_snapshot_id,
             sequence_number=next_sequence_number,
+            avro_compression=self._compression,
         ) as writer:
             writer.add_manifests(new_manifests)
 
@@ -291,6 +302,7 @@ class _SnapshotProducer(UpdateTableMetadata[U], Generic[U]):
             schema=self._transaction.table_metadata.schema(),
             output_file=self.new_manifest_output(),
             snapshot_id=self._snapshot_id,
+            avro_compression=self._compression,
         )
 
     def new_manifest_output(self) -> OutputFile:
@@ -416,6 +428,7 @@ class _DeleteFiles(_SnapshotProducer["_DeleteFiles"]):
                                     schema=self._transaction.table_metadata.schema(),
                                     output_file=self.new_manifest_output(),
                                     snapshot_id=self._snapshot_id,
+                                    avro_compression=self._compression,
                                 ) as writer:
                                     for existing_entry in existing_entries:
                                         writer.add_entry(existing_entry)
@@ -550,6 +563,7 @@ class _OverwriteFiles(_SnapshotProducer["_OverwriteFiles"]):
                             schema=self._transaction.table_metadata.schema(),
                             output_file=self.new_manifest_output(),
                             snapshot_id=self._snapshot_id,
+                            avro_compression=self._compression,
                         ) as writer:
                             [
                                 writer.add_entry(

--- a/tests/utils/test_manifest.py
+++ b/tests/utils/test_manifest.py
@@ -22,6 +22,7 @@ from unittest.mock import patch
 import fastavro
 import pytest
 
+from pyiceberg.avro.codecs import AvroCompressionCodec
 from pyiceberg.io import load_file_io
 from pyiceberg.io.pyarrow import PyArrowFileIO
 from pyiceberg.manifest import (
@@ -351,13 +352,18 @@ def test_write_empty_manifest() -> None:
                 schema=test_schema,
                 output_file=io.new_output(tmp_avro_file),
                 snapshot_id=8744736658442914487,
+                avro_compression="deflate",
             ) as _:
                 pass
 
 
 @pytest.mark.parametrize("format_version", [1, 2])
+@pytest.mark.parametrize("compression", ["null", "deflate"])
 def test_write_manifest(
-    generated_manifest_file_file_v1: str, generated_manifest_file_file_v2: str, format_version: TableVersion
+    generated_manifest_file_file_v1: str,
+    generated_manifest_file_file_v2: str,
+    format_version: TableVersion,
+    compression: AvroCompressionCodec,
 ) -> None:
     io = load_file_io()
     snapshot = Snapshot(
@@ -387,6 +393,7 @@ def test_write_manifest(
             schema=test_schema,
             output_file=output,
             snapshot_id=8744736658442914487,
+            avro_compression=compression,
         ) as writer:
             for entry in manifest_entries:
                 writer.add_entry(entry)
@@ -527,11 +534,13 @@ def test_write_manifest(
 
 @pytest.mark.parametrize("format_version", [1, 2])
 @pytest.mark.parametrize("parent_snapshot_id", [19, None])
+@pytest.mark.parametrize("compression", ["null", "deflate"])
 def test_write_manifest_list(
     generated_manifest_file_file_v1: str,
     generated_manifest_file_file_v2: str,
     format_version: TableVersion,
     parent_snapshot_id: Optional[int],
+    compression: AvroCompressionCodec,
 ) -> None:
     io = load_file_io()
 
@@ -554,6 +563,7 @@ def test_write_manifest_list(
             snapshot_id=25,
             parent_snapshot_id=parent_snapshot_id,
             sequence_number=0,
+            avro_compression=compression,
         ) as writer:
             writer.add_manifests(demo_manifest_list)
         new_manifest_list = list(read_manifest_list(io.new_input(path)))


### PR DESCRIPTION
# Rationale for this change

PyIceberg did not compress the Avro. This will make gzip/deflate the same as in Java.

# Are these changes tested?

Existing round-trip tests with FastAvro and Spark. Some tests are extended to both write compressed and uncompressed data.

# Are there any user-facing changes?

Smaller and faster manifest files :)

<!-- In the case of user-facing changes, please add the changelog label. -->
