### PR TITLE
perf: optimize `table.add_files` and `inspect.files`

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -847,7 +847,7 @@ class Transaction:
             import pyarrow.compute as pc
 
             expr = pc.field("file_path").isin(file_paths)
-            referenced_files = [file["file_path"] for file in self._table.inspect.files().filter(expr).to_pylist()]
+            referenced_files = [file["file_path"] for file in self._table.inspect.data_files().filter(expr).to_pylist()]
 
             if referenced_files:
                 raise ValueError(f"Cannot add files that are already referenced by table, files: {', '.join(referenced_files)}")

--- a/pyiceberg/table/inspect.py
+++ b/pyiceberg/table/inspect.py
@@ -653,7 +653,7 @@ class InspectTable:
 
         executor = ExecutorFactory.get_or_create()
         results = list(
-            executor.map(lambda manifest: self._get_files_from_manifest(manifest, data_file_filter), snapshot.manifests(io))
+            executor.map(lambda manifest_list: self._get_files_from_manifest(manifest_list, data_file_filter), snapshot.manifests(io))
         )
         return pa.concat_tables(results)
 

--- a/pyiceberg/table/inspect.py
+++ b/pyiceberg/table/inspect.py
@@ -650,11 +650,12 @@ class InspectTable:
 
         snapshot = self._get_snapshot(snapshot_id)
         io = self.tbl.io
-        files_table: list[pa.Table] = []
-        for manifest_list in snapshot.manifests(io):
-            files_table.append(self._get_files_from_manifest(manifest_list, data_file_filter))
 
-        return pa.concat_tables(files_table)
+        executor = ExecutorFactory.get_or_create()
+        results = list(
+            executor.map(lambda manifest: self._get_files_from_manifest(manifest, data_file_filter), snapshot.manifests(io))
+        )
+        return pa.concat_tables(results)
 
     def files(self, snapshot_id: Optional[int] = None) -> "pa.Table":
         return self._files(snapshot_id)

--- a/pyiceberg/table/inspect.py
+++ b/pyiceberg/table/inspect.py
@@ -653,7 +653,9 @@ class InspectTable:
 
         executor = ExecutorFactory.get_or_create()
         results = list(
-            executor.map(lambda manifest_list: self._get_files_from_manifest(manifest_list, data_file_filter), snapshot.manifests(io))
+            executor.map(
+                lambda manifest_list: self._get_files_from_manifest(manifest_list, data_file_filter), snapshot.manifests(io)
+            )
         )
         return pa.concat_tables(results)
 


### PR DESCRIPTION
Should help with #2130 and #2132

Modifies `Table.add_files` to explicitly use `inspect.data_files` and also parallelize `inspect._files`

I didn't see anywhere else where looping over manifest entries was parallelized, so seems better to parallelize across manifests than within.

No changes here but should be faster.
