### PR TITLE
Update pre-commit hooks 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,19 +27,19 @@ repos:
       - id: check-yaml
       - id: check-ast
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.13
+    rev: v0.12.9
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.16.0
+    rev:  v1.17.1
     hooks:
       - id: mypy
         args:
           [--install-types, --non-interactive, --config=pyproject.toml]
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.43.0
+    rev: v0.45.0
     hooks:
       - id: markdownlint
         args: ["--fix"]
@@ -54,7 +54,7 @@ repos:
         additional_dependencies:
           - tomli==2.0.1
   - repo: https://github.com/ikamensh/flynt
-    rev: 1.0.1
+    rev: 1.0.6
     hooks:
       - id: flynt
         args:
@@ -62,7 +62,7 @@ repos:
           - --line-length
           - '99999'
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
       - id: codespell
 ci:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ exclude: ^vendor/
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer


### PR DESCRIPTION

ISSUE -- #2341 
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
This is my first contribution ,please guide if any mistakes found.
Updated all pre-commit hooks to their latest versions :
- pre-commit-hooks: v5.0.0 → v6.0.0
- ruff-pre-commit: v0.11.13 → v0.12.9
- mirrors-mypy: v1.16.0 → v1.17.1  
- markdownlint-cli: v0.43.0 → v0.45.0
- flynt: 1.0.1 → 1.0.6
- codespell: v2.3.0 → v2.4.1
- pydocstyle: latest (already up to date)

Tested locally all checks pass.
<img width="449" height="138" alt="image" src="https://github.com/user-attachments/assets/3794b151-4915-48fd-b358-b39e04d1a706" />

