### PR TITLE
[Avro] Accept dict with only `'type': 'null'` as representation of `null`

### DIFF
--- a/pyiceberg/utils/schema_conversion.py
+++ b/pyiceberg/utils/schema_conversion.py
@@ -171,11 +171,11 @@ class AvroSchemaConversion:
         # This means that null has to come first:
         # https://avro.apache.org/docs/current/spec.html
         # type of the default value must match the first element of the union.
-        if "null" != avro_types[0]:
-            raise TypeError("Only null-unions are supported")
+        if avro_types[0] != "null" and avro_types[0] != {'type': 'null'}:
+            raise TypeError(f"Only null-unions are supported, not: {avro_types[0]}")
 
         # Filter the null value and return the type
-        return list(filter(lambda t: t != "null", avro_types))[0], False
+        return list(filter(lambda t: t != "null" and t != {'type': 'null'}, avro_types))[0], False
 
     def _convert_schema(self, avro_type: Union[str, Dict[str, Any]]) -> IcebergType:
         """

--- a/pyiceberg/utils/schema_conversion.py
+++ b/pyiceberg/utils/schema_conversion.py
@@ -171,11 +171,11 @@ class AvroSchemaConversion:
         # This means that null has to come first:
         # https://avro.apache.org/docs/current/spec.html
         # type of the default value must match the first element of the union.
-        if avro_types[0] != "null" and avro_types[0] != {'type': 'null'}:
+        if avro_types[0] != "null" and avro_types[0] != {"type": "null"}:
             raise TypeError(f"Only null-unions are supported, not: {avro_types[0]}")
 
         # Filter the null value and return the type
-        return list(filter(lambda t: t != "null" and t != {'type': 'null'}, avro_types))[0], False
+        return list(filter(lambda t: t != "null" and t != {"type": "null"}, avro_types))[0], False
 
     def _convert_schema(self, avro_type: Union[str, Dict[str, Any]]) -> IcebergType:
         """


### PR DESCRIPTION
This PR makes it so that a different serialization of the `null` type is accepted, this variation is produced by `avro-c` (`apache/avro`'s  `c` lang implementation)


Problem described in https://github.com/duckdb/duckdb-iceberg/pull/305#issuecomment-2979171652