### PR TITLE
Bump `pre-commit-hooks` in `.pre-commit-config.yaml` file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ exclude: ^vendor/
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer


### PR DESCRIPTION
issue #2341 

In this PR i update only `pre-commit-hooks` (updating `v5.0.0 -> v6.0.0`) in `.pre-commit-config.yaml` file.

i tested it with 'make lint' command and it  looks good to me.
<img width="969" height="263" alt="image" src="https://github.com/user-attachments/assets/77a80965-ad22-472e-87a0-4174ef0bf2ee" />


