### PR TITLE
maint: let requests handle params formatting

### DIFF
--- a/pyiceberg/catalog/rest/__init__.py
+++ b/pyiceberg/catalog/rest/__init__.py
@@ -613,8 +613,7 @@ class RestCatalog(Catalog):
 
     @retry(**_RETRY_ARGS)
     def list_tables(
-        self, namespace: Union[str, Identifier], page_token: str | None = None, page_size: int | None = None
-    ) -> List[Identifier]:
+        self, namespace: Union[str, Identifier]) -> List[Identifier]:
         namespace_tuple = self._check_valid_namespace_identifier(namespace)
         namespace_concat = NAMESPACE_SEPARATOR.join(namespace_tuple)
         response = self._session.get(self.url(Endpoints.list_tables, namespace=namespace_concat))

--- a/pyiceberg/catalog/rest/__init__.py
+++ b/pyiceberg/catalog/rest/__init__.py
@@ -14,7 +14,6 @@
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-import re
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
@@ -81,9 +80,6 @@ if TYPE_CHECKING:
     import pyarrow as pa
 
 ICEBERG_REST_SPEC_VERSION = "0.14.1"
-
-
-CAMEL_TO_SNAKE_CASE_PATTERN = re.compile(r"(?<!^)(?=[A-Z])")
 
 
 class Endpoints:

--- a/pyiceberg/catalog/rest/__init__.py
+++ b/pyiceberg/catalog/rest/__init__.py
@@ -125,6 +125,8 @@ def _get_endpoint_params(endpoint: str, **kwargs: Any) -> dict[str, Any] | None:
     _params = {}
     for camel, snake in snake_case_query_params.items():
         if snake in kwargs:
+            if kwargs[snake] is None:
+                continue
             _params[camel] = kwargs[snake]
 
     return _params

--- a/pyiceberg/catalog/rest/__init__.py
+++ b/pyiceberg/catalog/rest/__init__.py
@@ -612,8 +612,7 @@ class RestCatalog(Catalog):
         return self._response_to_table(self.identifier_to_tuple(identifier), table_response)
 
     @retry(**_RETRY_ARGS)
-    def list_tables(
-        self, namespace: Union[str, Identifier]) -> List[Identifier]:
+    def list_tables(self, namespace: Union[str, Identifier]) -> List[Identifier]:
         namespace_tuple = self._check_valid_namespace_identifier(namespace)
         namespace_concat = NAMESPACE_SEPARATOR.join(namespace_tuple)
         response = self._session.get(self.url(Endpoints.list_tables, namespace=namespace_concat))

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -24,7 +24,7 @@ from requests_mock import Mocker
 
 import pyiceberg
 from pyiceberg.catalog import PropertiesUpdateSummary, load_catalog
-from pyiceberg.catalog.rest import OAUTH2_SERVER_URI, SNAPSHOT_LOADING_MODE, RestCatalog
+from pyiceberg.catalog.rest import OAUTH2_SERVER_URI, SNAPSHOT_LOADING_MODE, Endpoints, RestCatalog, _get_endpoint_params
 from pyiceberg.exceptions import (
     AuthorizationExpiredError,
     NamespaceAlreadyExistsError,
@@ -1621,3 +1621,10 @@ def test_drop_view_204(rest_mock: Mocker) -> None:
         request_headers=TEST_HEADERS,
     )
     RestCatalog("rest", uri=TEST_URI, token=TEST_TOKEN).drop_view(("some_namespace", "some_view"))
+
+
+def test_get_endpoint_params() -> None:
+    params = _get_endpoint_params(Endpoints.drop_table, purge_requested=True)
+    assert params == {
+        "purgeRequested": True,
+    }

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -24,7 +24,7 @@ from requests_mock import Mocker
 
 import pyiceberg
 from pyiceberg.catalog import PropertiesUpdateSummary, load_catalog
-from pyiceberg.catalog.rest import OAUTH2_SERVER_URI, SNAPSHOT_LOADING_MODE, Endpoints, RestCatalog, _get_endpoint_params
+from pyiceberg.catalog.rest import OAUTH2_SERVER_URI, SNAPSHOT_LOADING_MODE, RestCatalog
 from pyiceberg.exceptions import (
     AuthorizationExpiredError,
     NamespaceAlreadyExistsError,
@@ -1621,15 +1621,3 @@ def test_drop_view_204(rest_mock: Mocker) -> None:
         request_headers=TEST_HEADERS,
     )
     RestCatalog("rest", uri=TEST_URI, token=TEST_TOKEN).drop_view(("some_namespace", "some_view"))
-
-
-def test_get_endpoint_params() -> None:
-    params = _get_endpoint_params(Endpoints.drop_table, purge_requested=True)
-    assert params == {
-        "purgeRequested": True,
-    }
-
-
-def test_get_endpoint_with_no_params() -> None:
-    params = _get_endpoint_params(Endpoints.namespace_exists, purge_requested=True)
-    assert params is None

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -1628,3 +1628,8 @@ def test_get_endpoint_params() -> None:
     assert params == {
         "purgeRequested": True,
     }
+
+
+def test_get_endpoint_with_no_params() -> None:
+    params = _get_endpoint_params(Endpoints.namespace_exists, purge_requested=True)
+    assert params is None


### PR DESCRIPTION
Let `requests` handle dealing with params instead of using `.format` on a templated string.
