### PR TITLE
FileIO must use absolute paths.

### DIFF
--- a/pyiceberg/io/fsspec.py
+++ b/pyiceberg/io/fsspec.py
@@ -351,6 +351,10 @@ class FsspecFileIO(FileIO):
             FsspecInputFile: An FsspecInputFile instance for the given location.
         """
         uri = urlparse(location)
+        if uri.scheme in ("", "file"):
+            path_to_check = uri.path if uri.scheme else location
+            if not os.path.isabs(path_to_check):
+                raise ValueError(f"FileIO implementation for local files requires absolute paths: {location}")
         fs = self.get_fs(uri.scheme)
         return FsspecInputFile(location=location, fs=fs)
 
@@ -364,6 +368,10 @@ class FsspecFileIO(FileIO):
             FsspecOutputFile: An FsspecOutputFile instance for the given location.
         """
         uri = urlparse(location)
+        if uri.scheme in ("", "file"):
+            path_to_check = uri.path if uri.scheme else location
+            if not os.path.isabs(path_to_check):
+                raise ValueError(f"FileIO implementation for local files requires absolute paths: {location}")
         fs = self.get_fs(uri.scheme)
         return FsspecOutputFile(location=location, fs=fs)
 

--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -391,7 +391,13 @@ class PyArrowFileIO(FileIO):
         """Return the path without the scheme."""
         uri = urlparse(location)
         if not uri.scheme:
-            return "file", uri.netloc, os.path.abspath(location)
+            if not os.path.isabs(location):
+                raise ValueError(f"FileIO implementation for local files requires absolute paths: {location}")
+            return "file", uri.netloc, location
+        elif uri.scheme == "file":
+            if not os.path.isabs(uri.path):
+                raise ValueError(f"FileIO implementation for local files requires absolute paths: {location}")
+            return uri.scheme, uri.netloc, uri.path
         elif uri.scheme in ("hdfs", "viewfs"):
             return uri.scheme, uri.netloc, uri.path
         else:

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -170,7 +170,6 @@ def test_output_file_to_input_file() -> None:
 @pytest.mark.parametrize(
     "string_uri",
     [
-        "foo/bar/baz.parquet",
         "file:/foo/bar/baz.parquet",
         "file:/foo/bar/baz.parquet",
     ],
@@ -184,6 +183,16 @@ def test_custom_file_io_locations(string_uri: str) -> None:
 
     output_file = file_io.new_output(location=string_uri)
     assert output_file.location == string_uri
+
+def test_custom_file_io_location_relative_path() -> None:
+    string_uri = "foo/bar/baz.parquet"
+    # Instantiate the file-io and create a new input and output file
+    file_io = PyArrowFileIO()
+    with pytest.raises(ValueError) as exc_info:
+        file_io.new_input(location=string_uri)
+
+    assert "FileIO implementation for local files requires absolute paths" in str(exc_info.value)
+
 
 
 def test_deleting_local_file_using_file_io() -> None:


### PR DESCRIPTION
Closes #1730 

# Rationale for this change
Ensure that FileIO must use absolute paths.

# Are these changes tested?
Unit test fixes.

# Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
