### PR TITLE
REST: Remove spec-version version HTTP header

### DIFF
--- a/pyiceberg/catalog/rest/__init__.py
+++ b/pyiceberg/catalog/rest/__init__.py
@@ -80,8 +80,6 @@ from pyiceberg.utils.properties import get_first_property_value, get_header_prop
 if TYPE_CHECKING:
     import pyarrow as pa
 
-ICEBERG_REST_SPEC_VERSION = "0.14.1"
-
 
 class Endpoints:
     get_config: str = "config"
@@ -485,7 +483,6 @@ class RestCatalog(Catalog):
         header_properties = get_header_properties(self.properties)
         session.headers.update(header_properties)
         session.headers["Content-type"] = "application/json"
-        session.headers["X-Client-Version"] = ICEBERG_REST_SPEC_VERSION
         session.headers["User-Agent"] = f"PyIceberg/{__version__}"
         session.headers.setdefault("X-Iceberg-Access-Delegation", ACCESS_DELEGATION_DEFAULT)
 

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -58,7 +58,6 @@ TEST_RESOURCE = "test_resource"
 
 TEST_HEADERS = {
     "Content-type": "application/json",
-    "X-Client-Version": "0.14.1",
     "User-Agent": f"PyIceberg/{pyiceberg.__version__}",
     "Authorization": f"Bearer {TEST_TOKEN}",
     "X-Iceberg-Access-Delegation": "vended-credentials",


### PR DESCRIPTION
# Rationale for this change

This was added way ago, but I don't think it makes any sense for two reasons:

- It was never updated properly :)
- The spec is not versioned with the Java release

Better to clean this up


# Are these changes tested?

# Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
