### PR TITLE
Build: Migrate markdown-link-check GH action

### DIFF
--- a/.github/workflows/check-md-link.yml
+++ b/.github/workflows/check-md-link.yml
@@ -36,4 +36,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+    - uses: tcort/github-action-markdown-link-check@v1


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

https://github.com/gaurav-nelson/github-action-markdown-link-check has been deprecated since Apr 2025 and https://github.com/tcort/github-action-markdown-link-check is recommended.

# Are these changes tested?
GH action change.

# Are there any user-facing changes?
No.
<!-- In the case of user-facing changes, please add the changelog label. -->
