### PR TITLE
Docs: fix manifest min count to merge description

### DIFF
--- a/mkdocs/docs/configuration.md
+++ b/mkdocs/docs/configuration.md
@@ -75,7 +75,7 @@ Iceberg tables support table properties to configure table behavior.
 | Key                                  | Options             | Default       | Description                                                 |
 | ------------------------------------ | ------------------- | ------------- | ----------------------------------------------------------- |
 | `commit.manifest.target-size-bytes`  | Size in bytes       | 8388608 (8MB) | Target size when merging manifest files                     |
-| `commit.manifest.min-count-to-merge` | Number of manifests | 100           | Target size when merging manifest files                     |
+| `commit.manifest.min-count-to-merge` | Number of manifests | 100           | Minimum number of manifests to accumulate before merging    |
 | `commit.manifest-merge.enabled`      | Boolean             | False         | Controls whether to automatically merge manifests on writes |
 
 <!-- prettier-ignore-start -->


### PR DESCRIPTION
# Rationale for this change

Fixing docs for [commit.manifest.min-count-to-merge](https://py.iceberg.apache.org/configuration/#table-behavior-options) py iceberg doc according to https://iceberg.apache.org/docs/1.5.2/configuration/#table-behavior-properties

# Are these changes tested?

Nope, but just fixing typo :)

# Are there any user-facing changes?

Nope
<!-- In the case of user-facing changes, please add the changelog label. -->
