### PR TITLE
[docs] Include link to Iceberg Dev Events in docs

### DIFF
--- a/mkdocs/docs/community.md
+++ b/mkdocs/docs/community.md
@@ -30,7 +30,7 @@ Community discussions happen primarily on the [dev mailing list](https://lists.a
 
 ## Iceberg Community Events
 
-The PyIceberg community sync is on the last Tuesday of every month. To join, make sure to subscribe to the [iceberg-python-sync Google group](https://groups.google.com/g/iceberg-python-sync).
+The PyIceberg community sync is on the last Tuesday of every month. The calendar event is located on the [Iceberg Dev Events](https://iceberg.apache.org/community#iceberg-community-events) calendar.
 
 ## Community Guidelines
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
Closes #2238 

# Rationale for this change
The pyiceberg monthly sync is now a part of the Iceberg Dev Events calendar. 

# Are these changes tested?
Just docs

# Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
