### PR TITLE
Add deprecation message for source-id

### DIFF
--- a/pyiceberg/partitioning.py
+++ b/pyiceberg/partitioning.py
@@ -59,6 +59,7 @@ from pyiceberg.types import (
     UUIDType,
 )
 from pyiceberg.utils.datetime import date_to_days, datetime_to_micros, time_to_micros
+from pyiceberg.utils.deprecated import deprecation_message
 
 INITIAL_PARTITION_SPEC_ID = 0
 PARTITION_FIELD_ID_START: int = 1000
@@ -100,6 +101,13 @@ class PartitionField(IcebergBaseModel):
             data["transform"] = transform
         if name is not None:
             data["name"] = name
+
+        if data["source-id"]:
+            deprecation_message(
+                deprecated_in="0.10.0",
+                removed_in="0.11.0",
+                help_message="source-id is not allowed for Iceberg v3. Please use source-ids instead.",
+            )
 
         super().__init__(**data)
 

--- a/pyiceberg/table/sorting.py
+++ b/pyiceberg/table/sorting.py
@@ -30,6 +30,7 @@ from pyiceberg.schema import Schema
 from pyiceberg.transforms import IdentityTransform, Transform, parse_transform
 from pyiceberg.typedef import IcebergBaseModel
 from pyiceberg.types import IcebergType
+from pyiceberg.utils.deprecated import deprecation_message
 
 
 class SortDirection(Enum):
@@ -85,6 +86,14 @@ class SortField(IcebergBaseModel):
             data["direction"] = direction
         if null_order is not None:
             data["null-order"] = null_order
+
+        if data["source-id"]:
+            deprecation_message(
+                deprecated_in="0.10.0",
+                removed_in="0.11.0",
+                help_message="source-id is not allowed for Iceberg v3. Please use source-ids instead.",
+            )
+
         super().__init__(**data)
 
     @model_validator(mode="before")


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
Closes #1547 

# Rationale for this change
Iceberg v3 does not support `source-id` and only supports `source-ids`. Meanwhile, Iceberg v2 only supports `source-id`.
Right now, it appears that all versions of Iceberg support both `source-id` and `source-ids`.

This PR does what #1547 asks and deprecates `source-id`. It seems like the most proper thing to do would be to make these fields aware of the Iceberg format version and then error out accordingly. But, I wanted to get everyone's opinion before I go down that path.

