### PR TITLE
fix: correct type mismatch in avro zstd decompression.

### DIFF
--- a/pyiceberg/avro/codecs/zstandard_codec.py
+++ b/pyiceberg/avro/codecs/zstandard_codec.py
@@ -39,7 +39,7 @@ try:
                     if not chunk:
                         break
                     uncompressed.extend(chunk)
-            return uncompressed
+            return bytes(uncompressed)
 
 except ImportError:
 

--- a/tests/utils/test_manifest.py
+++ b/tests/utils/test_manifest.py
@@ -358,7 +358,7 @@ def test_write_empty_manifest() -> None:
 
 
 @pytest.mark.parametrize("format_version", [1, 2])
-@pytest.mark.parametrize("compression", ["null", "deflate"])
+@pytest.mark.parametrize("compression", ["null", "deflate", "zstd"])
 def test_write_manifest(
     generated_manifest_file_file_v1: str,
     generated_manifest_file_file_v2: str,


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
The return type of the decompress method in `ZStandardCodec` should be `bytes`, but it currently returns a `bytearray`, which causes an exception when reading Avro files compressed with zstd.

```text
def new_decoder(b: bytes) -> BinaryDecoder:
        try:
            from pyiceberg.avro.decoder_fast import CythonBinaryDecoder

>           return CythonBinaryDecoder(b)
E           TypeError: Argument 'input_contents' has incorrect type (expected bytes, got bytearray)
```

# Are these changes tested?
Yes,  `test_write_manifest`

# Are there any user-facing changes?
No.
<!-- In the case of user-facing changes, please add the changelog label. -->
