### PR TITLE
chore: specify test paths to integrate with vscode testing extension

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -317,6 +317,8 @@ pyiceberg-core = ["pyiceberg-core"]
 datafusion = ["datafusion"]
 
 [tool.pytest.ini_options]
+testpaths = ["tests"]
+
 markers = [
   "unmarked: marks a test as a unittest",
   "s3: marks a test as requiring access to s3 compliant storage (use with --aws-access-key-id, --aws-secret-access-key, and --endpoint args)",


### PR DESCRIPTION
# Rationale for this change

Add `testpaths` option to enjoy the Test Explorer UI extension in development. Without this option, though the Python Test Adpater Log will run `pytest --collect-only` to discovery tests, it will potential occur error when parsing the test files (e.g. Import Error).

---
## Results:
| Before adding `testpaths`  | After adding `testpaths` |
|------------------------------|---------------------------|
| ![image](https://github.com/user-attachments/assets/bbee6269-7e96-4a4a-a838-3be283260f6a)| ![image](https://github.com/user-attachments/assets/210eabbd-12ea-4d70-b71e-a9d47a25d828)|

After adding `testpaths`:


# Are these changes tested?

Yes, Tested on Codespace and local VScode

# Are there any user-facing changes?

No, this change not affect any iceberg code.
