### PR TITLE
Add delete file index to pyiceberg and support equality delete reads

### DIFF
--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -1104,7 +1104,6 @@ def _read_deletes(io: FileIO, data_file: DataFile) -> dict[str, pa.ChunkedArray]
     elif data_file.file_format == FileFormat.PUFFIN:
         with io.new_input(data_file.file_path).open() as fi:
             payload = fi.read()
-
         return PuffinFile(payload).to_vector()
     else:
         raise ValueError(f"Delete file format not supported: {data_file.file_format}")
@@ -1705,7 +1704,7 @@ def _read_all_delete_files(io: FileIO, tasks: Iterable[FileScanTask]) -> dict[st
     }
     if deletion_vectors:
         executor = ExecutorFactory.get_or_create()
-        dv_results: Iterator[Dict[str, ChunkedArray]] = executor.map(
+        dv_results: Iterator[dict[str, ChunkedArray]] = executor.map(
             lambda args: _read_deletes(*args),
             [(io, delete_file) for delete_file in deletion_vectors],
         )

--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -1070,9 +1070,7 @@ def _get_file_format(file_format: FileFormat, **kwargs: dict[str, Any]) -> ds.Fi
 
 def _construct_fragment(io: FileIO, data_file: DataFile, file_format_kwargs: dict[str, Any] = EMPTY_DICT) -> ds.Fragment:
     with io.new_input(data_file.file_path).open() as fi:
-        return _get_file_format(
-            data_file.file_format, **file_format_kwargs
-        ).make_fragment(fi)
+        return _get_file_format(data_file.file_format, **file_format_kwargs).make_fragment(fi)
 
 
 def _read_deletes(io: FileIO, data_file: DataFile) -> dict[str, pa.ChunkedArray] | pa.Table:
@@ -3041,16 +3039,16 @@ def _get_field_from_arrow_table(arrow_table: pa.Table, field_path: str) -> pa.Ar
 
 
 def _group_deletes_by_equality_ids(
-    task_eq_files: List[DataFile], equality_delete_tables: List[pa.Table]
-) -> dict[FrozenSet[int], pa.Table]:
+    task_eq_files: list[DataFile], equality_delete_tables: list[pa.Table]
+) -> dict[frozenset[int], pa.Table]:
     """Concatenate equality delete tables by their equality IDs to reduce number of anti joins."""
     from collections import defaultdict
 
-    equality_delete_groups: Dict[FrozenSet[int], pa.Table] = {}
+    equality_delete_groups: dict[frozenset[int], pa.Table] = {}
     group_map = defaultdict(list)
 
     # Group the tables by their equality IDs
-    for delete_file, delete_table in zip(task_eq_files, equality_delete_tables):
+    for delete_file, delete_table in zip(task_eq_files, equality_delete_tables, strict=True):
         if delete_file.equality_ids is not None:
             key = frozenset(delete_file.equality_ids)
             group_map[key].append(delete_table)
@@ -3063,7 +3061,7 @@ def _group_deletes_by_equality_ids(
 
 
 def _apply_equality_deletes(
-    data_table: pa.Table, delete_table: pa.Table, equality_ids: List[int], data_schema: Optional[Schema]
+    data_table: pa.Table, delete_table: pa.Table, equality_ids: list[int], data_schema: Schema | None
 ) -> pa.Table:
     """Apply equality deletes to a data table.
 

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -33,7 +33,6 @@ from typing import (
 )
 
 from pydantic import Field
-from sortedcontainers import SortedList
 
 import pyiceberg.expressions.parser as parser
 from pyiceberg.expressions import (
@@ -56,7 +55,6 @@ from pyiceberg.expressions.visitors import (
 )
 from pyiceberg.io import FileIO, load_file_io
 from pyiceberg.manifest import (
-    POSITIONAL_DELETE_SCHEMA,
     DataFile,
     DataFileContent,
     ManifestContent,
@@ -70,6 +68,7 @@ from pyiceberg.partitioning import (
     PartitionSpec,
 )
 from pyiceberg.schema import Schema
+from pyiceberg.table.delete_file_index import DeleteFileIndex
 from pyiceberg.table.inspect import InspectTable
 from pyiceberg.table.locations import LocationProvider, load_location_provider
 from pyiceberg.table.maintenance import MaintenanceTable
@@ -1829,29 +1828,20 @@ def _min_sequence_number(manifests: list[ManifestFile]) -> int:
         return INITIAL_SEQUENCE_NUMBER
 
 
-def _match_deletes_to_data_file(data_entry: ManifestEntry, positional_delete_entries: SortedList[ManifestEntry]) -> set[DataFile]:
-    """Check if the delete file is relevant for the data file.
-
-    Using the column metrics to see if the filename is in the lower and upper bound.
+def _match_deletes_to_data_file(data_entry: ManifestEntry, delete_file_index: DeleteFileIndex) -> set[DataFile]:
+    """Check if delete files are relevant for the data file.
 
     Args:
-        data_entry (ManifestEntry): The manifest entry path of the datafile.
-        positional_delete_entries (List[ManifestEntry]): All the candidate positional deletes manifest entries.
+        data_entry (ManifestEntry): The manifest entry of the data file.
+        delete_file_index (DeleteFileIndex): Index containing all delete files.
 
     Returns:
-        A set of files that are relevant for the data file.
+        A set of delete files that are relevant for the data file.
     """
-    relevant_entries = positional_delete_entries[positional_delete_entries.bisect_right(data_entry) :]
-
-    if len(relevant_entries) > 0:
-        evaluator = _InclusiveMetricsEvaluator(POSITIONAL_DELETE_SCHEMA, EqualTo("file_path", data_entry.data_file.file_path))
-        return {
-            positional_delete_entry.data_file
-            for positional_delete_entry in relevant_entries
-            if evaluator.eval(positional_delete_entry.data_file)
-        }
-    else:
-        return set()
+    candidate_deletes = delete_file_index.for_data_file(
+        data_entry.sequence_number or 0, data_entry.data_file, partition_key=data_entry.data_file.partition
+    )
+    return set(candidate_deletes)
 
 
 class DataScan(TableScan):
@@ -1977,7 +1967,7 @@ class DataScan(TableScan):
             List of FileScanTasks that contain both data and delete files.
         """
         data_entries: list[ManifestEntry] = []
-        positional_delete_entries = SortedList(key=lambda entry: entry.sequence_number or INITIAL_SEQUENCE_NUMBER)
+        delete_file_index = DeleteFileIndex(self.table_metadata.schema(), self.table_metadata.specs())
 
         residual_evaluators: dict[int, Callable[[DataFile], ResidualEvaluator]] = KeyDefaultDict(self._build_residual_evaluator)
 
@@ -1985,19 +1975,16 @@ class DataScan(TableScan):
             data_file = manifest_entry.data_file
             if data_file.content == DataFileContent.DATA:
                 data_entries.append(manifest_entry)
-            elif data_file.content == DataFileContent.POSITION_DELETES:
-                positional_delete_entries.add(manifest_entry)
-            elif data_file.content == DataFileContent.EQUALITY_DELETES:
-                raise ValueError("PyIceberg does not yet support equality deletes: https://github.com/apache/iceberg/issues/6568")
+            elif data_file.content in (DataFileContent.POSITION_DELETES, DataFileContent.EQUALITY_DELETES):
+                delete_file_index.add_delete_file(manifest_entry, partition_key=data_file.partition)
             else:
                 raise ValueError(f"Unknown DataFileContent ({data_file.content}): {manifest_entry}")
-
         return [
             FileScanTask(
                 data_entry.data_file,
                 delete_files=_match_deletes_to_data_file(
                     data_entry,
-                    positional_delete_entries,
+                    delete_file_index,
                 ),
                 residual=residual_evaluators[data_entry.data_file.spec_id](data_entry.data_file).residual_for(
                     data_entry.data_file.partition

--- a/pyiceberg/table/delete_file_index.py
+++ b/pyiceberg/table/delete_file_index.py
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 from bisect import bisect_left
 from typing import Any, Dict, List, Optional, Tuple, Union
 

--- a/pyiceberg/table/delete_file_index.py
+++ b/pyiceberg/table/delete_file_index.py
@@ -418,7 +418,10 @@ class DeleteFileIndex:
             if delete_file.file_format == FileFormat.PUFFIN:
                 sequence_number = manifest_entry.sequence_number or 0
                 path = delete_file.file_path
-                self.dv[path] = (delete_file, sequence_number)
+                if path not in self.dv:
+                    self.dv[path] = (delete_file, sequence_number)
+                else:
+                    raise ValueError(f"Can't index multiple DVs for {path}: {self.dv[path]} and {(delete_file, sequence_number)}")
             else:
                 pos_wrapper = PositionalDeleteFileWrapper(manifest_entry)
 

--- a/pyiceberg/table/delete_file_index.py
+++ b/pyiceberg/table/delete_file_index.py
@@ -1,0 +1,512 @@
+from bisect import bisect_left
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from pyiceberg.conversions import from_bytes
+from pyiceberg.expressions import EqualTo
+from pyiceberg.expressions.visitors import _InclusiveMetricsEvaluator
+from pyiceberg.manifest import POSITIONAL_DELETE_SCHEMA, DataFile, DataFileContent, FileFormat, ManifestEntry
+from pyiceberg.partitioning import PartitionSpec
+from pyiceberg.schema import Schema
+from pyiceberg.typedef import Record
+from pyiceberg.types import NestedField
+from pyiceberg.utils.partition_map import PartitionMap
+
+PATH_FIELD_ID = 2147483546
+
+
+class EqualityDeleteFileWrapper:
+    """Stores the equality delete file along with the sequence number."""
+
+    def __init__(self, manifest_entry: ManifestEntry, schema: Schema) -> None:
+        """Initialize a new EqualityDeleteFileWrapper.
+
+        Args:
+            manifest_entry: The manifest entry containing the delete file
+            schema: The table schema for field lookups
+        """
+        self.delete_file = manifest_entry.data_file
+        self.schema = schema
+        self.apply_sequence_number = (manifest_entry.sequence_number or 0) - 1
+        self._converted_lower_bounds: Optional[Dict[int, Any]] = None
+        self._converted_upper_bounds: Optional[Dict[int, Any]] = None
+        self._equality_fields: Optional[List[NestedField]] = None
+
+    def equality_fields(self) -> List[NestedField]:
+        """Get equality fields for current delete file.
+
+        Returns:
+            List of NestedField objects representing the equality fields
+        """
+        if self._equality_fields is None:
+            fields = []
+            for field_id in self.delete_file.equality_ids or []:
+                field = self.schema.find_field(field_id)
+                if field:
+                    fields.append(field)
+            self._equality_fields = fields
+        return self._equality_fields
+
+    def lower_bound(self, field_id: int) -> Optional[Any]:
+        """Convert or get lower bound for a field.
+
+        Args:
+            field_id: The field ID to get the bound for
+
+        Returns:
+            The converted lower bound value or None if not available
+        """
+        if self._converted_lower_bounds is None:
+            self._converted_lower_bounds = self._convert_bounds(self.delete_file.lower_bounds)
+        return self._converted_lower_bounds.get(field_id)
+
+    def upper_bound(self, field_id: int) -> Optional[Any]:
+        """Convert or get upper bound for a field.
+
+        Args:
+            field_id: The field ID to get the bound for
+
+        Returns:
+            The converted upper bound value or None if not available
+        """
+        if self._converted_upper_bounds is None:
+            self._converted_upper_bounds = self._convert_bounds(self.delete_file.upper_bounds)
+        return self._converted_upper_bounds.get(field_id)
+
+    def _convert_bounds(self, bounds: Dict[int, bytes]) -> Dict[int, Any]:
+        """Convert byte bounds to their proper types.
+
+        Args:
+            bounds: Dictionary mapping field IDs to byte bounds
+
+        Returns:
+            Dictionary mapping field IDs to converted bound values
+        """
+        if not bounds:
+            return {}
+
+        converted = {}
+        for field in self.equality_fields():
+            field_id = field.field_id
+            bound = bounds.get(field_id)
+            if bound is not None:
+                # Use the field type to convert the bound
+                converted[field_id] = from_bytes(field.field_type, bound)
+        return converted
+
+
+class PositionalDeleteFileWrapper:
+    """Stores the position delete file along with the sequence number for filtering."""
+
+    def __init__(self, manifest_entry: ManifestEntry):
+        """Initialize a new PositionalDeleteFileWrapper.
+
+        Args:
+            manifest_entry: The manifest entry containing the delete file
+        """
+        self.delete_file = manifest_entry.data_file
+        self.apply_sequence_number = manifest_entry.sequence_number or 0
+
+
+class DeletesGroup:
+    """Base class for managing collections of delete files with lazy sorting and binary search.
+
+    Provides O(1) insertion with deferred O(n log n) sorting and O(log n + k) filtering
+    where k is the number of matching delete files.
+    """
+
+    def __init__(self) -> None:
+        """Initialize a new DeletesGroup."""
+        self._buffer: Optional[List[Any]] = []
+        self._sorted: bool = False  # Lazy sorting flag
+        self._seqs: Optional[List[int]] = None
+        self._files: Optional[List[Any]] = None
+
+    def add(self, wrapper: Any) -> None:
+        """Add a delete file wrapper to the group.
+
+        Args:
+            wrapper: The delete file wrapper to add
+
+        Raises:
+            ValueError: If attempting to add files after indexing
+        """
+        if self._buffer is None:
+            raise ValueError("Can't add files to group after indexing")
+        self._buffer.append(wrapper)
+        self._sorted = False
+
+    def _index_if_needed(self) -> None:
+        """Sort wrappers by apply_sequence_number if not already sorted.
+
+        This method implements lazy sorting to avoid unnecessary work when
+        files are only added but not queried.
+        """
+        if not self._sorted:
+            self._files = sorted(self._buffer, key=lambda f: f.apply_sequence_number)  # type: ignore
+            self._seqs = [f.apply_sequence_number for f in self._files]
+            self._buffer = None
+            self._sorted = True
+
+    def _get_candidates(self, seq: int) -> List[Any]:
+        """Get delete files with apply_sequence_number >= seq using binary search.
+
+        Args:
+            seq: The sequence number to filter by
+
+        Returns:
+            List of delete file wrappers with sequence number >= seq
+        """
+        self._index_if_needed()
+
+        if not self._files or not self._seqs:
+            return []
+
+        start_idx = bisect_left(self._seqs, seq)
+
+        if start_idx >= len(self._files):
+            return []
+
+        return self._files[start_idx:]
+
+
+class EqualityDeletesGroup(DeletesGroup):
+    """Extends the base DeletesGroup with equality-specific filtering logic.
+
+    Uses file statistics and bounds to eliminate impossible matches before expensive operations.
+    This optimization significantly reduces the number of delete files that need to be processed
+    during scan planning.
+    """
+
+    def filter(self, seq: int, data_file: DataFile) -> List[DataFile]:
+        """Find equality deletes that could apply to the data file.
+
+        Args:
+            seq: The sequence number to filter by
+            data_file: The data file to check against
+
+        Returns:
+            List of delete files that may apply to the data file
+        """
+        candidates = self._get_candidates(seq)
+
+        matching_files = []
+        for wrapper in candidates:
+            if self._can_contain_eq_deletes_for_file(data_file, wrapper):
+                matching_files.append(wrapper.delete_file)
+
+        return matching_files
+
+    def _can_contain_eq_deletes_for_file(self, data_file: DataFile, delete_wrapper: EqualityDeleteFileWrapper) -> bool:
+        """Check if a data file might contain rows deleted by an equality delete file.
+
+        This method uses statistics (bounds and null counts) to determine if a delete file
+        could possibly match any rows in a data file, avoiding unnecessary processing.
+
+        Args:
+            data_file: The data file to check
+            delete_wrapper: The equality delete file wrapper
+
+        Returns:
+            True if the delete file might apply to the data file, False otherwise
+        """
+        data_lowers = data_file.lower_bounds
+        data_uppers = data_file.upper_bounds
+        delete_file = delete_wrapper.delete_file
+
+        # Check bounds and null counts if available
+        data_null_counts = data_file.null_value_counts or {}
+        data_value_counts = data_file.value_counts or {}
+        delete_null_counts = delete_file.null_value_counts or {}
+        delete_value_counts = delete_file.value_counts or {}
+
+        # Check each equality field
+        for field in delete_wrapper.equality_fields():
+            if not field.field_type.is_primitive:
+                continue
+            field_id = field.field_id
+
+            # Check null values
+            if not field.required:
+                data_has_nulls = data_null_counts.get(field_id, 0) > 0
+                delete_has_nulls = delete_null_counts.get(field_id, 0) > 0
+                if data_has_nulls and delete_has_nulls:
+                    continue
+
+                # If data is all nulls but delete doesn't delete nulls, no match
+                data_all_nulls = data_null_counts.get(field_id, 0) == data_value_counts.get(field_id, 0)
+                if data_all_nulls and not delete_has_nulls:
+                    return False
+
+                # If delete is all nulls but data has no nulls, no match
+                delete_all_nulls = delete_null_counts.get(field_id, 0) == delete_value_counts.get(field_id, 0)
+                if delete_all_nulls and not data_has_nulls:
+                    return False
+
+            # Check bounds overlap if available
+            if (
+                data_lowers is not None
+                and data_uppers is not None
+                and delete_file.lower_bounds is not None
+                and delete_file.upper_bounds is not None
+            ):
+                data_lower_bytes = data_lowers.get(field_id)
+                data_upper_bytes = data_uppers.get(field_id)
+                delete_lower = delete_wrapper.lower_bound(field_id)
+                delete_upper = delete_wrapper.upper_bound(field_id)
+
+                # If any bound is missing, assume they overlap
+                if data_lower_bytes is None or data_upper_bytes is None or delete_lower is None or delete_upper is None:
+                    continue
+
+                # converting data file bounds
+                data_lower = from_bytes(field.field_type, data_lower_bytes)
+                data_upper = from_bytes(field.field_type, data_upper_bytes)
+
+                # Check if bounds don't overlap
+                if data_lower > delete_upper or data_upper < delete_lower:
+                    return False
+
+        return True
+
+
+class PositionalDeletesGroup(DeletesGroup):
+    """Extends the base DeletesGroup with positional-specific filtering.
+
+    Uses file path evaluation to determine which deletes apply to which data files.
+    This class handles both path-specific position deletes and partition-level position deletes.
+    """
+
+    def _is_file_targeted_by_delete(self, delete_file: DataFile, data_file: DataFile) -> bool:
+        """Check if a position delete file targets a specific data file.
+
+        Args:
+            delete_file: The position delete file to check
+            data_file: The data file to check against
+
+        Returns:
+            True if the delete file targets the data file, False otherwise
+        """
+        has_path_bounds = (
+            delete_file.lower_bounds
+            and delete_file.upper_bounds
+            and PATH_FIELD_ID in delete_file.lower_bounds
+            and PATH_FIELD_ID in delete_file.upper_bounds
+        )
+
+        if not has_path_bounds:
+            # applies to all files in the partition
+            return True
+
+        try:
+            lower_path = delete_file.lower_bounds[PATH_FIELD_ID].decode("utf-8")
+            upper_path = delete_file.upper_bounds[PATH_FIELD_ID].decode("utf-8")
+
+            if lower_path == upper_path and lower_path == data_file.file_path:
+                return True
+        except (UnicodeDecodeError, AttributeError):
+            # If we can't decode the path bounds, fall back to the metrics evaluator
+            pass
+
+        # Use metrics evaluator for more complex path matching
+        evaluator = _InclusiveMetricsEvaluator(POSITIONAL_DELETE_SCHEMA, EqualTo("file_path", data_file.file_path))
+        return evaluator.eval(delete_file)
+
+    def filter(self, seq: int, data_file: DataFile) -> List[DataFile]:
+        """Filter positional delete files that apply to the given sequence number and data file.
+
+        Args:
+            seq: The sequence number to filter by
+            data_file: The data file to check against
+
+        Returns:
+            List of delete files that apply to the data file
+        """
+        candidates = self._get_candidates(seq)
+
+        matching_files = []
+        for wrapper in candidates:
+            delete_file = wrapper.delete_file
+            if self._is_file_targeted_by_delete(delete_file, data_file):
+                matching_files.append(delete_file)
+
+        return matching_files
+
+
+class DeleteFileIndex:
+    """Main index that organizes delete files by partition for efficient lookup during scan planning.
+
+    This class indexes delete files by type (equality or positional), partition, and path
+    to enable efficient lookup of delete files that apply to a given data file.
+    """
+
+    def __init__(self, table_schema: Schema, partition_specs: Optional[Dict[int, PartitionSpec]] = None) -> None:
+        """Initialize a DeleteFileIndex.
+
+        Args:
+            table_schema: The table schema for field lookups
+            partition_specs: Dictionary mapping spec IDs to PartitionSpec objects
+        """
+        self.table_schema = table_schema
+        self.partition_specs = partition_specs or {}
+
+        # Global deletes
+        self.global_eq_deletes = EqualityDeletesGroup()
+
+        # Partition-specific deletes
+        self.eq_deletes_by_partition: PartitionMap[EqualityDeletesGroup] = PartitionMap(self.partition_specs)
+        self.pos_deletes_by_partition: PartitionMap[PositionalDeletesGroup] = PartitionMap(self.partition_specs)
+
+        # Path-specific deletes
+        self.pos_deletes_by_path: Dict[str, PositionalDeletesGroup] = {}
+        self.dv: Dict[str, Tuple[DataFile, int]] = {}
+        self.dv_values: Optional[List[Tuple[DataFile, int]]] = None
+        self.dv_sorted: bool = False
+
+    def add_delete_file(self, manifest_entry: ManifestEntry, partition_key: Optional[Record] = None) -> None:
+        """Add delete file to the appropriate partition group based on its type.
+
+        Args:
+            manifest_entry: The manifest entry containing the delete file
+            partition_key: The partition key for the delete file, if applicable
+
+        Raises:
+            ValueError: If attempting to add multiple deletion vectors for the same data file
+        """
+        data_file = manifest_entry.data_file
+
+        if data_file.content == DataFileContent.EQUALITY_DELETES:
+            # Skip equality deletes without equality_ids
+            if not data_file.equality_ids or len(data_file.equality_ids) == 0:
+                return
+
+            wrapper = EqualityDeleteFileWrapper(manifest_entry, self.table_schema)
+
+            # Check if the partition spec is unpartitioned
+            is_unpartitioned = False
+            spec_id = data_file.spec_id or 0
+
+            if spec_id in self.partition_specs:
+                spec = self.partition_specs[spec_id]
+                # A spec is unpartitioned when it has no partition fields
+                is_unpartitioned = spec.is_unpartitioned()
+
+            if is_unpartitioned:
+                # If the spec is unpartitioned, add to global deletes
+                self._add_to_partition_group(wrapper, None)
+            else:
+                # Otherwise, add to partition-specific deletes
+                self._add_to_partition_group(wrapper, partition_key)
+
+        elif data_file.content == DataFileContent.POSITION_DELETES:
+            # Check if this is a deletion vector (Puffin format)
+            if data_file.file_format == FileFormat.PUFFIN:
+                sequence_number = manifest_entry.sequence_number or 0
+                path = data_file.file_path
+                self.dv[path] = (data_file, sequence_number)
+            else:
+                pos_wrapper = PositionalDeleteFileWrapper(manifest_entry)
+
+                target_path = self.get_referenced_data_file(data_file)
+                if target_path:
+                    # Index by target file path
+                    self.pos_deletes_by_path.setdefault(target_path, PositionalDeletesGroup()).add(pos_wrapper)
+                else:
+                    # Index by partition
+                    self._add_to_partition_group(pos_wrapper, partition_key)
+
+    def get_referenced_data_file(self, data_file: DataFile) -> Optional[str]:
+        """Extract the target data file path from a position delete file.
+
+        Args:
+            data_file: The position delete file
+
+        Returns:
+            The referenced data file path or None if not available
+        """
+        if data_file.content != DataFileContent.POSITION_DELETES or not (data_file.lower_bounds and data_file.upper_bounds):
+            return None
+
+        lower_bound = data_file.lower_bounds.get(PATH_FIELD_ID)
+        upper_bound = data_file.upper_bounds.get(PATH_FIELD_ID)
+
+        if lower_bound and upper_bound and lower_bound == upper_bound:
+            try:
+                return lower_bound.decode("utf-8")
+            except (UnicodeDecodeError, AttributeError):
+                pass
+
+        return None
+
+    def _add_to_partition_group(
+        self, wrapper: Union[EqualityDeleteFileWrapper, PositionalDeleteFileWrapper], partition_key: Optional[Record]
+    ) -> None:
+        """Add wrapper to the appropriate partition group based on wrapper type.
+
+        Args:
+            wrapper: The delete file wrapper to add
+            partition_key: The partition key for the delete file, if applicable
+        """
+        # Get spec_id from the delete file if available, otherwise use default spec_id 0
+        spec_id = wrapper.delete_file.spec_id or 0
+
+        if isinstance(wrapper, EqualityDeleteFileWrapper):
+            if partition_key is None:
+                # Global equality deletes
+                self.global_eq_deletes.add(wrapper)
+            else:
+                # Partition-specific equality deletes
+                group_eq = self.eq_deletes_by_partition.compute_if_absent(spec_id, partition_key, lambda: EqualityDeletesGroup())
+                group_eq.add(wrapper)
+        else:
+            # Position deletes - both partitioned and unpartitioned deletes
+            group_pos = self.pos_deletes_by_partition.compute_if_absent(spec_id, partition_key, lambda: PositionalDeletesGroup())
+            group_pos.add(wrapper)
+
+    def for_data_file(self, seq: int, data_file: DataFile, partition_key: Optional[Record] = None) -> List[DataFile]:
+        """Find all delete files that apply to the given data file.
+
+        This method combines global deletes, partition-specific deletes, and path-specific deletes
+        to determine all delete files that apply to a given data file.
+
+        Args:
+            seq: The sequence number of the data file
+            data_file: The data file to find deletes for
+            partition_key: The partition key for the data file, if applicable
+
+        Returns:
+            List of delete files that apply to the data file
+
+        """
+        deletes = []
+
+        # Global equality deletes (apply to all partitions)
+        deletes.extend(self.global_eq_deletes.filter(seq, data_file))
+
+        # Partition-specific equality deletes
+        spec_id = data_file.spec_id or 0
+        if partition_key is not None:
+            eq_group = self.eq_deletes_by_partition.get(spec_id, partition_key)
+            if eq_group:
+                deletes.extend(eq_group.filter(seq, data_file))
+
+        # Check for deletion vector
+        if self.dv:
+            if not self.dv_sorted:
+                self.dv_values = sorted(self.dv.values(), key=lambda x: x[1])
+                self.dv_sorted = True
+
+            start_idx = bisect_left([item[1] for item in self.dv_values], seq)
+            deletes.extend([item[0] for item in self.dv_values[start_idx:]])
+
+        # Add position deletes
+        pos_group = self.pos_deletes_by_partition.get(spec_id, partition_key)
+        if pos_group:
+            deletes.extend(pos_group.filter(seq, data_file))
+
+        # Path-specific positional deletes
+        file_path = data_file.file_path
+        if file_path in self.pos_deletes_by_path:
+            deletes.extend(self.pos_deletes_by_path[file_path].filter(seq, data_file))
+
+        return deletes
+

--- a/pyiceberg/utils/partition_map.py
+++ b/pyiceberg/utils/partition_map.py
@@ -1,0 +1,59 @@
+from typing import Any, Callable, Dict, Generic, Iterator, Optional, Tuple, TypeVar
+
+from pyiceberg.partitioning import PartitionSpec
+from pyiceberg.typedef import Record
+
+T = TypeVar("T")
+
+
+class PartitionMap(Generic[T]):
+    """A map-like structure that organizes values by partition spec ID and partition values.
+
+    Attributes:
+        _specs_by_id: Dictionary mapping spec IDs to PartitionSpec objects
+        _map: Internal dictionary storing values by composite keys
+
+    """
+
+    def __init__(self, specs_by_id: Optional[Dict[int, PartitionSpec]] = None) -> None:
+        """Initialize a new PartitionMap."""
+        self._specs_by_id = specs_by_id or {}
+        self._map: Dict[Tuple[int, Tuple[Any, ...]], T] = {}
+
+    def get(self, spec_id: int, partition: Optional[Record]) -> Optional[T]:
+        """Get a value by spec ID and partition."""
+        key = self._make_key(spec_id, partition)
+        return self._map.get(key)
+
+    def put(self, spec_id: int, partition: Optional[Record], value: T) -> None:
+        """Put a value by spec ID and partition."""
+        if spec_id not in self._specs_by_id:
+            raise ValueError(f"Cannot find spec with ID {spec_id}: {self._specs_by_id}")
+        key = self._make_key(spec_id, partition)
+        self._map[key] = value
+
+    def compute_if_absent(self, spec_id: int, partition: Optional[Record], factory: Callable[[], T]) -> T:
+        """Get a value by spec ID and partition, creating it if it doesn't exist."""
+        if spec_id not in self._specs_by_id:
+            raise ValueError(f"Cannot find spec with ID {spec_id}: {self._specs_by_id}")
+
+        key = self._make_key(spec_id, partition)
+        if key not in self._map:
+            self._map[key] = factory()
+        return self._map[key]
+
+    def _make_key(self, spec_id: int, partition: Optional[Record]) -> Tuple[int, Tuple[Any, ...]]:
+        """Create a composite key from spec ID and partition."""
+        if partition is None:
+            partition_values = ()
+        else:
+            partition_values = tuple(partition._data)
+        return spec_id, partition_values
+
+    def values(self) -> Iterator[T]:
+        """Get all values in the map."""
+        return iter(self._map.values())
+
+    def is_empty(self) -> bool:
+        """Check if the map is empty."""
+        return len(self._map) == 0

--- a/pyiceberg/utils/partition_map.py
+++ b/pyiceberg/utils/partition_map.py
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 from typing import Any, Callable, Dict, Generic, Iterator, Optional, Tuple, TypeVar
 
 from pyiceberg.partitioning import PartitionSpec

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2473,7 +2473,7 @@ def example_task_orc(data_file_orc: str) -> FileScanTask:
 
 
 @pytest.fixture
-def equality_delete_task(table_schema_simple: Schema, tmp_path: str) -> FileScanTask:
+def simple_scan_task(table_schema_simple: Schema, tmp_path: str) -> FileScanTask:
     import pyarrow as pa
     from pyarrow import parquet as pq
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2487,20 +2487,21 @@ def simple_scan_task(table_schema_simple: Schema, tmp_path: str) -> FileScanTask
     file_path = f"{tmp_path}/equality-data.parquet"
     pq.write_table(table=table, where=file_path)
 
-    return FileScanTask(
-        data_file=DataFile.from_args(
-            file_path=file_path,
-            file_format=FileFormat.PARQUET,
-            record_count=4,
-            column_sizes={1: 10, 2: 10},
-            value_counts={1: 4, 2: 4},
-            null_value_counts={1: 0, 2: 0},
-            nan_value_counts={},
-            lower_bounds={1: b"a", 2: b"\x01\x00\x00\x00"},
-            upper_bounds={1: b"d", 2: b"\x04\x00\x00\x00"},
-            key_metadata=None,
-        ),
+    data_file = DataFile.from_args(
+        file_path=file_path,
+        file_format=FileFormat.PARQUET,
+        record_count=4,
+        column_sizes={1: 10, 2: 10},
+        value_counts={1: 4, 2: 4},
+        null_value_counts={1: 0, 2: 0},
+        nan_value_counts={},
+        lower_bounds={1: b"a", 2: b"\x01\x00\x00\x00"},
+        upper_bounds={1: b"d", 2: b"\x04\x00\x00\x00"},
+        key_metadata=None,
     )
+    data_file.spec_id = 0
+
+    return FileScanTask(data_file=data_file)
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/test_delete_file_integration.py
+++ b/tests/integration/test_delete_file_integration.py
@@ -1,0 +1,270 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import pandas as pd
+import pytest
+from pyspark.sql import SparkSession
+
+from pyiceberg.catalog import Catalog
+
+
+@pytest.mark.integration
+def test_basic_positional_deletes(spark: SparkSession, session_catalog: Catalog) -> None:
+    identifier = "default.test_basic_positional_deletes"
+
+    spark.sql(f"DROP TABLE IF EXISTS {identifier}")
+    spark.sql(f"""
+        CREATE TABLE {identifier} (id INT, data STRING)
+        USING iceberg
+        TBLPROPERTIES(
+            'format-version' = '2',
+            'write.delete.mode' = 'merge-on-read',
+            'write.update.mode' = 'merge-on-read',
+            'write.merge.mode' = 'merge-on-read'
+        )
+    """)
+
+    spark.sql(f"INSERT INTO {identifier} VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e')")
+    spark.sql(f"DELETE FROM {identifier} WHERE id IN (2, 4)")
+
+    # Expected output
+    # {
+    #     "id": [1, 3, 5],
+    #     "data": ["a", "c", "e"]
+    # }
+
+    spark_df = spark.sql(f"SELECT * FROM {identifier} ORDER BY id").toPandas()
+
+    table = session_catalog.load_table(identifier)
+    pyiceberg_df = table.scan().to_pandas().sort_values("id").reset_index(drop=True)
+    pd.testing.assert_frame_equal(spark_df, pyiceberg_df, check_dtype=False)
+
+
+@pytest.mark.integration
+def test_partitioned_deletes(spark: SparkSession, session_catalog: Catalog) -> None:
+    identifier = "default.test_partitioned_deletes"
+
+    spark.sql(f"DROP TABLE IF EXISTS {identifier}")
+    spark.sql(f"""
+        CREATE TABLE {identifier} (id INT, data STRING, part INT)
+        USING iceberg
+        PARTITIONED BY (part)
+        TBLPROPERTIES(
+            'format-version' = '2',
+            'write.delete.mode' = 'merge-on-read',
+            'write.update.mode' = 'merge-on-read',
+            'write.merge.mode' = 'merge-on-read'
+        )
+    """)
+
+    spark.sql(f"""
+        INSERT INTO {identifier} VALUES
+        (1, 'a', 1), (2, 'b', 1), (3, 'c', 1),
+        (4, 'd', 2), (5, 'e', 2), (6, 'f', 2)
+    """)
+
+    spark.sql(f"DELETE FROM {identifier} WHERE part = 1 AND id = 2")
+
+    spark.sql(f"ALTER TABLE {identifier} SET TBLPROPERTIES('format-version' = '3')")
+
+    spark.sql(f"DELETE FROM {identifier} WHERE part = 2 AND id = 5")
+
+    # Expected output
+    # {
+    #     "id": [1, 3, 4, 5, 6],
+    #     "data": ["a", "c", "d", "e", "f"],
+    #     "part": [1, 1, 2, 2, 2]
+    # }
+
+    spark_df = spark.sql(f"SELECT * FROM {identifier} ORDER BY id").toPandas()
+
+    table = session_catalog.load_table(identifier)
+    pyiceberg_df = table.scan().to_pandas().sort_values("id").reset_index(drop=True)
+
+    pd.testing.assert_frame_equal(spark_df, pyiceberg_df, check_dtype=False)
+
+
+@pytest.mark.integration
+def test_multiple_deletes(spark: SparkSession, session_catalog: Catalog) -> None:
+    identifier = "default.test_multiple_deletes"
+
+    spark.sql(f"DROP TABLE IF EXISTS {identifier}")
+    spark.sql(f"""
+        CREATE TABLE {identifier} (id INT, data STRING, category STRING)
+        USING iceberg
+        TBLPROPERTIES(
+            'format-version' = '2',
+            'write.delete.mode' = 'merge-on-read',
+            'write.update.mode' = 'merge-on-read',
+            'write.merge.mode' = 'merge-on-read'
+        )
+    """)
+
+    spark.sql(f"""
+        INSERT INTO {identifier} VALUES
+        (1, 'a', 'x'), (2, 'b', 'y'), (3, 'c', 'x'),
+        (4, 'd', 'y'), (5, 'e', 'x'), (6, 'f', 'y')
+    """)
+
+    spark.sql(f"DELETE FROM {identifier} WHERE id = 1")
+    spark.sql(f"DELETE FROM {identifier} WHERE category = 'y' AND id > 4")
+    spark.sql(f"DELETE FROM {identifier} WHERE data = 'c'")
+
+    spark_df = spark.sql(f"SELECT * FROM {identifier} ORDER BY id").toPandas()
+
+    table = session_catalog.load_table(identifier)
+    pyiceberg_df = table.scan().to_pandas().sort_values("id").reset_index(drop=True)
+
+    pd.testing.assert_frame_equal(spark_df, pyiceberg_df, check_dtype=False)
+
+
+@pytest.mark.integration
+def test_sequence_number_filtering(spark: SparkSession, session_catalog: Catalog) -> None:
+    identifier = "default.test_sequence_number_filtering"
+
+    spark.sql(f"DROP TABLE IF EXISTS {identifier}")
+    spark.sql(f"""
+        CREATE TABLE {identifier} (id INT, data STRING)
+        USING iceberg
+        TBLPROPERTIES(
+            'format-version' = '2',
+            'write.delete.mode' = 'merge-on-read',
+            'write.update.mode' = 'merge-on-read',
+            'write.merge.mode' = 'merge-on-read'
+        )
+    """)
+
+    spark.sql(f"INSERT INTO {identifier} VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e')")  # Seq 0
+    spark.sql(f"DELETE FROM {identifier} WHERE id = 1")  # Seq 1
+    spark.sql(f"INSERT INTO {identifier} VALUES (6, 'f')")  # Seq 2
+    spark.sql(f"DELETE FROM {identifier} WHERE id = 3")  # Seq 3
+    spark.sql(f"INSERT INTO {identifier} VALUES (7, 'g')")  # Seq 4
+    spark.sql(f"DELETE FROM {identifier} WHERE id = 5")  # Seq 5
+
+    spark_df = spark.sql(f"SELECT * FROM {identifier} ORDER BY id").toPandas()
+
+    table = session_catalog.load_table(identifier)
+    pyiceberg_df = table.scan().to_pandas().sort_values("id").reset_index(drop=True)
+
+    pd.testing.assert_frame_equal(spark_df, pyiceberg_df, check_dtype=False)
+
+
+@pytest.mark.integration
+def test_unpartitioned_and_partitioned_deletes(spark: SparkSession, session_catalog: Catalog) -> None:
+    identifier = "default.test_unpartitioned_and_partitioned_deletes"
+
+    spark.sql(f"DROP TABLE IF EXISTS {identifier}")
+    spark.sql(f"""
+        CREATE TABLE {identifier} (id INT, data STRING, part INT)
+        USING iceberg
+        PARTITIONED BY (part)
+        TBLPROPERTIES(
+            'format-version' = '2',
+            'write.delete.mode' = 'merge-on-read',
+            'write.update.mode' = 'merge-on-read',
+            'write.merge.mode' = 'merge-on-read'
+        )
+    """)
+
+    spark.sql(f"""
+        INSERT INTO {identifier} VALUES
+        (1, 'a', 1), (2, 'b', 1), (3, 'c', 1),
+        (4, 'd', 2), (5, 'e', 2), (6, 'f', 2),
+        (7, 'g', 3), (8, 'h', 3), (9, 'i', 3)
+    """)
+
+    # Unpartitioned deletes
+    spark.sql(f"DELETE FROM {identifier} WHERE data IN ('b', 'e', 'h')")
+
+    # Partition-specific delete
+    spark.sql(f"DELETE FROM {identifier} WHERE part = 1 AND id = 3")
+
+    spark.sql(f"ALTER TABLE {identifier} SET TBLPROPERTIES('format-version' = '3')")
+
+    spark.sql(f"DELETE FROM {identifier} WHERE part = 3 AND id = 9")
+
+    spark_df = spark.sql(f"SELECT * FROM {identifier} ORDER BY id").toPandas()
+
+    table = session_catalog.load_table(identifier)
+    pyiceberg_df = table.scan().to_pandas().sort_values("id").reset_index(drop=True)
+
+    pd.testing.assert_frame_equal(spark_df, pyiceberg_df, check_dtype=False)
+
+
+@pytest.mark.integration
+def test_multi_partition(spark: SparkSession, session_catalog: Catalog) -> None:
+    identifier = "default.test_multi_partition"
+
+    spark.sql(f"DROP TABLE IF EXISTS {identifier}")
+    spark.sql(f"""
+        CREATE TABLE {identifier} (id INT, data STRING, year INT, month INT)
+        USING iceberg
+        PARTITIONED BY (year, month)
+        TBLPROPERTIES(
+            'format-version' = '2',
+            'write.delete.mode' = 'merge-on-read',
+            'write.update.mode' = 'merge-on-read',
+            'write.merge.mode' = 'merge-on-read'
+        )
+    """)
+
+    spark.sql(f"""
+        INSERT INTO {identifier}
+        SELECT id, CONCAT('data_', id), 2023 + (id % 2), 1 + (id % 12)
+        FROM range(500)
+    """)
+
+    spark.sql(f"DELETE FROM {identifier} WHERE year = 2023 AND month <= 3")
+    spark.sql(f"DELETE FROM {identifier} WHERE year = 2024 AND month > 9")
+    spark.sql(f"DELETE FROM {identifier} WHERE id % 10 = 0")
+
+    spark.sql(f"ALTER TABLE {identifier} SET TBLPROPERTIES('format-version' = '3')")
+
+    spark.sql(f"DELETE FROM {identifier} WHERE year = 2023 AND month = 6 AND id < 50")
+
+    spark_df = spark.sql(f"SELECT * FROM {identifier} ORDER BY id").toPandas()
+
+    table = session_catalog.load_table(identifier)
+    pyiceberg_df = table.scan().to_pandas().sort_values("id").reset_index(drop=True)
+
+    pd.testing.assert_frame_equal(spark_df, pyiceberg_df, check_dtype=False)
+
+
+@pytest.mark.integration
+def test_empty_results(spark: SparkSession, session_catalog: Catalog) -> None:
+    identifier = "default.test_empty_results"
+
+    spark.sql(f"DROP TABLE IF EXISTS {identifier}")
+    spark.sql(f"""
+        CREATE TABLE {identifier} (id INT, data STRING)
+        USING iceberg
+        TBLPROPERTIES(
+            'format-version' = '2',
+            'write.delete.mode' = 'merge-on-read',
+            'write.update.mode' = 'merge-on-read',
+            'write.merge.mode' = 'merge-on-read'
+        )
+    """)
+
+    spark.sql(f"INSERT INTO {identifier} VALUES (1, 'a'), (2, 'b'), (3, 'c')")
+    spark.sql(f"DELETE FROM {identifier} WHERE id IN (1, 2, 3)")
+
+    spark_df = spark.sql(f"SELECT * FROM {identifier} ORDER BY id").toPandas()
+
+    table = session_catalog.load_table(identifier)
+    pyiceberg_df = table.scan().to_pandas().sort_values("id").reset_index(drop=True)
+
+    pd.testing.assert_frame_equal(spark_df, pyiceberg_df, check_dtype=False)

--- a/tests/io/test_pyarrow.py
+++ b/tests/io/test_pyarrow.py
@@ -4722,7 +4722,7 @@ def write_equality_delete_file(tmp_path: str, table_schema_simple: Schema) -> st
 
 
 def test_read_equality_deletes_file(write_equality_delete_file: str) -> None:
-    deletes = _read_deletes(
+    deletes = _read_eq_deletes(
         PyArrowFileIO(),
         DataFile.from_args(
             file_path=write_equality_delete_file,

--- a/tests/io/test_pyarrow.py
+++ b/tests/io/test_pyarrow.py
@@ -4851,6 +4851,7 @@ def test_mor_read_with_partitions_and_deletes(tmp_path: str, pa_schema: Any) -> 
         file_format=FileFormat.PARQUET,
         content=DataFileContent.DATA,
     )
+    datafile_a.spec_id = 0
 
     data_b = pa.table({"id": [4, 5, 6], "part": ["B", "B", "B"]}, schema=pa_schema)
     data_file_b = os.path.join(tmp_path, "data_b.parquet")
@@ -4860,6 +4861,7 @@ def test_mor_read_with_partitions_and_deletes(tmp_path: str, pa_schema: Any) -> 
         file_format=FileFormat.PARQUET,
         content=DataFileContent.DATA,
     )
+    datafile_b.spec_id = 0
 
     eq_delete_a_path = os.path.join(tmp_path, "eq_delete_a.parquet")
     eq_delete_a_table = pa.table({"id": pa.array([2], type=pa.int32())})
@@ -4870,6 +4872,7 @@ def test_mor_read_with_partitions_and_deletes(tmp_path: str, pa_schema: Any) -> 
         content=DataFileContent.EQUALITY_DELETES,
         equality_ids=[1],
     )
+    eq_delete_file_a.spec_id = 0
 
     pos_delete_b_path = os.path.join(tmp_path, "pos_delete_b.parquet")
     pos_delete_b_table = pa.table({"file_path": [data_file_b], "pos": [0]})
@@ -4879,6 +4882,7 @@ def test_mor_read_with_partitions_and_deletes(tmp_path: str, pa_schema: Any) -> 
         file_format=FileFormat.PARQUET,
         content=DataFileContent.POSITION_DELETES,
     )
+    pos_delete_file_b.spec_id = 0
 
     task_a = FileScanTask(
         data_file=datafile_a,

--- a/tests/io/test_pyarrow.py
+++ b/tests/io/test_pyarrow.py
@@ -1632,7 +1632,10 @@ def test_read_deletes(deletes_file: str, request: pytest.FixtureRequest) -> None
     else:
         request.getfixturevalue("example_task_orc")
 
-    deletes = _read_deletes(PyArrowFileIO(), DataFile.from_args(file_path=deletes_file, file_format=file_format))
+    deletes = _read_deletes(
+        PyArrowFileIO(),
+        DataFile.from_args(file_path=deletes_file, file_format=file_format, content=DataFileContent.POSITION_DELETES),
+    )
     # Get the expected file path from the actual deletes keys since they might differ between formats
     expected_file_path = list(deletes.keys())[0]
     assert set(deletes.keys()) == {expected_file_path}
@@ -4699,3 +4702,258 @@ def test_partition_column_projection_with_schema_evolution(catalog: InMemoryCata
     result_sorted = result.sort_by("name")
     assert result_sorted["name"].to_pylist() == ["Alice", "Bob", "Charlie", "David"]
     assert result_sorted["new_column"].to_pylist() == [None, None, "new1", "new2"]
+
+
+@pytest.fixture
+def equality_deletes_file_path(tmp_path: str, table_schema_simple: Schema) -> str:
+    """Create an equality deletes file and return its path"""
+    deletes_file = os.path.join(tmp_path, "equality-deletes.parquet")
+    pa_schema = schema_to_pyarrow(table_schema_simple)
+    foo_type = pa_schema.field("foo").type
+    bar_type = pa_schema.field("bar").type
+
+    table = pa.table(
+        {
+            "foo": pa.array(["a", "b"], type=foo_type),
+            "bar": pa.array([1, 2], type=bar_type),
+        }
+    )
+    pq.write_table(table, deletes_file)
+    return deletes_file
+
+
+def test_read_equality_deletes(equality_deletes_file_path: str) -> None:
+    deletes = _read_deletes(
+        LocalFileSystem(),
+        DataFile.from_args(
+            file_path=equality_deletes_file_path,
+            file_format=FileFormat.PARQUET,
+            content=DataFileContent.EQUALITY_DELETES,
+            equality_ids=[1, 2],
+        ),
+    )
+    assert isinstance(deletes, pa.Table)
+    assert deletes.num_rows == 2
+    assert deletes["foo"].to_pylist() == ["a", "b"]
+    assert deletes["bar"].to_pylist() == [1, 2]
+
+
+def test_equality_delete(
+    equality_deletes_file_path: str, equality_delete_task: FileScanTask, table_schema_simple: Schema
+) -> None:
+    import pyarrow.parquet as pq
+
+    print("Data table:")
+    print(pq.read_table(equality_delete_task.file.file_path))
+    print("Delete table:")
+    print(pq.read_table(equality_deletes_file_path))
+    metadata_location = "file://a/b/c.json"
+    example_task_with_delete = FileScanTask(
+        data_file=equality_delete_task.file,
+        delete_files={
+            DataFile.from_args(
+                content=DataFileContent.EQUALITY_DELETES,
+                file_path=equality_deletes_file_path,
+                file_format=FileFormat.PARQUET,
+                equality_ids=[1, 2],
+            )
+        },
+    )
+    with_deletes = ArrowScan(
+        table_metadata=TableMetadataV2(
+            location=metadata_location,
+            last_column_id=1,
+            format_version=2,
+            current_schema_id=1,
+            schemas=[table_schema_simple],
+            partition_specs=[PartitionSpec()],
+        ),
+        io=load_file_io(),
+        projected_schema=table_schema_simple,
+        row_filter=AlwaysTrue(),
+    ).to_table(tasks=[example_task_with_delete])
+
+    assert len(with_deletes) == 2
+    assert with_deletes["foo"].to_pylist() == ["c", "d"]
+    assert with_deletes["bar"].to_pylist() == [3.0, 4.0]
+
+
+def test_mor_read_with_positional_and_equality_deletes(
+    example_task: FileScanTask, equality_delete_task: FileScanTask, table_schema_simple: Schema, tmp_path: str, pa_schema: Any
+) -> None:
+    pos_delete_path = os.path.join(tmp_path, "pos_delete.parquet")
+    pos_delete_table = pa.table(
+        {
+            "file_path": [example_task.file.file_path],
+            "pos": [1],
+        }
+    )
+    pq.write_table(pos_delete_table, pos_delete_path)
+    pos_delete_file = DataFile.from_args(
+        file_path=pos_delete_path,
+        file_format=FileFormat.PARQUET,
+        content=DataFileContent.POSITION_DELETES,
+    )
+
+    eq_delete_path = os.path.join(tmp_path, "eq_delete.parquet")
+    eq_delete_schema = pa.schema([("bar", pa.int32())])
+    eq_delete_table = pa.table(
+        {
+            "bar": pa.array([3], type=pa.int32()),
+        },
+        schema=eq_delete_schema,
+    )
+    pq.write_table(eq_delete_table, eq_delete_path)
+    eq_delete_file = DataFile.from_args(
+        file_path=eq_delete_path,
+        file_format=FileFormat.PARQUET,
+        content=DataFileContent.EQUALITY_DELETES,
+        equality_ids=[2],
+    )
+
+    task_with_pos_delete = FileScanTask(
+        data_file=example_task.file,
+        delete_files={pos_delete_file},
+    )
+    task_with_eq_delete = FileScanTask(
+        data_file=equality_delete_task.file,
+        delete_files={eq_delete_file},
+    )
+
+    scan = ArrowScan(
+        table_metadata=TableMetadataV2(
+            location="file://dummy",
+            last_column_id=3,
+            format_version=2,
+            current_schema_id=1,
+            schemas=[table_schema_simple],
+            partition_specs=[PartitionSpec()],
+        ),
+        io=load_file_io(),
+        projected_schema=table_schema_simple,
+        row_filter=AlwaysTrue(),
+    )
+    result = scan.to_table(tasks=[task_with_pos_delete, task_with_eq_delete])
+
+    bars = result["bar"].to_pylist()
+    foos = result["foo"].to_pylist()
+    bazs = result["baz"].to_pylist()
+
+    assert bars == [1, 3, 1, 2, 4]
+    assert foos == ["a", "c", "a", "b", "d"]
+    assert bazs == [True, None, True, False, True]
+
+
+def test_mor_read_with_partitions_and_deletes(tmp_path: str, pa_schema: Any) -> None:
+    schema = Schema(
+        NestedField(1, "id", IntegerType(), required=True),
+        NestedField(2, "part", StringType(), required=True),
+        schema_id=1,  # Explicitly set schema_id to match current_schema_id
+    )
+    pa_schema = schema_to_pyarrow(schema)
+
+    data_a = pa.table({"id": [1, 2, 3], "part": ["A", "A", "A"]}, schema=pa_schema)
+    data_file_a = os.path.join(tmp_path, "data_a.parquet")
+    pq.write_table(data_a, data_file_a)
+    datafile_a = DataFile.from_args(
+        file_path=data_file_a,
+        file_format=FileFormat.PARQUET,
+        content=DataFileContent.DATA,
+    )
+
+    data_b = pa.table({"id": [4, 5, 6], "part": ["B", "B", "B"]}, schema=pa_schema)
+    data_file_b = os.path.join(tmp_path, "data_b.parquet")
+    pq.write_table(data_b, data_file_b)
+    datafile_b = DataFile.from_args(
+        file_path=data_file_b,
+        file_format=FileFormat.PARQUET,
+        content=DataFileContent.DATA,
+    )
+
+    eq_delete_a_path = os.path.join(tmp_path, "eq_delete_a.parquet")
+    eq_delete_a_table = pa.table({"id": pa.array([2], type=pa.int32())})
+    pq.write_table(eq_delete_a_table, eq_delete_a_path)
+    eq_delete_file_a = DataFile.from_args(
+        file_path=eq_delete_a_path,
+        file_format=FileFormat.PARQUET,
+        content=DataFileContent.EQUALITY_DELETES,
+        equality_ids=[1],
+    )
+
+    pos_delete_b_path = os.path.join(tmp_path, "pos_delete_b.parquet")
+    pos_delete_b_table = pa.table({"file_path": [data_file_b], "pos": [0]})
+    pq.write_table(pos_delete_b_table, pos_delete_b_path)
+    pos_delete_file_b = DataFile.from_args(
+        file_path=pos_delete_b_path,
+        file_format=FileFormat.PARQUET,
+        content=DataFileContent.POSITION_DELETES,
+    )
+
+    task_a = FileScanTask(
+        data_file=datafile_a,
+        delete_files={eq_delete_file_a},
+    )
+    task_b = FileScanTask(
+        data_file=datafile_b,
+        delete_files={pos_delete_file_b},
+    )
+
+    scan = ArrowScan(
+        table_metadata=TableMetadataV2(
+            location="file://dummy",
+            last_column_id=2,
+            format_version=2,
+            current_schema_id=1,
+            schemas=[schema],
+            partition_specs=[PartitionSpec()],
+        ),
+        io=load_file_io(),
+        projected_schema=schema,
+        row_filter=AlwaysTrue(),
+    )
+    result = scan.to_table(tasks=[task_a, task_b])
+
+    assert set(result["id"].to_pylist()) == {1, 3, 5, 6}
+    assert set(result["part"].to_pylist()) == {"A", "B"}
+
+
+def test_mor_read_with_duplicate_deletes(
+    example_task: FileScanTask, table_schema_simple: Schema, tmp_path: str, pa_schema: Any
+) -> None:
+    pos_delete_path = os.path.join(tmp_path, "pos_delete.parquet")
+    pos_delete_table = pa.table(
+        {
+            "file_path": [example_task.file.file_path],
+            "pos": [1],
+        }
+    )
+    pq.write_table(pos_delete_table, pos_delete_path)
+    pos_delete_file = DataFile.from_args(
+        file_path=pos_delete_path,
+        file_format=FileFormat.PARQUET,
+        content=DataFileContent.POSITION_DELETES,
+    )
+
+    task_with_duplicate_deletes = FileScanTask(
+        data_file=example_task.file,
+        delete_files={pos_delete_file, pos_delete_file},
+    )
+
+    scan = ArrowScan(
+        table_metadata=TableMetadataV2(
+            location="file://dummy",
+            last_column_id=3,
+            format_version=2,
+            current_schema_id=1,
+            schemas=[table_schema_simple],
+            partition_specs=[PartitionSpec()],
+        ),
+        io=load_file_io(),
+        projected_schema=table_schema_simple,
+        row_filter=AlwaysTrue(),
+    )
+    result = scan.to_table(tasks=[task_with_duplicate_deletes])
+
+    assert result["bar"].to_pylist() == [1, 3]
+    assert result["foo"].to_pylist() == ["a", "c"]
+    assert result["baz"].to_pylist() == [True, None]

--- a/tests/io/test_pyarrow.py
+++ b/tests/io/test_pyarrow.py
@@ -4950,3 +4950,81 @@ def test_mor_read_with_duplicate_deletes(example_task: FileScanTask, table_schem
     assert result["bar"].to_pylist() == [1, 3]
     assert result["foo"].to_pylist() == ["a", "c"]
     assert result["baz"].to_pylist() == [True, None]
+
+
+@pytest.mark.parametrize("format_version", [1, 2, 3])
+def test_task_to_record_batches_nanos(format_version: TableVersion, tmpdir: str) -> None:
+    arrow_table = pa.table(
+        [
+            pa.array(
+                [
+                    datetime(2025, 8, 14, 12, 0, 0),
+                    datetime(2025, 8, 14, 13, 0, 0),
+                ],
+                type=pa.timestamp("ns"),
+            )
+        ],
+        pa.schema((pa.field("ts_field", pa.timestamp("ns"), nullable=True, metadata={PYARROW_PARQUET_FIELD_ID_KEY: "1"}),)),
+    )
+
+    data_file = _write_table_to_data_file(f"{tmpdir}/test_task_to_record_batches_nanos.parquet", arrow_table.schema, arrow_table)
+
+    if format_version <= 2:
+        table_schema = Schema(NestedField(1, "ts_field", TimestampType(), required=False))
+    else:
+        table_schema = Schema(NestedField(1, "ts_field", TimestampNanoType(), required=False))
+
+    actual_result = list(
+        _task_to_record_batches(
+            PyArrowFileIO(),
+            FileScanTask(data_file),
+            bound_row_filter=AlwaysTrue(),
+            projected_schema=table_schema,
+            projected_field_ids={1},
+            deletes=None,
+            case_sensitive=True,
+            format_version=format_version,
+        )
+    )[0]
+
+    def _expected_batch(unit: str) -> pa.RecordBatch:
+        return pa.record_batch(
+            [
+                pa.array(
+                    [
+                        datetime(2025, 8, 14, 12, 0, 0),
+                        datetime(2025, 8, 14, 13, 0, 0),
+                    ],
+                    type=pa.timestamp(unit),
+                )
+            ],
+            names=["ts_field"],
+        )
+
+    assert _expected_batch("ns" if format_version > 2 else "us").equals(actual_result)
+
+
+def test_parse_location_defaults() -> None:
+    """Test that parse_location uses defaults."""
+
+    from pyiceberg.io.pyarrow import PyArrowFileIO
+
+    # if no default scheme or netloc is provided, use file scheme and empty netloc
+    scheme, netloc, path = PyArrowFileIO.parse_location("/foo/bar")
+    assert scheme == "file"
+    assert netloc == ""
+    assert path == "/foo/bar"
+
+    scheme, netloc, path = PyArrowFileIO.parse_location(
+        "/foo/bar", properties={"DEFAULT_SCHEME": "scheme", "DEFAULT_NETLOC": "netloc:8000"}
+    )
+    assert scheme == "scheme"
+    assert netloc == "netloc:8000"
+    assert path == "/foo/bar"
+
+    scheme, netloc, path = PyArrowFileIO.parse_location(
+        "/foo/bar", properties={"DEFAULT_SCHEME": "hdfs", "DEFAULT_NETLOC": "netloc:8000"}
+    )
+    assert scheme == "hdfs"
+    assert netloc == "netloc:8000"
+    assert path == "/foo/bar"

--- a/tests/table/test_delete_file_index.py
+++ b/tests/table/test_delete_file_index.py
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 import pytest
 
 from pyiceberg.manifest import DataFileContent, FileFormat

--- a/tests/table/test_delete_file_index.py
+++ b/tests/table/test_delete_file_index.py
@@ -1,0 +1,542 @@
+import pytest
+
+from pyiceberg.manifest import DataFileContent, FileFormat
+from pyiceberg.partitioning import PartitionField, PartitionSpec
+from pyiceberg.schema import Schema
+from pyiceberg.table.delete_file_index import (
+    DeleteFileIndex,
+    EqualityDeleteFileWrapper,
+    EqualityDeletesGroup,
+    PositionalDeleteFileWrapper,
+    PositionalDeletesGroup,
+)
+from pyiceberg.transforms import IdentityTransform
+from pyiceberg.typedef import Record
+from pyiceberg.types import IntegerType, NestedField, StringType
+from tests.conftest import (
+    create_basic_data_file,
+    create_basic_equality_delete_file,
+    create_deletion_vector_entry,
+    create_equality_delete_entry,
+    create_manifest_entry_with_delete_file,
+    create_partition_positional_delete_entry,
+    create_positional_delete_entry,
+)
+
+
+@pytest.fixture
+def id_data_schema() -> Schema:
+    return Schema(
+        NestedField(1, "id", IntegerType(), required=True),
+        NestedField(2, "data", StringType(), required=True),
+    )
+
+
+@pytest.fixture
+def delete_index(id_data_schema: Schema) -> DeleteFileIndex:
+    """Create a DeleteFileIndex with the id_data_schema."""
+    return DeleteFileIndex(id_data_schema)
+
+
+class TestDeleteFileIndex:
+    """Tests for the DeleteFileIndex class."""
+
+    def test_empty_index(self, delete_index: DeleteFileIndex) -> None:
+        """Test that an empty index returns no delete files."""
+        data_file = create_basic_data_file()
+        assert len(delete_index.for_data_file(1, data_file)) == 0
+
+    def test_min_sequence_number_filtering(self, id_data_schema: Schema) -> None:
+        """Test filtering delete files by minimum sequence number."""
+        part_spec = PartitionSpec()
+
+        # Create delete files with different sequence numbers
+        eq_delete_1 = create_basic_equality_delete_file(equality_ids=[1])
+        eq_delete_1._spec_id = 0
+        eq_delete_entry_1 = create_manifest_entry_with_delete_file(eq_delete_1, sequence_number=4)
+
+        eq_delete_2 = create_basic_equality_delete_file(equality_ids=[1])
+        eq_delete_2._spec_id = 0
+        eq_delete_entry_2 = create_manifest_entry_with_delete_file(eq_delete_2, sequence_number=6)
+
+        # Create a delete index with a minimum sequence number filter
+        delete_index = DeleteFileIndex(id_data_schema, {0: part_spec})
+        delete_index.add_delete_file(eq_delete_entry_1)
+        delete_index.add_delete_file(eq_delete_entry_2)
+
+        data_file = create_basic_data_file()
+        data_file._spec_id = 0
+
+        # Only one delete file should apply with sequence number > 4
+        result = delete_index.for_data_file(4, data_file)
+        assert len(result) == 1
+        assert result[0].file_path == eq_delete_2.file_path
+
+    def test_unpartitioned_deletes(self, id_data_schema: Schema) -> None:
+        """Test unpartitioned delete files with different sequence numbers."""
+        part_spec = PartitionSpec()
+
+        # Unpartitioned equality delete files
+        eq_delete_1 = create_basic_equality_delete_file(equality_ids=[1])
+        eq_delete_1._spec_id = 0
+        eq_delete_entry_1 = create_manifest_entry_with_delete_file(eq_delete_1, sequence_number=4)
+
+        eq_delete_2 = create_basic_equality_delete_file(equality_ids=[1])
+        eq_delete_2._spec_id = 0
+        eq_delete_entry_2 = create_manifest_entry_with_delete_file(eq_delete_2, sequence_number=6)
+
+        # Path specific position delete files
+        pos_delete_1 = create_positional_delete_entry(sequence_number=5, spec_id=0)
+        pos_delete_2 = create_positional_delete_entry(sequence_number=6, spec_id=0)
+
+        # Create delete index
+        delete_index = DeleteFileIndex(id_data_schema, {0: part_spec, 1: PartitionSpec()})
+        delete_index.add_delete_file(eq_delete_entry_1)
+        delete_index.add_delete_file(eq_delete_entry_2)
+        delete_index.add_delete_file(pos_delete_1)
+        delete_index.add_delete_file(pos_delete_2)
+
+        #  Unpartitioned data file
+        data_file = create_basic_data_file()
+        data_file._spec_id = 0
+
+        # All deletes should apply
+        result = delete_index.for_data_file(0, data_file)
+        assert len(result) == 4
+
+        # All deletes should apply
+        result = delete_index.for_data_file(3, data_file)
+        assert len(result) == 4
+
+        # Only last 3 deletes should apply
+        result = delete_index.for_data_file(4, data_file)
+        assert len(result) == 3
+
+        # Last 2 deletes should apply
+        result = delete_index.for_data_file(5, data_file)
+        assert len(result) == 3
+
+        # Only last delete should apply
+        result = delete_index.for_data_file(6, data_file)
+        assert len(result) == 1
+
+        # No deletes applied
+        result = delete_index.for_data_file(7, data_file)
+        assert len(result) == 0
+
+        # Global equality deletes and path specific position deletes should apply to partitioned file
+        partitioned_file = create_basic_data_file(partition={"id": 1})
+        partitioned_file._spec_id = 1
+
+        result = delete_index.for_data_file(0, partitioned_file)
+        assert len(result) == 4
+
+    def test_partitioned_delete_index(self, id_data_schema: Schema) -> None:
+        """Test partitioned delete files with different sequence numbers."""
+        part_spec = PartitionSpec(PartitionField(source_id=1, field_id=1000, transform=IdentityTransform(), name="id_partition"))
+
+        # Partitioned equality delete files
+        partition_key = Record(1)
+        eq_delete_1 = create_basic_equality_delete_file(equality_ids=[1], partition=partition_key)
+        eq_delete_1._spec_id = 0
+        eq_delete_entry_1 = create_manifest_entry_with_delete_file(eq_delete_1, sequence_number=4)
+
+        eq_delete_2 = create_basic_equality_delete_file(equality_ids=[1], partition=partition_key)
+        eq_delete_2._spec_id = 0
+        eq_delete_entry_2 = create_manifest_entry_with_delete_file(eq_delete_2, sequence_number=6)
+
+        # Position delete files with partition
+        pos_delete_1 = create_partition_positional_delete_entry(sequence_number=5, spec_id=0, partition=partition_key)
+        pos_delete_2 = create_partition_positional_delete_entry(sequence_number=6, spec_id=0, partition=partition_key)
+
+        # Create delete index
+        delete_index = DeleteFileIndex(id_data_schema, {0: part_spec, 1: PartitionSpec()})
+        delete_index.add_delete_file(eq_delete_entry_1, partition_key=partition_key)
+        delete_index.add_delete_file(eq_delete_entry_2, partition_key=partition_key)
+        delete_index.add_delete_file(pos_delete_1, partition_key=partition_key)
+        delete_index.add_delete_file(pos_delete_2, partition_key=partition_key)
+
+        # Data file with same partition
+        data_file_a = create_basic_data_file(partition={"id": 1})
+        data_file_a._spec_id = 0
+
+        result = delete_index.for_data_file(0, data_file_a, partition_key=partition_key)
+        assert len(result) == 4
+
+        result = delete_index.for_data_file(3, data_file_a, partition_key=partition_key)
+        assert len(result) == 4
+
+        result = delete_index.for_data_file(4, data_file_a, partition_key=partition_key)
+        assert len(result) == 3
+
+        result = delete_index.for_data_file(5, data_file_a, partition_key=partition_key)
+        assert len(result) == 3
+
+        result = delete_index.for_data_file(6, data_file_a, partition_key=partition_key)
+        assert len(result) == 1
+
+        # No deletes should apply to seq 7
+        result = delete_index.for_data_file(7, data_file_a, partition_key=partition_key)
+        assert len(result) == 0
+
+        # Test with file in different partition
+        data_file_b = create_basic_data_file(partition={"id": 2})
+        data_file_b._spec_id = 0
+        different_partition_key = Record(2)
+
+        # No deletes should apply to file in different partition
+        result = delete_index.for_data_file(0, data_file_b, partition_key=different_partition_key)
+        assert len(result) == 0
+
+        # Test with unpartitioned file
+        unpartitioned_file = create_basic_data_file()
+        unpartitioned_file._spec_id = 1
+
+        # No partition deletes should apply to unpartitioned file
+        result = delete_index.for_data_file(0, unpartitioned_file)
+        assert len(result) == 0
+
+    def test_partitioned_table_scan_with_global_deletes(self, id_data_schema: Schema) -> None:
+        """Test that global equality deletes apply to partitioned files."""
+        # Create partitioned spec
+        part_spec = PartitionSpec(PartitionField(source_id=1, field_id=1000, transform=IdentityTransform(), name="id_partition"))
+
+        # Create partitioned data file
+        partition_key = Record(1)
+        data_file = create_basic_data_file(partition={"id": 1})
+        data_file._spec_id = 0
+
+        # Create unpartitioned equality delete file (global)
+        unpart_eq_delete = create_basic_equality_delete_file(equality_ids=[1])
+        unpart_eq_delete._spec_id = 1  # Unpartitioned spec
+        unpart_eq_delete_entry = create_manifest_entry_with_delete_file(unpart_eq_delete, sequence_number=5)
+
+        # Create unpartitioned position delete file
+        unpart_pos_delete = create_partition_positional_delete_entry(sequence_number=5, spec_id=1)
+
+        # Create delete index
+        delete_index = DeleteFileIndex(id_data_schema, {0: part_spec, 1: PartitionSpec()})
+        delete_index.add_delete_file(unpart_eq_delete_entry)
+        delete_index.add_delete_file(unpart_pos_delete)
+
+        # Test that only global equality deletes apply to partitioned file
+        result = delete_index.for_data_file(0, data_file, partition_key=partition_key)
+        assert len(result) == 1
+        assert result[0].content == DataFileContent.EQUALITY_DELETES
+        assert result[0].file_path == unpart_eq_delete.file_path
+
+    def test_partitioned_table_scan_with_global_and_partition_deletes(self, id_data_schema: Schema) -> None:
+        """Test that both global and partition-specific deletes apply to partitioned files."""
+        part_spec = PartitionSpec(PartitionField(source_id=1, field_id=1000, transform=IdentityTransform(), name="id_partition"))
+
+        # Partitioned data file
+        partition_key = Record(1)
+        data_file = create_basic_data_file(partition={"id": 1})
+        data_file._spec_id = 0
+
+        # Partitioned equality delete file
+        part_eq_delete = create_basic_equality_delete_file(equality_ids=[1], partition=partition_key)
+        part_eq_delete._spec_id = 0
+        part_eq_delete_entry = create_manifest_entry_with_delete_file(part_eq_delete, sequence_number=4)
+
+        # Unpartitioned equality delete file (global)
+        unpart_eq_delete = create_basic_equality_delete_file(equality_ids=[1])
+        unpart_eq_delete._spec_id = 1  # Unpartitioned spec
+        unpart_eq_delete_entry = create_manifest_entry_with_delete_file(unpart_eq_delete, sequence_number=5)
+
+        # Unpartitioned position delete file
+        unpart_pos_delete = create_partition_positional_delete_entry(sequence_number=5, spec_id=1)
+        part_pos_delete = create_partition_positional_delete_entry(sequence_number=5, spec_id=0, partition=partition_key)
+
+        delete_index = DeleteFileIndex(id_data_schema, {0: part_spec, 1: PartitionSpec()})
+        delete_index.add_delete_file(part_eq_delete_entry, partition_key=partition_key)
+        delete_index.add_delete_file(unpart_eq_delete_entry)
+        delete_index.add_delete_file(unpart_pos_delete)
+        delete_index.add_delete_file(part_pos_delete, partition_key=partition_key)
+
+        # Test that both partition-specific deletes and global equality deletes apply
+        result = delete_index.for_data_file(0, data_file, partition_key=partition_key)
+        assert len(result) == 3
+
+        file_paths = {d.file_path for d in result}
+        assert part_eq_delete.file_path in file_paths
+        assert unpart_eq_delete.file_path in file_paths
+
+    def test_partitioned_table_sequence_numbers(self, id_data_schema: Schema) -> None:
+        """Test sequence number handling in partitioned tables."""
+        data_file = create_basic_data_file(file_path="s3://bucket/data.parquet", partition={"id": 1})
+        data_file._spec_id = 0
+
+        eq_delete = create_basic_equality_delete_file(
+            file_path="s3://bucket/eq-delete.parquet", equality_ids=[1], partition=Record(1)
+        )
+        eq_delete._spec_id = 0
+        eq_delete_entry = create_manifest_entry_with_delete_file(eq_delete, sequence_number=5)
+
+        pos_delete = create_positional_delete_entry(sequence_number=5, file_path="s3://bucket/data.parquet", spec_id=0)
+
+        part_spec = PartitionSpec(PartitionField(source_id=1, field_id=1000, transform=IdentityTransform(), name="id_partition"))
+        delete_index = DeleteFileIndex(id_data_schema, {0: part_spec})
+        delete_index.add_delete_file(eq_delete_entry, partition_key=Record(1))
+        delete_index.add_delete_file(pos_delete, partition_key=Record(1))
+
+        # Position deletes apply to data file with same sequence number
+        result = delete_index.for_data_file(5, data_file, partition_key=Record(1))
+
+        # Only position deletes should apply to files with the same sequence number
+        pos_deletes = [d for d in result if d.content == DataFileContent.POSITION_DELETES]
+        eq_deletes = [d for d in result if d.content == DataFileContent.EQUALITY_DELETES]
+
+        assert len(pos_deletes) == 1
+        assert len(eq_deletes) == 0
+
+    def test_unpartitioned_table_sequence_numbers(self, id_data_schema: Schema) -> None:
+        """Test sequence number handling in unpartitioned tables."""
+        data_file = create_basic_data_file(file_path="s3://bucket/data.parquet")
+        data_file._spec_id = 0
+
+        eq_delete = create_basic_equality_delete_file(file_path="s3://bucket/eq-delete.parquet", equality_ids=[1])
+        eq_delete._spec_id = 0
+        eq_delete_entry = create_manifest_entry_with_delete_file(eq_delete, sequence_number=5)
+
+        pos_delete = create_positional_delete_entry(sequence_number=5, file_path="s3://bucket/data.parquet", spec_id=0)
+        delete_index = DeleteFileIndex(id_data_schema, {0: PartitionSpec()})
+        delete_index.add_delete_file(eq_delete_entry)
+        delete_index.add_delete_file(pos_delete)
+
+        # Position deletes apply to data file with same sequence number
+        result = delete_index.for_data_file(5, data_file)
+
+        # Only position deletes should apply to files with the same sequence number
+        pos_deletes = [d for d in result if d.content == DataFileContent.POSITION_DELETES]
+        eq_deletes = [d for d in result if d.content == DataFileContent.EQUALITY_DELETES]
+
+        assert len(pos_deletes) == 1
+        assert len(eq_deletes) == 0
+
+    def test_position_deletes_group(self) -> None:
+        """Test the PositionalDeletesGroup class."""
+        # Create position delete files with different sequence numbers
+        pos_delete_1 = create_positional_delete_entry(sequence_number=1).data_file
+        pos_delete_2 = create_positional_delete_entry(sequence_number=2).data_file
+        pos_delete_3 = create_positional_delete_entry(sequence_number=3).data_file
+        pos_delete_4 = create_positional_delete_entry(sequence_number=4).data_file
+
+        # PositionalDeletesGroup
+        group = PositionalDeletesGroup()
+        group.add(PositionalDeleteFileWrapper(create_manifest_entry_with_delete_file(pos_delete_4, sequence_number=4)))
+        group.add(PositionalDeleteFileWrapper(create_manifest_entry_with_delete_file(pos_delete_2, sequence_number=2)))
+        group.add(PositionalDeleteFileWrapper(create_manifest_entry_with_delete_file(pos_delete_1, sequence_number=1)))
+        group.add(PositionalDeleteFileWrapper(create_manifest_entry_with_delete_file(pos_delete_3, sequence_number=3)))
+
+        # Test filtering by sequence number
+        result_0 = group.filter(0, create_basic_data_file())
+        assert len(result_0) == 4
+
+        result_1 = group.filter(1, create_basic_data_file())
+        assert len(result_1) == 4
+
+        result_2 = group.filter(2, create_basic_data_file())
+        assert len(result_2) == 3
+
+        result_3 = group.filter(3, create_basic_data_file())
+        assert len(result_3) == 2
+
+        result_4 = group.filter(4, create_basic_data_file())
+        assert len(result_4) == 1
+
+        result_5 = group.filter(5, create_basic_data_file())
+        assert len(result_5) == 0
+
+        # Test that adding files after indexing raises an error
+        group._index_if_needed()
+        with pytest.raises(ValueError, match="Can't add files to group after indexing"):
+            group.add(PositionalDeleteFileWrapper(create_manifest_entry_with_delete_file(pos_delete_1, sequence_number=1)))
+
+    def test_equality_deletes_group(self, id_data_schema: Schema) -> None:
+        """Test the EqualityDeletesGroup class."""
+        # Create equality delete files with different sequence numbers
+        eq_delete_1 = create_basic_equality_delete_file(equality_ids=[1])
+        eq_delete_2 = create_basic_equality_delete_file(equality_ids=[1])
+        eq_delete_3 = create_basic_equality_delete_file(equality_ids=[1])
+        eq_delete_4 = create_basic_equality_delete_file(equality_ids=[1])
+
+        # EqualityDeletesGroup
+        group = EqualityDeletesGroup()
+        group.add(
+            EqualityDeleteFileWrapper(create_manifest_entry_with_delete_file(eq_delete_4, sequence_number=4), id_data_schema)
+        )
+        group.add(
+            EqualityDeleteFileWrapper(create_manifest_entry_with_delete_file(eq_delete_2, sequence_number=2), id_data_schema)
+        )
+        group.add(
+            EqualityDeleteFileWrapper(create_manifest_entry_with_delete_file(eq_delete_1, sequence_number=1), id_data_schema)
+        )
+        group.add(
+            EqualityDeleteFileWrapper(create_manifest_entry_with_delete_file(eq_delete_3, sequence_number=3), id_data_schema)
+        )
+
+        data_file = create_basic_data_file()
+
+        # Test filtering by sequence number
+        result_0 = group.filter(0, data_file)
+        assert len(result_0) == 4
+
+        result_1 = group.filter(1, data_file)
+        assert len(result_1) == 3
+
+        result_2 = group.filter(2, data_file)
+        assert len(result_2) == 2
+
+        result_3 = group.filter(3, data_file)
+        assert len(result_3) == 1
+
+        result_4 = group.filter(4, data_file)
+        assert len(result_4) == 0
+
+        # Adding files after indexing raises an error
+        group._index_if_needed()
+        with pytest.raises(ValueError, match="Can't add files to group after indexing"):
+            group.add(
+                EqualityDeleteFileWrapper(create_manifest_entry_with_delete_file(eq_delete_1, sequence_number=1), id_data_schema)
+            )
+
+    def test_mix_delete_files_and_dvs(self, id_data_schema: Schema) -> None:
+        """Test mixing regular delete files and deletion vectors."""
+        data_file_a = create_basic_data_file(file_path="s3://bucket/data-a.parquet", partition={"id": 1})
+        data_file_a._spec_id = 0
+
+        data_file_b = create_basic_data_file(file_path="s3://bucket/data-b.parquet", partition={"id": 2})
+        data_file_b._spec_id = 0
+
+        # Position delete for file A
+        pos_delete_a = create_positional_delete_entry(sequence_number=1, file_path="s3://bucket/data-a.parquet", spec_id=0)
+
+        # Deletion vector for file A
+        dv_a = create_deletion_vector_entry(sequence_number=2, file_path="s3://bucket/data-a.parquet", spec_id=0)
+
+        # Position deletes for file B
+        pos_delete_b1 = create_positional_delete_entry(sequence_number=1, file_path="s3://bucket/data-b.parquet", spec_id=0)
+        pos_delete_b2 = create_positional_delete_entry(sequence_number=2, file_path="s3://bucket/data-b.parquet", spec_id=0)
+
+        # Partitioned spec
+        part_spec = PartitionSpec(PartitionField(source_id=1, field_id=1000, transform=IdentityTransform(), name="id_partition"))
+
+        delete_index = DeleteFileIndex(id_data_schema, {0: part_spec})
+        delete_index.add_delete_file(pos_delete_a)
+        delete_index.add_delete_file(dv_a)
+        delete_index.add_delete_file(pos_delete_b1)
+        delete_index.add_delete_file(pos_delete_b2)
+
+        # Test file A - DV and positional deletes will be added for file A
+        result_a = delete_index.for_data_file(0, data_file_a)
+        assert len(result_a) == 2
+
+        # Test file B - both position deletes for file B apply and DV
+        result_b = delete_index.for_data_file(0, data_file_b)
+        assert len(result_b) == 3
+        assert all(d.content == DataFileContent.POSITION_DELETES for d in result_b)
+
+    def test_equality_delete_bounds_filtering(self, id_data_schema: Schema) -> None:
+        """Test that equality deletes use bounds to filter out impossible matches."""
+        # Create data file with bounds
+        data_file = create_basic_data_file(
+            lower_bounds={1: b"\x05\x00\x00\x00"},  # id >= 5
+            upper_bounds={1: b"\x0a\x00\x00\x00"},  # id <= 10
+        )
+
+        # With non-overlapping bounds
+        delete_index1 = DeleteFileIndex(id_data_schema)
+        eq_delete_file = create_basic_equality_delete_file(
+            equality_ids=[1],
+            lower_bounds={1: b"\x0f\x00\x00\x00"},  # id >= 15
+            upper_bounds={1: b"\x14\x00\x00\x00"},  # id <= 20
+        )
+        eq_delete_entry = create_manifest_entry_with_delete_file(eq_delete_file)
+        delete_index1.add_delete_file(eq_delete_entry)
+
+        # Should not apply because bounds don't overlap
+        assert len(delete_index1.for_data_file(0, data_file)) == 0
+
+        # Overlapping bounds
+        delete_index2 = DeleteFileIndex(id_data_schema)
+        eq_delete_file2 = create_basic_equality_delete_file(
+            equality_ids=[1],
+            lower_bounds={1: b"\x08\x00\x00\x00"},  # id >= 8
+            upper_bounds={1: b"\x0f\x00\x00\x00"},  # id <= 15
+        )
+        eq_delete_entry2 = create_manifest_entry_with_delete_file(eq_delete_file2)
+        delete_index2.add_delete_file(eq_delete_entry2)
+
+        # Should apply because bounds overlap
+        assert len(delete_index2.for_data_file(0, data_file)) == 1
+
+    def test_equality_delete_null_filtering(self) -> None:
+        """Test that equality deletes use null counts to filter out impossible matches."""
+        schema = Schema(
+            NestedField(1, "id", IntegerType(), required=False),
+            NestedField(2, "data", StringType(), required=False),
+        )
+
+        data_file = create_basic_data_file(
+            value_counts={1: 100, 2: 100},
+            null_value_counts={1: 100, 2: 0},  # All values in field 1 are null
+        )
+
+        delete_index1 = DeleteFileIndex(schema)
+        eq_delete_file = create_basic_equality_delete_file(
+            equality_ids=[1],
+            value_counts={1: 10},
+            null_value_counts={1: 0},  # No nulls in delete file
+        )
+        eq_delete_entry = create_manifest_entry_with_delete_file(eq_delete_file)
+        delete_index1.add_delete_file(eq_delete_entry)
+
+        # Should not apply because data is all nulls but delete doesn't delete nulls
+        assert len(delete_index1.for_data_file(0, data_file)) == 0
+
+        delete_index2 = DeleteFileIndex(schema)
+        eq_delete_file2 = create_basic_equality_delete_file(
+            equality_ids=[1],
+            value_counts={1: 10},
+            null_value_counts={1: 5},  # Has nulls in delete file
+        )
+        eq_delete_entry2 = create_manifest_entry_with_delete_file(eq_delete_file2)
+        delete_index2.add_delete_file(eq_delete_entry2)
+
+        # Should apply because delete file has nulls
+        assert len(delete_index2.for_data_file(0, data_file)) == 1
+
+    def test_all_delete_types(self, id_data_schema: Schema) -> None:
+        """Test that when all three delete types target the same file."""
+        file_path = "s3://bucket/data.parquet"
+
+        delete_index = DeleteFileIndex(id_data_schema)
+
+        # Add an equality delete
+        eq_delete_entry = create_equality_delete_entry(sequence_number=5, equality_ids=[1])
+        delete_index.add_delete_file(eq_delete_entry)
+
+        # Add a position delete
+        pos_delete_entry = create_positional_delete_entry(sequence_number=5, file_path=file_path)
+        delete_index.add_delete_file(pos_delete_entry)
+
+        # Add a deletion vector
+        dv_entry = create_deletion_vector_entry(sequence_number=5, file_path=file_path)
+        delete_index.add_delete_file(dv_entry)
+
+        data_file = create_basic_data_file(file_path=file_path)
+        deletes = delete_index.for_data_file(4, data_file)
+
+        # Should all deletes
+        assert len(deletes) == 3
+
+        eq_deletes = [d for d in deletes if d.content == DataFileContent.EQUALITY_DELETES]
+        assert len(eq_deletes) == 1
+
+        dv_deletes = [d for d in deletes if d.file_format == FileFormat.PUFFIN]
+        assert len(dv_deletes) == 1
+
+        # Verify that no position deletes are included
+        pos_deletes = [d for d in deletes if d.content == DataFileContent.POSITION_DELETES and d.file_format != FileFormat.PUFFIN]
+        assert len(pos_deletes) == 1


### PR DESCRIPTION
Closes #1210

# Summary

This work was primarily done by @rutb327 while I provided guidance!

This PR adds equality delete read support to PyIceberg by implementing the delete file indexing system that matches delete files to data files, mimicking the behavior found in [Iceberg Core](https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java). With this implementation we are able to index files and now read equality deletes during table scans.

## Design details

### Delete File Index
The new `DeleteFileIndex` class centralizes handling of all delete file types: positional deletes, equality deletes, and deletion vectors. It organizes deletes by type (equality vs. positional), partition (using `PartitionMap` for spec-aware grouping), and path (for path-specific positional deletes). This enables efficient lookup during table scans, reducing unnecessary delete file processing.


## Equality Delete support

Equality delete files are loaded as PyArrow Tables with their respective equality ids for the schema and for each we are grouping tables with the same set equality id's to reduce anti join operations.


# Testing
Added tests from the core iceberg [DeleteFileIndex](https://github.com/apache/iceberg/blob/main/core/src/test/java/org/apache/iceberg/DeleteFileIndexTestBase.java#L45) test suite and added some tests with dummy files. As well as some manual testing with a flink setup.

```
table_eq with only equality deletes on id=2, id=5
+---+-------+
| id|   data|
+---+-------+
|  1|  Alice|
|  3|Charlie|
|  4|  David|
|  6|  Frank|
+---+-------+

table_eq_pos with equality deletes and positional delete at position 3
+---+-----+
| id| data|
+---+-----+
|  1|Alice|
|  4|David|
|  6|Frank|
+---+-----+
```


# Are there any user-facing changes?

Yes can read tables with equality deletes
