### PR TITLE
Hive: update hive storage descriptor after commit schema change

### DIFF
--- a/dev/hive/core-site.xml
+++ b/dev/hive/core-site.xml
@@ -50,4 +50,9 @@
       <name>fs.s3a.path.style.access</name>
       <value>true</value>
     </property>
+    <property>
+      <name>hive.metastore.disallow.incompatible.col.type.changes</name>
+      <value>false</value>
+    </property>
+
 </configuration>

--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -542,6 +542,12 @@ class HiveCatalog(MetastoreCatalog):
                         metadata_location=updated_staged_table.metadata_location,
                         previous_metadata_location=current_table.metadata_location,
                     )
+                    # Update hive's schema and properties
+                    hive_table.sd = _construct_hive_storage_descriptor(
+                        updated_staged_table.schema(),
+                        updated_staged_table.location(),
+                        property_as_bool(updated_staged_table.properties, HIVE2_COMPATIBLE, HIVE2_COMPATIBLE_DEFAULT),
+                    )
                     open_client.alter_table_with_environment_context(
                         dbname=database_name,
                         tbl_name=table_name,


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
Like iceberg jar, we should also update hive storage descriptor after commit metadata

see: https://github.com/apache/iceberg/blob/b504f9c51c6c0e0a5c0c5ff53f295e69b67d8e59/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java#L170

# Are these changes tested?
new UTs

# Are there any user-facing changes?
No


<!-- In the case of user-facing changes, please add the changelog label. -->
