### PR TITLE
feat: support listing known catalogs

### DIFF
--- a/pyiceberg/catalog/__init__.py
+++ b/pyiceberg/catalog/__init__.py
@@ -262,6 +262,10 @@ def load_catalog(name: Optional[str] = None, **properties: Optional[str]) -> Cat
     raise ValueError(f"Could not initialize catalog with the following properties: {properties}")
 
 
+def list_catalogs() -> List[str]:
+    return _ENV_CONFIG.get_known_catalogs()
+
+
 def delete_files(io: FileIO, files_to_delete: Set[str], file_type: str) -> None:
     """Delete files.
 

--- a/pyiceberg/utils/config.py
+++ b/pyiceberg/utils/config.py
@@ -159,6 +159,12 @@ class Config:
                 return catalog_conf
         return None
 
+    def get_known_catalogs(self) -> List[str]:
+        catalogs = self.config.get(CATALOG, {})
+        if not isinstance(catalogs, dict):
+            raise ValueError("Catalog configurations needs to be an object")
+        return list(catalogs.keys())
+
     def get_int(self, key: str) -> Optional[int]:
         if (val := self.config.get(key)) is not None:
             try:

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -56,6 +56,15 @@ def test_fix_nested_objects_from_environment_variables() -> None:
     }
 
 
+@mock.patch.dict(os.environ, EXAMPLE_ENV)
+@mock.patch.dict(os.environ, {"PYICEBERG_CATALOG__DEVELOPMENT__URI": "https://dev.service.io/api"})
+def test_list_all_known_catalogs() -> None:
+    assert Config().get_known_catalogs() == [
+        "production",
+        "development",
+    ]
+
+
 def test_from_configuration_files(tmp_path_factory: pytest.TempPathFactory) -> None:
     config_path = str(tmp_path_factory.mktemp("config"))
     with open(f"{config_path}/.pyiceberg.yaml", "w", encoding=UTF8) as file:


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

Adds a new function `pyiceberg.catalog.list_catalogs() -> List[str]` to list all known catalogs.

# Rationale for this change
In creating a pyiceberg-backed API, one must either duplicate the config-parsing logic or access private data in order to know what catalogs are available in the env. I believe that this logic should be part of the library. 

# Are these changes tested?
Yes

# Are there any user-facing changes?
Yes, knew public function in `pyiceberg.catalog`

<!-- In the case of user-facing changes, please add the changelog label. -->
