### PR TITLE
Sanitize field names to ensure valid Avro identifiers

### DIFF
--- a/pyiceberg/schema.py
+++ b/pyiceberg/schema.py
@@ -395,25 +395,6 @@ class Schema(IcebergBaseModel):
                     f"{field.field_type} is only supported in {field.field_type.minimum_format_version()} or higher. Current format version is: {format_version}"
                 )
 
-    @classmethod
-    def create_with_invalid_names(cls, *fields: NestedField, **data: Any) -> "Schema":
-        """Create a Schema with potentially invalid field names for testing purposes.
-        
-        This method bypasses the Avro field name validation and should only be used for testing.
-        
-        Args:
-            *fields: The fields to include in the schema
-            **data: Additional schema data
-            
-        Returns:
-            Schema: A schema instance with validation bypassed
-        """
-        if fields:
-            data["fields"] = fields
-        schema = cls(**data)
-        schema._skip_validation = True
-        return schema
-
 
 class SchemaVisitor(Generic[T], ABC):
     def before_field(self, field: NestedField) -> None:

--- a/tests/expressions/test_expressions.py
+++ b/tests/expressions/test_expressions.py
@@ -1178,23 +1178,24 @@ def test_nested_bind() -> None:
 def test_bind_dot_name() -> None:
     schema = Schema(NestedField(1, "foo.bar", StringType()), schema_id=1)
     bound = BoundIsNull(BoundReference(schema.find_field(1), schema.accessor_for_field(1)))
-    assert IsNull(Reference("foo.bar")).bind(schema) == bound
+    assert IsNull(Reference("foo_x2Ebar")).bind(schema) == bound
 
 
 def test_nested_bind_with_dot_name() -> None:
     schema = Schema(NestedField(1, "foo.bar", StructType(NestedField(2, "baz", StringType()))), schema_id=1)
     bound = BoundIsNull(BoundReference(schema.find_field(2), schema.accessor_for_field(2)))
-    assert IsNull(Reference("foo.bar.baz")).bind(schema) == bound
+    assert IsNull(Reference("foo_x2Ebar.baz")).bind(schema) == bound
 
 
 def test_bind_ambiguous_name() -> None:
     with pytest.raises(ValueError) as exc_info:
         Schema(
-            NestedField(1, "foo", StructType(NestedField(2, "bar", StringType()))),
-            NestedField(3, "foo.bar", StringType()),
+            NestedField(1, "foo", StringType()),
+            NestedField(2, "foo.bar", StringType()),
+            NestedField(3, "foo_x2Ebar", StringType()),
             schema_id=1,
         )
-    assert "Invalid schema, multiple fields for name foo.bar: 2 and 3" in str(exc_info)
+    assert "Invalid schema, multiple fields for name foo_x2Ebar: 2 and 3" in str(exc_info.value)
 
 
 #   __  __      ___

--- a/tests/integration/test_reads.py
+++ b/tests/integration/test_reads.py
@@ -856,7 +856,7 @@ def test_table_scan_keep_types(catalog: Catalog) -> None:
     expected_schema = pa.schema(
         [
             pa.field("string", pa.string()),
-            pa.field("string-to-binary", pa.large_binary()),
+            pa.field("string_x2Dto_x2Dbinary", pa.large_binary()),
             pa.field("binary", pa.binary()),
             pa.field("list", pa.list_(pa.large_string())),
         ]
@@ -886,7 +886,7 @@ def test_table_scan_keep_types(catalog: Catalog) -> None:
     tbl.append(arrow_table)
 
     with tbl.update_schema() as update_schema:
-        update_schema.update_column("string-to-binary", BinaryType())
+        update_schema.update_column("string_x2Dto_x2Dbinary", BinaryType())
 
     result_table = tbl.scan().to_arrow()
     assert result_table.schema.equals(expected_schema)
@@ -903,7 +903,7 @@ def test_table_scan_override_with_small_types(catalog: Catalog) -> None:
             pa.array([b"a", b"b", b"c"]),
             pa.array([["a", "b"], ["c", "d"], ["e", "f"]]),
         ],
-        names=["string", "string-to-binary", "binary", "list"],
+        names=["string", "string_x2Dto_x2Dbinary", "binary", "list"],
     )
 
     try:
@@ -919,7 +919,7 @@ def test_table_scan_override_with_small_types(catalog: Catalog) -> None:
     tbl.append(arrow_table)
 
     with tbl.update_schema() as update_schema:
-        update_schema.update_column("string-to-binary", BinaryType())
+        update_schema.update_column("string_x2Dto_x2Dbinary", BinaryType())
 
     tbl.io.properties[PYARROW_USE_LARGE_TYPES_ON_READ] = "False"
     result_table = tbl.scan().to_arrow()
@@ -927,7 +927,7 @@ def test_table_scan_override_with_small_types(catalog: Catalog) -> None:
     expected_schema = pa.schema(
         [
             pa.field("string", pa.string()),
-            pa.field("string-to-binary", pa.large_binary()),
+            pa.field("string_x2Dto_x2Dbinary", pa.large_binary()),
             pa.field("binary", pa.binary()),
             pa.field("list", pa.list_(pa.string())),
         ]

--- a/tests/integration/test_rest_schema.py
+++ b/tests/integration/test_rest_schema.py
@@ -738,21 +738,21 @@ def test_rename_simple_nested_with_dots(catalog: Catalog) -> None:
         Schema(
             NestedField(
                 field_id=1,
-                name="a.b",
-                field_type=StructType(NestedField(field_id=2, name="c.d", field_type=StringType())),
+                name="a_x2Eb",
+                field_type=StructType(NestedField(field_id=2, name="c_x2Ed", field_type=StringType())),
                 required=True,
             ),
         ),
     )
 
     with tbl.update_schema() as schema_update:
-        schema_update.rename_column(("a.b", "c.d"), "e.f")
+        schema_update.rename_column(("a_x2Eb", "c_x2Ed"), "e_x2Ef")
 
     assert tbl.schema() == Schema(
         NestedField(
             field_id=1,
-            name="a.b",
-            field_type=StructType(NestedField(field_id=2, name="e.f", field_type=StringType())),
+            name="a_x2Eb",
+            field_type=StructType(NestedField(field_id=2, name="e_x2Ef", field_type=StringType())),
             required=True,
         ),
     )
@@ -2386,10 +2386,10 @@ def test_add_dotted_identifier_field_columns(catalog: Catalog) -> None:
     )
 
     with tbl.update_schema(allow_incompatible_changes=True) as update_schema:
-        update_schema.add_column(("dot.field",), StringType(), required=True)
-        update_schema.set_identifier_fields("dot.field")
+        update_schema.add_column(("dot_x2Efield",), StringType(), required=True)
+        update_schema.set_identifier_fields("dot_x2Efield")
 
-    assert tbl.schema().identifier_field_names() == {"dot.field"}
+    assert tbl.schema().identifier_field_names() == {"dot_x2Efield"}
 
 
 @pytest.mark.integration

--- a/tests/integration/test_writes/test_writes.py
+++ b/tests/integration/test_writes/test_writes.py
@@ -470,7 +470,7 @@ def test_python_writes_special_character_column_with_spark_reads(
         ]
     )
     arrow_table_with_special_character_column = pa.Table.from_pydict(TEST_DATA_WITH_SPECIAL_CHARACTER_COLUMN, schema=pa_schema)
-    
+
     # Create table using Iceberg Schema directly to ensure field names are sanitized
     iceberg_schema = Schema(
         NestedField(field_id=1, name=sanitized_column_name, field_type=StringType(), required=False),
@@ -488,7 +488,7 @@ def test_python_writes_special_character_column_with_spark_reads(
             required=False,
         ),
     )
-    
+
     tbl = _create_table(session_catalog, identifier, {"format-version": format_version}, schema=iceberg_schema)
 
     tbl.append(arrow_table_with_special_character_column)


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
Closes https://github.com/apache/iceberg-python/issues/2123

# Rationale for this change
Field names are sanitized during initialization to ensure they are valid Avro identifiers

# Are these changes tested?
Yes

# Are there any user-facing changes?
Yes - field names are sanitized in constructor

<!-- In the case of user-facing changes, please add the changelog label. -->
