### PR TITLE
Refactor `Makefile` and run s3/adls/gcs integration tests in CI

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -79,26 +79,27 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y libkrb5-dev # for kerberos
     - name: Install
       run: make install
+
     - name: Run integration tests
       run: make test-coverage-integration
     - name: Show debug logs
       if: ${{ failure() }}
       run: docker compose -f dev/docker-compose.yml logs
 
-  object-store-integration-test:
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        python: ['3.9', '3.10', '3.11', '3.12']
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Install system dependencies
-      run: sudo apt-get update && sudo apt-get install -y libkrb5-dev # for kerberos
-    - name: Install
-      run: make install
-    - name: Run object store integration tests
-      run: make test-coverage-object-store-integration
+    - name: Run s3 integration tests
+      run: make test-s3
     - name: Show debug logs
       if: ${{ failure() }}
       run: docker compose -f dev/docker-compose.yml logs
+
+    - name: Run adls integration tests
+      run: make test-adls
+    - name: Show debug logs
+      if: ${{ failure() }}
+      run: docker compose -f dev/docker-compose-azurite.yml logs
+
+    - name: Run gcs integration tests
+      run: make test-gcs
+    - name: Show debug logs
+      if: ${{ failure() }}
+      run: docker compose -f dev/docker-compose-gcs-server.yml logs

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -84,3 +84,21 @@ jobs:
     - name: Show debug logs
       if: ${{ failure() }}
       run: docker compose -f dev/docker-compose.yml logs
+
+  object-store-integration-test:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        python: ['3.9', '3.10', '3.11', '3.12']
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install system dependencies
+      run: sudo apt-get update && sudo apt-get install -y libkrb5-dev # for kerberos
+    - name: Install
+      run: make install
+    - name: Run object store integration tests
+      run: make test-coverage-object-store-integration
+    - name: Show debug logs
+      if: ${{ failure() }}
+      run: docker compose -f dev/docker-compose.yml logs

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -64,8 +64,10 @@ jobs:
       run: make install-dependencies
     - name: Run linters
       run: make lint
-    - name: Run unit tests
-      run: make test
+    - name: Run unit tests with coverage
+      run: COVERAGE=1 make test
+    - name: Generate coverage report
+      run: make coverage-report
 
   integration-test:
     runs-on: ubuntu-22.04
@@ -80,26 +82,29 @@ jobs:
     - name: Install
       run: make install
 
-    - name: Run integration tests
-      run: make test-integration
+    - name: Run integration tests with coverage
+      run: COVERAGE=1 make test-integration
     - name: Show debug logs
       if: ${{ failure() }}
       run: docker compose -f dev/docker-compose.yml logs
 
-    - name: Run s3 integration tests
-      run: make test-s3
+    - name: Run s3 integration tests with coverage
+      run: COVERAGE=1 make test-s3
     - name: Show debug logs
       if: ${{ failure() }}
       run: docker compose -f dev/docker-compose.yml logs
 
-    - name: Run adls integration tests
-      run: make test-adls
+    - name: Run adls integration tests with coverage
+      run: COVERAGE=1 make test-adls
     - name: Show debug logs
       if: ${{ failure() }}
       run: docker compose -f dev/docker-compose-azurite.yml logs
 
-    - name: Run gcs integration tests
-      run: make test-gcs
+    - name: Run gcs integration tests with coverage
+      run: COVERAGE=1 make test-gcs
     - name: Show debug logs
       if: ${{ failure() }}
       run: docker compose -f dev/docker-compose-gcs-server.yml logs
+
+    - name: Generate coverage report
+      run: make coverage-report

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -62,10 +62,10 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y libkrb5-dev # for kerberos
     - name: Install
       run: make install-dependencies
-    - name: Linters
+    - name: Run linters
       run: make lint
-    - name: Tests
-      run: make test-coverage-unit
+    - name: Run unit tests
+      run: make test
 
   integration-test:
     runs-on: ubuntu-22.04
@@ -81,7 +81,7 @@ jobs:
       run: make install
 
     - name: Run integration tests
-      run: make test-coverage-integration
+      run: make test-integration
     - name: Show debug logs
       if: ${{ failure() }}
       run: docker compose -f dev/docker-compose.yml logs

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -66,8 +66,8 @@ jobs:
       run: make lint
     - name: Run unit tests with coverage
       run: COVERAGE=1 make test
-    - name: Generate coverage report
-      run: make coverage-report
+    - name: Generate coverage report (85%) # Coverage threshold should only increase over time — never decrease it!
+      run: COVERAGE_FAIL_UNDER=85 make coverage-report
 
   integration-test:
     runs-on: ubuntu-22.04
@@ -106,5 +106,5 @@ jobs:
       if: ${{ failure() }}
       run: docker compose -f dev/docker-compose-gcs-server.yml logs
 
-    - name: Generate coverage report
-      run: make coverage-report
+    - name: Generate coverage report (75%) # Coverage threshold should only increase over time — never decrease it!
+      run: COVERAGE_FAIL_UNDER=75 make coverage-report

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ test-adls: ## Run tests marked with adls, can add arguments with PYTEST_ARGS="-v
 
 test-gcs: ## Run tests marked with gcs, can add arguments with PYTEST_ARGS="-vv"
 	sh ./dev/run-gcs-server.sh
-	poetry run  pytest tests/ -m gcs ${PYTEST_ARGS}
+	poetry run pytest tests/ -m gcs ${PYTEST_ARGS}
 
 test-coverage-unit: # Run test with coverage for unit tests, can add arguments with PYTEST_ARGS="-vv"
 	poetry run coverage run --source=pyiceberg/ --data-file=.coverage.unit -m pytest tests/ -v -m "(unmarked or parametrize) and not integration" ${PYTEST_ARGS}
@@ -85,14 +85,12 @@ test-coverage-integration: # Run test with coverage for integration tests, can a
 	docker compose -f dev/docker-compose-integration.yml kill
 	docker compose -f dev/docker-compose-integration.yml rm -f
 	docker compose -f dev/docker-compose-integration.yml up -d
-	sh ./dev/run-azurite.sh
-	sh ./dev/run-gcs-server.sh
 	sleep 10
 	docker compose -f dev/docker-compose-integration.yml cp ./dev/provision.py spark-iceberg:/opt/spark/provision.py
 	docker compose -f dev/docker-compose-integration.yml exec -T spark-iceberg ipython ./provision.py
 	poetry run coverage run --source=pyiceberg/ --data-file=.coverage.integration -m pytest tests/ -v -m integration ${PYTEST_ARGS}
 
-test-coverage: | test-coverage-unit test-coverage-integration ## Run all tests with coverage including unit and integration tests
+test-coverage: | test-coverage-unit test-coverage-integration test-s3 test-adls test-gcs ## Run all tests with coverage including unit and integration tests
 	poetry run coverage combine .coverage.unit .coverage.integration
 	poetry run coverage report -m --fail-under=90
 	poetry run coverage html

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,6 @@ test-coverage-unit: # Run test with coverage for unit tests, can add arguments w
 	poetry run coverage run --source=pyiceberg/ --data-file=.coverage.unit -m pytest tests/ -v -m "(unmarked or parametrize) and not integration" ${PYTEST_ARGS}
 
 test-coverage-integration: test-integration-setup test-object-store-integration # Run test with coverage for integration tests, can add arguments with PYTEST_ARGS="-vv"
-	docker compose -f dev/docker-compose-integration.yml exec -T spark-iceberg ipython ./provision.py
 	poetry run coverage run --source=pyiceberg/ --data-file=.coverage.integration -m pytest tests/ -v -m integration ${PYTEST_ARGS}
 
 test-coverage-object-store-integration: # Run test with coverage for object stores integration tests, can add arguments with PYTEST_ARGS="-vv"

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ test-coverage: test test-integration test-s3 test-adls test-gcs coverage-report 
 
 coverage-report: ## Combine and report coverage
 	poetry run coverage combine
-	poetry run coverage report -m --fail-under=90
+	poetry run coverage report -m --fail-under=85
 	poetry run coverage html
 	poetry run coverage xml
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@
 
 PYTEST_ARGS ?= -v  # Override with e.g. PYTEST_ARGS="-vv --tb=short"
 COVERAGE ?= 0      # Set COVERAGE=1 to enable coverage: make test COVERAGE=1
+COVERAGE_FAIL_UNDER ?= 85  # Minimum coverage % to pass: make coverage-report COVERAGE_FAIL_UNDER=70
 
 ifeq ($(COVERAGE),1)
   TEST_RUNNER = poetry run coverage run --parallel-mode --source=pyiceberg -m
@@ -119,7 +120,7 @@ test-coverage: test test-integration test-s3 test-adls test-gcs coverage-report 
 
 coverage-report: ## Combine and report coverage
 	poetry run coverage combine
-	poetry run coverage report -m --fail-under=85
+	poetry run coverage report -m --fail-under=$(COVERAGE_FAIL_UNDER)
 	poetry run coverage html
 	poetry run coverage xml
 

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,6 @@ test: ## Run all unit tests (excluding integration)
 	$(TEST_RUNNER) pytest tests/ -m "(unmarked or parametrize) and not integration" $(PYTEST_ARGS)
 
 test-integration: test-integration-setup test-integration-exec ## Run integration tests
-	$(TEST_RUNNER) pytest tests/ -m integration $(PYTEST_ARGS)
 
 test-integration-setup: ## Start Docker services for integration tests
 	docker compose -f dev/docker-compose-integration.yml kill

--- a/Makefile
+++ b/Makefile
@@ -48,10 +48,6 @@ lint: ## lint
 test: ## Run all unit tests, can add arguments with PYTEST_ARGS="-vv"
 	poetry run pytest tests/ -m "(unmarked or parametrize) and not integration" ${PYTEST_ARGS}
 
-test-s3: # Run tests marked with s3, can add arguments with PYTEST_ARGS="-vv"
-	sh ./dev/run-minio.sh
-	poetry run pytest tests/ -m s3 ${PYTEST_ARGS}
-
 test-integration: | test-integration-setup test-integration-exec ## Run all integration tests, can add arguments with PYTEST_ARGS="-vv"
 
 test-integration-setup: # Prepare the environment for integration
@@ -69,6 +65,10 @@ test-integration-rebuild:
 	docker compose -f dev/docker-compose-integration.yml kill
 	docker compose -f dev/docker-compose-integration.yml rm -f
 	docker compose -f dev/docker-compose-integration.yml build --no-cache
+
+test-s3: # Run tests marked with s3, can add arguments with PYTEST_ARGS="-vv"
+	sh ./dev/run-minio.sh
+	poetry run pytest tests/ -m s3 ${PYTEST_ARGS}
 
 test-adls: ## Run tests marked with adls, can add arguments with PYTEST_ARGS="-vv"
 	sh ./dev/run-azurite.sh

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,9 @@ test-gcs: ## Run tests marked with @pytest.mark.gcs
 	$(TEST_RUNNER) pytest tests/ -m gcs $(PYTEST_ARGS)
 
 test-coverage: COVERAGE=1
-test-coverage: test test-integration test-s3 test-adls test-gcs ## Run all tests with coverage
+test-coverage: test test-integration test-s3 test-adls test-gcs coverage-report ## Run all tests with coverage and report
+
+coverage-report: ## Combine and report coverage
 	poetry run coverage combine
 	poetry run coverage report -m --fail-under=90
 	poetry run coverage html

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,11 @@
 # under the License.
 
 
-help:  ## Display this help
+help: # Display this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 POETRY_VERSION = 2.1.1
-install-poetry:  ## Ensure Poetry is installed and the correct version is being used.
+install-poetry: # Ensure Poetry is installed and the correct version is being used.
 	@if ! command -v poetry &> /dev/null; then \
 		echo "Poetry could not be found. Installing..."; \
 		pip install --user poetry==$(POETRY_VERSION); \
@@ -34,21 +34,21 @@ install-poetry:  ## Ensure Poetry is installed and the correct version is being 
 		fi \
 	fi
 
-install-dependencies: ## Install dependencies including dev, docs, and all extras
+install-dependencies: # Install dependencies including dev, docs, and all extras
 	poetry install --all-extras
 
 install: | install-poetry install-dependencies
 
-check-license: ## Check license headers
+check-license: # Check license headers
 	./dev/check-license
 
-lint: ## lint
+lint: # lint
 	poetry run pre-commit run --all-files
 
-test: ## Run all unit tests, can add arguments with PYTEST_ARGS="-vv"
+test: # Run all unit tests, can add arguments with PYTEST_ARGS="-vv"
 	poetry run pytest tests/ -m "(unmarked or parametrize) and not integration" ${PYTEST_ARGS}
 
-test-integration: | test-integration-setup test-integration-exec ## Run all integration tests, can add arguments with PYTEST_ARGS="-vv"
+test-integration: | test-integration-setup test-integration-exec # Run all integration tests, can add arguments with PYTEST_ARGS="-vv"
 
 test-integration-setup: # Prepare the environment for integration
 	docker compose -f dev/docker-compose-integration.yml kill
@@ -58,7 +58,7 @@ test-integration-setup: # Prepare the environment for integration
 	docker compose -f dev/docker-compose-integration.yml cp ./dev/provision.py spark-iceberg:/opt/spark/provision.py
 	docker compose -f dev/docker-compose-integration.yml exec -T spark-iceberg ipython ./provision.py
 
-test-integration-exec:  # Execute integration tests, can add arguments with PYTEST_ARGS="-vv"
+test-integration-exec: # Execute integration tests, can add arguments with PYTEST_ARGS="-vv"
 	poetry run pytest tests/ -v -m integration ${PYTEST_ARGS}
 
 test-integration-rebuild:
@@ -70,34 +70,29 @@ test-s3: # Run tests marked with s3, can add arguments with PYTEST_ARGS="-vv"
 	sh ./dev/run-minio.sh
 	poetry run pytest tests/ -m s3 ${PYTEST_ARGS}
 
-test-adls: ## Run tests marked with adls, can add arguments with PYTEST_ARGS="-vv"
+test-adls: # Run tests marked with adls, can add arguments with PYTEST_ARGS="-vv"
 	sh ./dev/run-azurite.sh
 	poetry run pytest tests/ -m adls ${PYTEST_ARGS}
 
-test-gcs: ## Run tests marked with gcs, can add arguments with PYTEST_ARGS="-vv"
+test-gcs: # Run tests marked with gcs, can add arguments with PYTEST_ARGS="-vv"
 	sh ./dev/run-gcs-server.sh
 	poetry run pytest tests/ -m gcs ${PYTEST_ARGS}
 
 test-coverage-unit: # Run test with coverage for unit tests, can add arguments with PYTEST_ARGS="-vv"
 	poetry run coverage run --source=pyiceberg/ --data-file=.coverage.unit -m pytest tests/ -v -m "(unmarked or parametrize) and not integration" ${PYTEST_ARGS}
 
-test-coverage-integration: # Run test with coverage for integration tests, can add arguments with PYTEST_ARGS="-vv"
-	docker compose -f dev/docker-compose-integration.yml kill
-	docker compose -f dev/docker-compose-integration.yml rm -f
-	docker compose -f dev/docker-compose-integration.yml up -d
-	sleep 10
-	docker compose -f dev/docker-compose-integration.yml cp ./dev/provision.py spark-iceberg:/opt/spark/provision.py
+test-coverage-integration: test-integration-setup # Run test with coverage for integration tests, can add arguments with PYTEST_ARGS="-vv"
 	docker compose -f dev/docker-compose-integration.yml exec -T spark-iceberg ipython ./provision.py
 	poetry run coverage run --source=pyiceberg/ --data-file=.coverage.integration -m pytest tests/ -v -m integration ${PYTEST_ARGS}
 
-test-coverage: | test-coverage-unit test-coverage-integration test-s3 test-adls test-gcs ## Run all tests with coverage including unit and integration tests
+test-coverage: | test-coverage-unit test-coverage-integration test-s3 test-adls test-gcs # Run all tests with coverage including unit and integration tests
 	poetry run coverage combine .coverage.unit .coverage.integration
 	poetry run coverage report -m --fail-under=90
 	poetry run coverage html
 	poetry run coverage xml
 
 
-clean: ## Clean up the project Python working environment
+clean: # Clean up the project Python working environment
 	@echo "Cleaning up Cython and Python cached files"
 	@rm -rf build dist *.egg-info
 	@find . -name "*.so" -exec echo Deleting {} \; -delete

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -338,10 +338,6 @@ filterwarnings = [
   "ignore:datetime.datetime.utcnow\\(\\) is deprecated and scheduled for removal in a future version.",
   # Latest PySpark version (v3.5.3) throws this error, remove in a future release of PySpark (possibly v4.0.0).
   "ignore:is_datetime64tz_dtype is deprecated and will be removed in a future version.",
-  # From fsspec gcsfs
-  "ignore:pkg_resources is deprecated as an API.",
-  "ignore:Deprecated call to `pkg_resources\\.declare_namespace\\('.*'\\):DeprecationWarning",
-  "ignore::DeprecationWarning:google.rpc",
 ]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -338,6 +338,10 @@ filterwarnings = [
   "ignore:datetime.datetime.utcnow\\(\\) is deprecated and scheduled for removal in a future version.",
   # Latest PySpark version (v3.5.3) throws this error, remove in a future release of PySpark (possibly v4.0.0).
   "ignore:is_datetime64tz_dtype is deprecated and will be removed in a future version.",
+  # From fsspec gcsfs
+  "ignore:pkg_resources is deprecated as an API.",
+  "ignore:Deprecated call to `pkg_resources\\.declare_namespace\\('.*'\\):DeprecationWarning",
+  "ignore::DeprecationWarning:google.rpc",
 ]
 
 [tool.black]


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
Closes #2124

# Rationale for this change
Refactor `Makefile` 
* Grouped commands and added comments
* Added `COVERAGE` param to run test with coverage
* Added `COVERAGE_FAIL_UNDER` param to specify coverage threshold to pass
* Change test coverage threshold to `85` for unit tests, we are currently at `87`
* Change test coverage threshold to `75` for integration tests, we are currently at `77`

CI 
* Add s3/adls/gcs integration tests to run in CI
* Run tests with coverage report

Note the `gcsfs` issue was resolved by #2127

# Are these changes tested?
Yes

# Are there any user-facing changes?
No

<!-- In the case of user-facing changes, please add the changelog label. -->
