### PR TITLE
feat: support pagination in list_* methods in rest catalog

### DIFF
--- a/pyiceberg/catalog/rest/__init__.py
+++ b/pyiceberg/catalog/rest/__init__.py
@@ -607,7 +607,7 @@ class RestCatalog(Catalog):
             params["pageToken"] = next_page_token
         if page_size is not None:
             params["pageSize"] = page_size
-        response = self._session.get(self.url(Endpoints.list_tables, namespace=namespace_concat))
+        response = self._session.get(self.url(Endpoints.list_tables, namespace=namespace_concat), params=params)
         try:
             response.raise_for_status()
         except HTTPError as exc:
@@ -723,14 +723,12 @@ class RestCatalog(Catalog):
 
         next_page_token = None
         while True:
-            list_namespace_response = self.list_views_raw(
-                namespace=namespace, page_size=page_size, next_page_token=next_page_token
-            )
-            views.extend([(*view.namespace, view.name) for view in list_namespace_response.identifiers])
-            if list_namespace_response.next_page_token is None:
+            list_views_response = self.list_views_raw(namespace=namespace, page_size=page_size, next_page_token=next_page_token)
+            views.extend([(*view.namespace, view.name) for view in list_views_response.identifiers])
+            if list_views_response.next_page_token is None:
                 break
             else:
-                next_page_token = list_namespace_response.next_page_token
+                next_page_token = list_views_response.next_page_token
 
         return views
 

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -412,6 +412,28 @@ def test_list_tables_200(rest_mock: Mocker) -> None:
     assert RestCatalog("rest", uri=TEST_URI, token=TEST_TOKEN).list_tables(namespace) == [("examples", "fooshare")]
 
 
+def test_list_tables_paginated_200(rest_mock: Mocker) -> None:
+    namespace = "examples"
+    rest_mock.get(
+        f"{TEST_URI}v1/namespaces/{namespace}/tables",
+        json={"identifiers": [{"namespace": ["examples"], "name": "fooshare"}], "next-page-token": "page2"},
+        status_code=200,
+        request_headers=TEST_HEADERS,
+    )
+    rest_mock.get(
+        f"{TEST_URI}v1/namespaces/{namespace}/tables?pageToken=page2",
+        json={"identifiers": [{"namespace": ["examples"], "name": "fooshare2"}]},
+        status_code=200,
+        request_headers=TEST_HEADERS,
+    )
+
+    assert RestCatalog("rest", uri=TEST_URI, token=TEST_TOKEN).list_tables(namespace) == [
+        ("examples", "fooshare"),
+        ("examples", "fooshare2"),
+    ]
+    assert rest_mock.call_count == 3
+
+
 def test_list_tables_200_sigv4(rest_mock: Mocker) -> None:
     namespace = "examples"
     rest_mock.get(
@@ -456,6 +478,30 @@ def test_list_views_200(rest_mock: Mocker) -> None:
     )
 
     assert RestCatalog("rest", uri=TEST_URI, token=TEST_TOKEN).list_views(namespace) == [("examples", "fooshare")]
+
+
+def test_list_views_paginated_200(rest_mock: Mocker) -> None:
+    namespace = "examples"
+    rest_mock.get(
+        f"{TEST_URI}v1/namespaces/{namespace}/views",
+        json={"identifiers": [{"namespace": ["examples"], "name": "fooshare"}], "next-page-token": "page2"},
+        status_code=200,
+        request_headers=TEST_HEADERS,
+    )
+
+    rest_mock.get(
+        f"{TEST_URI}v1/namespaces/{namespace}/views?pageToken=page2",
+        json={"identifiers": [{"namespace": ["examples"], "name": "fooshare2"}]},
+        status_code=200,
+        request_headers=TEST_HEADERS,
+    )
+
+    assert RestCatalog("rest", uri=TEST_URI, token=TEST_TOKEN).list_views(namespace) == [
+        ("examples", "fooshare"),
+        ("examples", "fooshare2"),
+    ]
+
+    assert rest_mock.call_count == 3
 
 
 def test_list_views_200_sigv4(rest_mock: Mocker) -> None:
@@ -541,6 +587,33 @@ def test_list_namespaces_200(rest_mock: Mocker) -> None:
         ("fokko",),
         ("system",),
     ]
+
+
+def test_list_namespaces_paginated_200(rest_mock: Mocker) -> None:
+    rest_mock.get(
+        f"{TEST_URI}v1/namespaces",
+        json={"namespaces": [["default"], ["examples"], ["fokko"], ["system"]], "next-page-token": "page2"},
+        status_code=200,
+        request_headers=TEST_HEADERS,
+    )
+    rest_mock.get(
+        f"{TEST_URI}v1/namespaces?pageToken=page2",
+        json={"namespaces": [["default2"], ["examples2"], ["fokko2"], ["system2"]]},
+        status_code=200,
+        request_headers=TEST_HEADERS,
+    )
+    assert RestCatalog("rest", uri=TEST_URI, token=TEST_TOKEN).list_namespaces() == [
+        ("default",),
+        ("examples",),
+        ("fokko",),
+        ("system",),
+        ("default2",),
+        ("examples2",),
+        ("fokko2",),
+        ("system2",),
+    ]
+
+    assert rest_mock.call_count == 3
 
 
 def test_list_namespace_with_parent_200(rest_mock: Mocker) -> None:


### PR DESCRIPTION
Closes #2084 

# Rationale for this change
Support pagination!

I looked at the rust iceberg implementation and noticed there is no laziness there either so seems fine for the non-lazy list methods to just exhaust into a list.

Also needed to move all requests behind a `self._request_with_retries` method that now handles all previous retry logic

# Are these changes tested?
Added tests

# Are there any user-facing changes?
Yes.
