### PR TITLE
Add RemovePartitionSpecsUpdate event

### DIFF
--- a/pyiceberg/table/update/__init__.py
+++ b/pyiceberg/table/update/__init__.py
@@ -194,7 +194,7 @@ class RemoveStatisticsUpdate(IcebergBaseModel):
 
 
 class RemovePartitionSpecsUpdate(IcebergBaseModel):
-    action: Literal["remove-partition-spec"] = Field(default="remove-partition-spec")
+    action: Literal["remove-partition-specs"] = Field(default="remove-partition-specs")
     spec_ids: List[int] = Field(alias="spec-ids")
 
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
This adds RemovePartitionSpecsUpdate, another missing TableMetadata update event.

It also ends up testing AddPartitionSpecUpdate, which it looks like it untested.

[REST API Spec Reference](https://github.com/apache/iceberg/blob/09140e52836048b112c42c9cfe721295bd57048b/open-api/rest-catalog-open-api.yaml#L3006-L3018)

# Are these changes tested?
Unit tests added.

# Are there any user-facing changes?
- Added RemovePartitionSpecsUpdate event

<!-- In the case of user-facing changes, please add the changelog label. -->
