### PR TITLE
Add schema conversion time

### DIFF
--- a/pyiceberg/utils/schema_conversion.py
+++ b/pyiceberg/utils/schema_conversion.py
@@ -68,8 +68,9 @@ PRIMITIVE_FIELD_TYPE_MAPPING: Dict[str, PrimitiveType] = {
 
 LOGICAL_FIELD_TYPE_MAPPING: Dict[Tuple[str, str], PrimitiveType] = {
     ("date", "int"): DateType(),
+    ("time-millis", "int"): TimeType(),
     ("time-micros", "long"): TimeType(),
-    ("timestamp-millis", "int"): TimestampType(),
+    ("timestamp-millis", "long"): TimestampType(),
     ("timestamp-micros", "long"): TimestampType(),
     ("uuid", "fixed"): UUIDType(),
     ("uuid", "string"): UUIDType(),

--- a/tests/utils/test_schema_conversion.py
+++ b/tests/utils/test_schema_conversion.py
@@ -33,6 +33,7 @@ from pyiceberg.types import (
     NestedField,
     StringType,
     StructType,
+    TimeType,
     TimestampType,
     UnknownType,
     UUIDType,

--- a/tests/utils/test_schema_conversion.py
+++ b/tests/utils/test_schema_conversion.py
@@ -33,8 +33,8 @@ from pyiceberg.types import (
     NestedField,
     StringType,
     StructType,
-    TimeType,
     TimestampType,
+    TimeType,
     UnknownType,
     UUIDType,
 )

--- a/tests/utils/test_schema_conversion.py
+++ b/tests/utils/test_schema_conversion.py
@@ -341,8 +341,20 @@ def test_convert_uuid_fixed_type() -> None:
     assert actual == UUIDType()
 
 
+def test_convert_time_millis_type() -> None:
+    avro_logical_type = {"type": "int", "logicalType": "time-millis"}
+    actual = AvroSchemaConversion()._convert_logical_type(avro_logical_type)
+    assert actual == TimeType()
+
+
+def test_convert_time_micros_type() -> None:
+    avro_logical_type = {"type": "long", "logicalType": "time-micros"}
+    actual = AvroSchemaConversion()._convert_logical_type(avro_logical_type)
+    assert actual == TimeType()
+
+
 def test_convert_timestamp_millis_type() -> None:
-    avro_logical_type = {"type": "int", "logicalType": "timestamp-millis"}
+    avro_logical_type = {"type": "long", "logicalType": "timestamp-millis"}
     actual = AvroSchemaConversion()._convert_logical_type(avro_logical_type)
     assert actual == TimestampType()
 


### PR DESCRIPTION
# Rationale for this change
* Fix schema_conversion for `timestamp-millis`
* add conversion for `time-millis`
Following up on #2173 the `timestamp-millis` is actually stored are `long` not `int`. I also noted, that `time-millis` was missing as well.
https://avro.apache.org/docs/1.12.0/specification/#time_ms


# Are these changes tested?
yes

# Are there any user-facing changes?
no
