### PR TITLE
Catalog: Fix bug for renaming table that already exists

### DIFF
--- a/mkdocs/docs/api.md
+++ b/mkdocs/docs/api.md
@@ -1031,6 +1031,7 @@ Expert Iceberg users may choose to commit existing parquet files to the Iceberg 
 ### Example
 
 Add files to Iceberg table:
+
 ```python
 # Given that these parquet files have schema consistent with the Iceberg table
 
@@ -1047,6 +1048,7 @@ tbl.add_files(file_paths=file_paths)
 ```
 
 Add files to Iceberg table with custom snapshot properties:
+
 ```python
 # Assume an existing Iceberg table object `tbl`
 

--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -657,7 +657,7 @@ class HiveCatalog(MetastoreCatalog):
         to_database_name, to_table_name = self.identifier_to_database_and_table(to_identifier)
 
         if self.table_exists(to_identifier):
-            raise TableAlreadyExistsError(f"Table already exist: {to_table_name}")
+            raise TableAlreadyExistsError(f"Table already exists: {to_table_name}")
 
         try:
             with self._client as open_client:

--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -651,9 +651,14 @@ class HiveCatalog(MetastoreCatalog):
             ValueError: When from table identifier is invalid.
             NoSuchTableError: When a table with the name does not exist.
             NoSuchNamespaceError: When the destination namespace doesn't exist.
+            TableAlreadyExistsError: When the destination table already exists.
         """
         from_database_name, from_table_name = self.identifier_to_database_and_table(from_identifier, NoSuchTableError)
         to_database_name, to_table_name = self.identifier_to_database_and_table(to_identifier)
+
+        if self.table_exists(to_identifier):
+            raise TableAlreadyExistsError(f"Table already exist: {to_table_name}")
+
         try:
             with self._client as open_client:
                 tbl = open_client.get_table(dbname=from_database_name, tbl_name=from_table_name)

--- a/tests/catalog/test_hive.py
+++ b/tests/catalog/test_hive.py
@@ -976,9 +976,10 @@ def test_rename_table_to_table_already_exists(hive_table: HiveTable) -> None:
     catalog = HiveCatalog(HIVE_CATALOG_NAME, uri=HIVE_METASTORE_FAKE_URL)
     catalog.load_table = MagicMock(return_value=hive_table)  # type: ignore[method-assign]
 
-    with pytest.raises(TableAlreadyExistsError):
+    with pytest.raises(TableAlreadyExistsError) as exc_info:
         catalog.rename_table(("default", "some_table"), ("default", "new_tabl2e"))
 
+    assert "Table already exists: new_tabl2e" in str(exc_info.value)
 
 def test_drop_database_does_not_empty() -> None:
     catalog = HiveCatalog(HIVE_CATALOG_NAME, uri=HIVE_METASTORE_FAKE_URL)


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

Hive catalog returned a `NoSuchNamespaceError` when it tried to rename to a table that already exists in the catalog. This change will first check for the destination table existence before executing the alter table.

# Are these changes tested?

Yes, added one unit test and one integration test

# Are there any user-facing changes?

Yes? Users using the hive catalog will get a new exception for this edge case.

<!-- In the case of user-facing changes, please add the changelog label. -->
