### PR TITLE
revert avro timestamp-millis mapping

### DIFF
--- a/pyiceberg/utils/schema_conversion.py
+++ b/pyiceberg/utils/schema_conversion.py
@@ -69,7 +69,6 @@ PRIMITIVE_FIELD_TYPE_MAPPING: Dict[str, PrimitiveType] = {
 LOGICAL_FIELD_TYPE_MAPPING: Dict[Tuple[str, str], PrimitiveType] = {
     ("date", "int"): DateType(),
     ("time-micros", "long"): TimeType(),
-    ("timestamp-millis", "int"): TimestampType(),
     ("timestamp-micros", "long"): TimestampType(),
     ("uuid", "fixed"): UUIDType(),
     ("uuid", "string"): UUIDType(),

--- a/tests/utils/test_schema_conversion.py
+++ b/tests/utils/test_schema_conversion.py
@@ -341,12 +341,6 @@ def test_convert_uuid_fixed_type() -> None:
     assert actual == UUIDType()
 
 
-def test_convert_timestamp_millis_type() -> None:
-    avro_logical_type = {"type": "int", "logicalType": "timestamp-millis"}
-    actual = AvroSchemaConversion()._convert_logical_type(avro_logical_type)
-    assert actual == TimestampType()
-
-
 def test_convert_timestamp_micros_type() -> None:
     avro_logical_type = {"type": "int", "logicalType": "timestamp-micros"}
     actual = AvroSchemaConversion()._convert_logical_type(avro_logical_type)


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
Follow up to #2173, the conversion as implemented is not safe since iceberg does not natively have `millis` precision. Timestamp values are implicitly in `micros` precision
This is confirmed by https://github.com/apache/iceberg-python/pull/2173#discussion_r2209756001

Let's revert for now and follow up to figure out the right way to support `millis` precision. 

# Are these changes tested?

# Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
