### PR TITLE
fix config test when running locally

### DIFF
--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -59,10 +59,9 @@ def test_fix_nested_objects_from_environment_variables() -> None:
 @mock.patch.dict(os.environ, EXAMPLE_ENV)
 @mock.patch.dict(os.environ, {"PYICEBERG_CATALOG__DEVELOPMENT__URI": "https://dev.service.io/api"})
 def test_list_all_known_catalogs() -> None:
-    assert Config().get_known_catalogs() == [
-        "production",
-        "development",
-    ]
+    catalogs = Config().get_known_catalogs()
+    assert "production" in catalogs
+    assert "development" in catalogs
 
 
 def test_from_configuration_files(tmp_path_factory: pytest.TempPathFactory) -> None:


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
`make test` fails locally since `Config().get_known_catalogs()` also reads my local `~/.pyiceberg.yaml` 

Follow up to #2088

# Are these changes tested?

# Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
