### PR TITLE
fix: add metadata_properties to _construct_parameters when updating glue table

### DIFF
--- a/pyiceberg/catalog/glue.py
+++ b/pyiceberg/catalog/glue.py
@@ -140,12 +140,20 @@ EXISTING_RETRY_MODES = [STANDARD_RETRY_MODE, ADAPTIVE_RETRY_MODE, LEGACY_RETRY_M
 
 
 def _construct_parameters(
-    metadata_location: str, glue_table: Optional["TableTypeDef"] = None, prev_metadata_location: Optional[str] = None
+    metadata_location: str,
+    glue_table: Optional["TableTypeDef"] = None,
+    prev_metadata_location: Optional[str] = None,
+    metadata_properties: Optional[Properties] = None,
 ) -> Properties:
     new_parameters = glue_table.get("Parameters", {}) if glue_table else {}
     new_parameters.update({TABLE_TYPE: ICEBERG.upper(), METADATA_LOCATION: metadata_location})
     if prev_metadata_location:
         new_parameters[PREVIOUS_METADATA_LOCATION] = prev_metadata_location
+
+    if metadata_properties:
+        for key, value in metadata_properties.items():
+            new_parameters[key] = str(value)
+
     return new_parameters
 
 
@@ -236,7 +244,7 @@ def _construct_table_input(
     table_input: "TableInputTypeDef" = {
         "Name": table_name,
         "TableType": EXTERNAL_TABLE,
-        "Parameters": _construct_parameters(metadata_location, glue_table, prev_metadata_location),
+        "Parameters": _construct_parameters(metadata_location, glue_table, prev_metadata_location, properties),
         "StorageDescriptor": {
             "Columns": _to_columns(metadata),
             "Location": metadata.location,

--- a/tests/catalog/test_glue.py
+++ b/tests/catalog/test_glue.py
@@ -791,6 +791,8 @@ def test_commit_table_properties(
         Name=table_name,
     )
     assert table_info["Table"]["Description"] == "test_description"
+    assert table_info["Table"]["Parameters"]["test_a"] == "test_aa"
+    assert table_info["Table"]["Parameters"]["test_c"] == "test_c"
 
 
 @mock_aws


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

See https://github.com/apache/iceberg-python/pull/2013
Closes https://github.com/apache/iceberg-python/issues/2064

Continuing the trend, but with glue.

# Are these changes tested?

See test below

# Are there any user-facing changes?

When a user specifies property update on commit table, those parameters will be passed to the glue client.

<!-- In the case of user-facing changes, please add the changelog label. -->
