### PR TITLE
[Append Scan] Add `__eq__` and `__hash__` methods to `ManifestFile`

### DIFF
--- a/pyiceberg/manifest.py
+++ b/pyiceberg/manifest.py
@@ -866,6 +866,14 @@ class ManifestFile(Record):
                 if not discard_deleted or entry.status != ManifestEntryStatus.DELETED
             ]
 
+    def __eq__(self, other: Any) -> bool:
+        """Return the equality of two instances of the ManifestFile class."""
+        return self.manifest_path == other.manifest_path if isinstance(other, ManifestFile) else False
+
+    def __hash__(self) -> int:
+        """Return the hash of manifest_path."""
+        return hash(self.manifest_path)
+
 
 @cached(cache=LRUCache(maxsize=128), key=lambda io, manifest_list: hashkey(manifest_list))
 def _manifests(io: FileIO, manifest_list: str) -> Tuple[ManifestFile, ...]:


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

Split up from incremental append scan work - see https://github.com/apache/iceberg-python/pull/2031#issuecomment-3102702127. PyIceberg doesn't support incremental reading of appended data between snapshots, like Spark does.

This PR adds equality and hash notions to `ManifestFile`, because for incremental reading, we construct a set of manifest files. See https://github.com/apache/iceberg-python/pull/2233#discussion_r2222501916.

# Are these changes tested?

N/A

# Are there any user-facing changes?

Technically yes, manifest equality now works via the introduced semantics

<!-- In the case of user-facing changes, please add the changelog label. -->
