### PR TITLE
Document `older_than` of ExpireSnapshots

### DIFF
--- a/mkdocs/docs/api.md
+++ b/mkdocs/docs/api.md
@@ -1296,7 +1296,13 @@ PyIceberg provides table maintenance operations through the `table.maintenance` 
 Expire old snapshots to clean up table metadata and reduce storage costs:
 
 ```python
-# Basic usage - expire a specific snapshot by ID
+# Expire snapshots older than three days
+from datetime import datetime, timedelta
+table.maintenance.expire_snapshots().older_than(
+    datetime.now() - timedelta(days=3)
+).commit()
+
+# Expire a specific snapshot by ID
 table.maintenance.expire_snapshots().by_id(12345).commit()
 
 # Context manager usage (recommended for multiple operations)
@@ -1304,9 +1310,6 @@ with table.maintenance.expire_snapshots() as expire:
     expire.by_id(12345)
     expire.by_id(67890)
     # Automatically commits when exiting the context
-
-# Method chaining
-table.maintenance.expire_snapshots().by_id(12345).commit()
 ```
 
 #### Real-world Example

--- a/tests/table/test_expire_snapshots.py
+++ b/tests/table/test_expire_snapshots.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import datetime
 from unittest.mock import MagicMock
 from uuid import uuid4
 
@@ -142,7 +143,7 @@ def test_expire_snapshots_by_timestamp_skips_protected(table_v2: Table) -> None:
     table_v2.catalog = MagicMock()
 
     # Attempt to expire all snapshots before a future timestamp (so both are candidates)
-    future_timestamp = 9999999999999  # Far in the future, after any real snapshot
+    future_datetime = datetime.datetime.now() + datetime.timedelta(days=1)
 
     # Mock the catalog's commit_table to return the current metadata (simulate no change)
     mock_response = CommitTableResponse(
@@ -152,7 +153,7 @@ def test_expire_snapshots_by_timestamp_skips_protected(table_v2: Table) -> None:
     )
     table_v2.catalog.commit_table.return_value = mock_response
 
-    table_v2.maintenance.expire_snapshots().older_than(future_timestamp).commit()
+    table_v2.maintenance.expire_snapshots().older_than(future_datetime).commit()
     # Update metadata to reflect the commit (as in other tests)
     table_v2.metadata = mock_response.metadata
 


### PR DESCRIPTION
# Rationale for this change

I was looking into this, and took the liberty of changing the API to a datetime rather than milliseconds to avoid anyone passing in seconds or microseconds.


# Are these changes tested?

# Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
