### PR TITLE
feat: add schema conversion from avro `timestamp-millis` and `uuid`

### DIFF
--- a/pyiceberg/utils/schema_conversion.py
+++ b/pyiceberg/utils/schema_conversion.py
@@ -72,6 +72,7 @@ LOGICAL_FIELD_TYPE_MAPPING: Dict[Tuple[str, str], PrimitiveType] = {
     ("timestamp-millis", "int"): TimestampType(),
     ("timestamp-micros", "long"): TimestampType(),
     ("uuid", "fixed"): UUIDType(),
+    ("uuid", "string"): UUIDType(),
 }
 
 AvroType = Union[str, Any]

--- a/pyiceberg/utils/schema_conversion.py
+++ b/pyiceberg/utils/schema_conversion.py
@@ -69,6 +69,7 @@ PRIMITIVE_FIELD_TYPE_MAPPING: Dict[str, PrimitiveType] = {
 LOGICAL_FIELD_TYPE_MAPPING: Dict[Tuple[str, str], PrimitiveType] = {
     ("date", "int"): DateType(),
     ("time-micros", "long"): TimeType(),
+    ("timestamp-millis", "int"): TimestampType(),
     ("timestamp-micros", "long"): TimestampType(),
     ("uuid", "fixed"): UUIDType(),
 }

--- a/tests/utils/test_schema_conversion.py
+++ b/tests/utils/test_schema_conversion.py
@@ -34,6 +34,7 @@ from pyiceberg.types import (
     StringType,
     StructType,
     TimestampType,
+    UUIDType,
     UnknownType,
 )
 from pyiceberg.utils.schema_conversion import AvroSchemaConversion
@@ -327,12 +328,20 @@ def test_convert_date_type() -> None:
     actual = AvroSchemaConversion()._convert_logical_type(avro_logical_type)
     assert actual == DateType()
 
+def test_convert_uuid_str_type() -> None:
+    avro_logical_type = {"type": "string", "logicalType": "uuid"}
+    actual = AvroSchemaConversion()._convert_logical_type(avro_logical_type)
+    assert actual == UUIDType()
+
+def test_convert_uuid_fixed_type() -> None:
+    avro_logical_type = {"type": "fixed", "logicalType": "uuid"}
+    actual = AvroSchemaConversion()._convert_logical_type(avro_logical_type)
+    assert actual == UUIDType()
 
 def test_convert_timestamp_millis_type() -> None:
     avro_logical_type = {"type": "int", "logicalType": "timestamp-millis"}
     actual = AvroSchemaConversion()._convert_logical_type(avro_logical_type)
     assert actual == TimestampType()
-
 
 def test_convert_timestamp_micros_type() -> None:
     avro_logical_type = {"type": "int", "logicalType": "timestamp-micros"}

--- a/tests/utils/test_schema_conversion.py
+++ b/tests/utils/test_schema_conversion.py
@@ -33,6 +33,7 @@ from pyiceberg.types import (
     NestedField,
     StringType,
     StructType,
+    TimestampType,
     UnknownType,
 )
 from pyiceberg.utils.schema_conversion import AvroSchemaConversion
@@ -325,6 +326,18 @@ def test_convert_date_type() -> None:
     avro_logical_type = {"type": "int", "logicalType": "date"}
     actual = AvroSchemaConversion()._convert_logical_type(avro_logical_type)
     assert actual == DateType()
+
+
+def test_convert_timestamp_millis_type() -> None:
+    avro_logical_type = {"type": "int", "logicalType": "timestamp-millis"}
+    actual = AvroSchemaConversion()._convert_logical_type(avro_logical_type)
+    assert actual == TimestampType()
+
+
+def test_convert_timestamp_micros_type() -> None:
+    avro_logical_type = {"type": "int", "logicalType": "timestamp-micros"}
+    actual = AvroSchemaConversion()._convert_logical_type(avro_logical_type)
+    assert actual == TimestampType()
 
 
 def test_unknown_logical_type() -> None:

--- a/tests/utils/test_schema_conversion.py
+++ b/tests/utils/test_schema_conversion.py
@@ -34,8 +34,8 @@ from pyiceberg.types import (
     StringType,
     StructType,
     TimestampType,
-    UUIDType,
     UnknownType,
+    UUIDType,
 )
 from pyiceberg.utils.schema_conversion import AvroSchemaConversion
 
@@ -328,20 +328,24 @@ def test_convert_date_type() -> None:
     actual = AvroSchemaConversion()._convert_logical_type(avro_logical_type)
     assert actual == DateType()
 
+
 def test_convert_uuid_str_type() -> None:
     avro_logical_type = {"type": "string", "logicalType": "uuid"}
     actual = AvroSchemaConversion()._convert_logical_type(avro_logical_type)
     assert actual == UUIDType()
+
 
 def test_convert_uuid_fixed_type() -> None:
     avro_logical_type = {"type": "fixed", "logicalType": "uuid"}
     actual = AvroSchemaConversion()._convert_logical_type(avro_logical_type)
     assert actual == UUIDType()
 
+
 def test_convert_timestamp_millis_type() -> None:
     avro_logical_type = {"type": "int", "logicalType": "timestamp-millis"}
     actual = AvroSchemaConversion()._convert_logical_type(avro_logical_type)
     assert actual == TimestampType()
+
 
 def test_convert_timestamp_micros_type() -> None:
     avro_logical_type = {"type": "int", "logicalType": "timestamp-micros"}


### PR DESCRIPTION
# Rationale for this change
The schema conversion util from avro schema to iceberg schema did ignore `timestamp-millis`. 
Also added conversion from `uuid` 

# Are these changes tested?
Added tests for `timestamp-millis` and `timestamp-micros` as the latter was missing

# Are there any user-facing changes?

no
