### PR TITLE
docs: add ugi back to hive catalog config

### DIFF
--- a/mkdocs/docs/configuration.md
+++ b/mkdocs/docs/configuration.md
@@ -515,6 +515,7 @@ catalog:
 | hive.hive2-compatible        | true    | Using Hive 2.x compatibility mode    |
 | hive.kerberos-authentication | true    | Using authentication via Kerberos    |
 | hive.kerberos-service-name   | hive    | Kerberos service name (default hive) |
+| ugi                 | t-1234:secret                    | Hadoop UGI for Hive client.                                                                        |
 
 When using Hive 2.x, make sure to set the compatibility flag:
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
[`ugi` is a Hive Catalog property](https://github.com/apache/iceberg-python/blob/e33cf5ac1adf47131d4992bdb686f0e58f4e4669/pyiceberg/catalog/hive.py#L322-L327). It was accidentally added to the REST catalog section in https://github.com/apache/iceberg-python/commit/5209874cd4685427520b67b64188f5e9919f2816#diff-497e037708cc64870c6ba9372f6064a69ca1e74d65d6195dcee5a44851e8b47dR151

#2175 removed it from the REST catalog section. 

This PR adds `ugi` back to the Hive Catalog section

<img width="666" alt="Screenshot 2025-07-08 at 7 48 41 AM" src="https://github.com/user-attachments/assets/42247bae-4dfd-4688-b4d5-a33bd94d686b" />

# Are these changes tested?

# Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
