### PR TITLE
Use `rest` shorthand in `conftest.py`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2519,7 +2519,7 @@ def spark() -> "SparkSession":
         .config("spark.default.parallelism", "1")
         .config("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions")
         .config("spark.sql.catalog.integration", "org.apache.iceberg.spark.SparkCatalog")
-        .config("spark.sql.catalog.integration.catalog-impl", "org.apache.iceberg.rest.RESTCatalog")
+        .config("spark.sql.catalog.integration.type", "rest")
         .config("spark.sql.catalog.integration.cache-enabled", "false")
         .config("spark.sql.catalog.integration.uri", "http://localhost:8181")
         .config("spark.sql.catalog.integration.io-impl", "org.apache.iceberg.aws.s3.S3FileIO")


### PR DESCRIPTION
# Rationale for this change

Added this wayyyy back: https://github.com/apache/iceberg/pull/5570/. I think this is nicer than the full Java classpath

# Are these changes tested?

# Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
