### PR TITLE
Fix column projection predicate evaluation

### DIFF
--- a/pyiceberg/expressions/visitors.py
+++ b/pyiceberg/expressions/visitors.py
@@ -897,6 +897,12 @@ class _ColumnNameTranslator(BooleanExpressionVisitor[BooleanExpression]):
         file_column_name = self.file_schema.find_column_name(field.field_id)
 
         if file_column_name is None:
+            # In the case of column projection, the field might not be present in the file schema
+            # If the field has no initial_default, return AlwaysTrue to include all rows
+            # for further evaluation
+            if field.initial_default is None:
+                return AlwaysTrue()
+
             # In the case of schema evolution, the column might not be present
             # we can use the default value as a constant and evaluate it against
             # the predicate

--- a/pyiceberg/expressions/visitors.py
+++ b/pyiceberg/expressions/visitors.py
@@ -896,16 +896,13 @@ class _ColumnNameTranslator(BooleanExpressionVisitor[BooleanExpression]):
         field = predicate.term.ref().field
         file_column_name = self.file_schema.find_column_name(field.field_id)
 
+        # In the case of schema evolution or column projection, the field might not be present in the file schema
         if file_column_name is None:
-            # In the case of column projection, the field might not be present in the file schema
-            # If the field has no initial_default, return AlwaysTrue to include all rows
-            # for further evaluation
+            # If the field has no initial_default, return AlwaysTrue to include all rows for further evaluation
             if field.initial_default is None:
                 return AlwaysTrue()
 
-            # In the case of schema evolution, the column might not be present
-            # we can use the default value as a constant and evaluate it against
-            # the predicate
+            # If the field has initial_default, use the default value as a constant and evaluate it against the predicate
             pred: BooleanExpression
             if isinstance(predicate, BoundUnaryPredicate):
                 pred = predicate.as_unbound(field.name)

--- a/pyiceberg/expressions/visitors.py
+++ b/pyiceberg/expressions/visitors.py
@@ -898,7 +898,9 @@ class _ColumnNameTranslator(BooleanExpressionVisitor[BooleanExpression]):
 
         # In the case of schema evolution or column projection, the field might not be present in the file schema
         if file_column_name is None:
-            # If the field has no initial_default, return AlwaysTrue to include all rows for further evaluation
+            # If the field has no initial_default, return AlwaysTrue to include all rows for further evaluation.
+            # This ensures that the predicate is evaluated during row-level filtering rather than being eliminated
+            # at the file level, preserving the ability to apply more granular filtering later in the process.
             if field.initial_default is None:
                 return AlwaysTrue()
 

--- a/tests/io/test_pyarrow.py
+++ b/tests/io/test_pyarrow.py
@@ -1197,6 +1197,16 @@ def test_identity_transform_column_projection(tmp_path: str, catalog: InMemoryCa
         },
         schema=schema,
     )
+    # Test that the partition value is projected correctly
+    assert table.scan(row_filter="partition_id = 1").to_arrow() == pa.table(
+        {
+            "other_field": ["foo", "bar", "baz"],
+            "partition_id": [1, 1, 1],
+        },
+        schema=schema,
+    )
+    # Test that the partition value is not projected for a non-existing partition
+    assert len(table.scan(row_filter="partition_id = -1").to_arrow()) == 0
 
 
 def test_identity_transform_columns_projection(tmp_path: str, catalog: InMemoryCatalog) -> None:


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
Closes #2028
Heavily inspired by #2029 (thanks @Erigara)

This PR fixes a bug where predicate evaluation for a column that is not in the parquet file schema will return no result. This is due to  `_ColumnNameTranslator` visitor returning `AlwaysFalse` when the column cannot be found in the file schema.

This PR follows the change in #1644 to evaluate predicates based on a field's `initial_default`. When the evaluated field does not have `initial_default`, `_ColumnNameTranslator` will now return `AlwaysTrue` to scan the entire parquet file and pass the result along for further evaluation. 

# Are these changes tested?
Yes, added some unit tests for `_ColumnNameTranslator`/`translate_column_names`
Added a test for predicate evaluation for projected columns. 

# Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
