### PR TITLE
Add RemovePartitionStatisticsUpdate and SetPartitionStatisticsUpdate

### DIFF
--- a/pyiceberg/table/statistics.py
+++ b/pyiceberg/table/statistics.py
@@ -52,3 +52,10 @@ def filter_statistics_by_snapshot_id(
     reject_snapshot_id: int,
 ) -> List[StatisticsFile]:
     return [stat for stat in statistics if stat.snapshot_id != reject_snapshot_id]
+
+
+def filter_partition_statistics_by_snapshot_id(
+    statistics: List[PartitionStatisticsFile],
+    reject_snapshot_id: int,
+) -> List[PartitionStatisticsFile]:
+    return [stat for stat in statistics if stat.snapshot_id != reject_snapshot_id]

--- a/pyiceberg/table/statistics.py
+++ b/pyiceberg/table/statistics.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Dict, List, Literal, Optional
+from typing import Dict, List, Literal, Optional, Union
 
 from pydantic import Field
 
@@ -48,7 +48,7 @@ class PartitionStatisticsFile(StatisticsCommonFields):
 
 
 def filter_statistics_by_snapshot_id(
-    statistics: List[StatisticsFile | PartitionStatisticsFile],
+    statistics: List[Union[StatisticsFile, PartitionStatisticsFile]],
     reject_snapshot_id: int,
-) -> List[StatisticsFile | PartitionStatisticsFile]:
+) -> List[Union[StatisticsFile, PartitionStatisticsFile]]:
     return [stat for stat in statistics if stat.snapshot_id != reject_snapshot_id]

--- a/pyiceberg/table/statistics.py
+++ b/pyiceberg/table/statistics.py
@@ -48,14 +48,7 @@ class PartitionStatisticsFile(StatisticsCommonFields):
 
 
 def filter_statistics_by_snapshot_id(
-    statistics: List[StatisticsFile],
+    statistics: List[StatisticsFile | PartitionStatisticsFile],
     reject_snapshot_id: int,
-) -> List[StatisticsFile]:
-    return [stat for stat in statistics if stat.snapshot_id != reject_snapshot_id]
-
-
-def filter_partition_statistics_by_snapshot_id(
-    statistics: List[PartitionStatisticsFile],
-    reject_snapshot_id: int,
-) -> List[PartitionStatisticsFile]:
+) -> List[StatisticsFile | PartitionStatisticsFile]:
     return [stat for stat in statistics if stat.snapshot_id != reject_snapshot_id]

--- a/pyiceberg/table/update/__init__.py
+++ b/pyiceberg/table/update/__init__.py
@@ -39,7 +39,6 @@ from pyiceberg.table.sorting import SortOrder
 from pyiceberg.table.statistics import (
     PartitionStatisticsFile,
     StatisticsFile,
-    filter_partition_statistics_by_snapshot_id,
     filter_statistics_by_snapshot_id,
 )
 from pyiceberg.typedef import (
@@ -601,7 +600,7 @@ def _(update: RemoveStatisticsUpdate, base_metadata: TableMetadata, context: _Ta
 
 @_apply_table_update.register(SetPartitionStatisticsUpdate)
 def _(update: SetPartitionStatisticsUpdate, base_metadata: TableMetadata, context: _TableMetadataUpdateContext) -> TableMetadata:
-    partition_statistics = filter_partition_statistics_by_snapshot_id(
+    partition_statistics = filter_statistics_by_snapshot_id(
         base_metadata.partition_statistics, update.partition_statistics.snapshot_id
     )
     context.add_update(update)
@@ -616,7 +615,7 @@ def _(
     if not any(part_stat.snapshot_id == update.snapshot_id for part_stat in base_metadata.partition_statistics):
         raise ValueError(f"Partition Statistics with snapshot id {update.snapshot_id} does not exist")
 
-    statistics = filter_partition_statistics_by_snapshot_id(base_metadata.partition_statistics, update.snapshot_id)
+    statistics = filter_statistics_by_snapshot_id(base_metadata.partition_statistics, update.snapshot_id)
     context.add_update(update)
 
     return base_metadata.model_copy(update={"partition_statistics": statistics})


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
Closes #2191 

# Rationale for this change
apache/iceberg supports these two event types. We should do the same to match the Java implementation and allow users to alter their partition statistics files.

[REST Spec Reference]([apache/iceberg@09140e5/open-api/rest-catalog-open-api.yaml#L2981-L3004](https://github.com/apache/iceberg/blob/09140e52836048b112c42c9cfe721295bd57048b/open-api/rest-catalog-open-api.yaml#L2981-L3004))

# Are these changes tested?
Unit test included.

# Are there any user-facing changes?
- Adds `RemovePartitionStatisticsUpdate` and `SetPartitionStatisticsUpdate` actions.

<!-- In the case of user-facing changes, please add the changelog label. -->
