### PR TITLE
Make `validation_history` private before release

### DIFF
--- a/pyiceberg/table/update/validate.py
+++ b/pyiceberg/table/update/validate.py
@@ -27,7 +27,7 @@ from pyiceberg.typedef import Record
 VALIDATE_DATA_FILES_EXIST_OPERATIONS = {Operation.OVERWRITE, Operation.REPLACE, Operation.DELETE}
 
 
-def validation_history(
+def _validation_history(
     table: Table,
     from_snapshot: Snapshot,
     to_snapshot: Snapshot,
@@ -100,7 +100,7 @@ def _deleted_data_files(
     if parent_snapshot is None:
         return
 
-    manifests, snapshot_ids = validation_history(
+    manifests, snapshot_ids = _validation_history(
         table,
         parent_snapshot,
         starting_snapshot,

--- a/tests/table/test_validate.py
+++ b/tests/table/test_validate.py
@@ -25,7 +25,7 @@ from pyiceberg.io import FileIO
 from pyiceberg.manifest import ManifestContent, ManifestEntry, ManifestEntryStatus, ManifestFile
 from pyiceberg.table import Table
 from pyiceberg.table.snapshots import Operation, Snapshot, Summary
-from pyiceberg.table.update.validate import _deleted_data_files, _validate_deleted_data_files, validation_history
+from pyiceberg.table.update.validate import _deleted_data_files, _validate_deleted_data_files, _validation_history
 
 
 @pytest.fixture
@@ -69,7 +69,7 @@ def test_validation_history(table_v2_with_extensive_snapshots_and_manifests: tup
         return []
 
     with patch("pyiceberg.table.snapshots.Snapshot.manifests", new=mock_read_manifest_side_effect):
-        manifests, snapshots = validation_history(
+        manifests, snapshots = _validation_history(
             table,
             oldest_snapshot,
             newest_snapshot,
@@ -99,7 +99,7 @@ def test_validation_history_fails_on_snapshot_with_no_summary(
     )
     with patch("pyiceberg.table.update.validate.ancestors_between", return_value=[snapshot_with_no_summary]):
         with pytest.raises(ValidationException):
-            validation_history(
+            _validation_history(
                 table,
                 oldest_snapshot,
                 newest_snapshot,
@@ -129,7 +129,7 @@ def test_validation_history_fails_on_from_snapshot_not_matching_last_snapshot(
     with patch("pyiceberg.table.snapshots.Snapshot.manifests", new=mock_read_manifest_side_effect):
         with patch("pyiceberg.table.update.validate.ancestors_between", return_value=missing_oldest_snapshot):
             with pytest.raises(ValidationException):
-                validation_history(
+                _validation_history(
                     table,
                     oldest_snapshot,
                     newest_snapshot,


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

`validation_history` is a helper function that will be used for checking for newly added manifests. Hence it would make sense to make this function private before it is released.

# Are these changes tested?

Yes, integration tests and unit tests.

# Are there any user-facing changes?

This function has yet to be released