### PR TITLE
perf: optimize `inspect.partitions`

### DIFF
--- a/pyiceberg/table/inspect.py
+++ b/pyiceberg/table/inspect.py
@@ -290,7 +290,7 @@ class InspectTable:
 
         snapshot = self._get_snapshot(snapshot_id)
         executor = ExecutorFactory.get_or_create()
-        local_partitions_maps = list(executor.map(self._process_manifest, snapshot.manifests(self.tbl.io)))
+        local_partitions_maps = executor.map(self._process_manifest, snapshot.manifests(self.tbl.io))
 
         partitions_map: Dict[Tuple[str, Any], Any] = {}
         for local_map in local_partitions_maps:


### PR DESCRIPTION
Parallelizes manifest processing to improve performance for large tables with many manifest files. After parallel processing, merges the resulting partition maps to produce the final aggregated result.
Previous example ref: e937f6a1811c9e090552a4ae2015a8032e7ea910

<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
Perf improvement.
We experienced slowness with table.inspect.partitions() with large table.

# Are these changes tested?
Yes.

# Are there any user-facing changes?
No.
<!-- In the case of user-facing changes, please add the changelog label. -->
