### PR TITLE
Bump `mirrors-mypy` in `.pre-commit-config.yaml` file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         args: [ --fix, --exit-non-zero-on-fix ]
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.16.0
+    rev: v1.17.1
     hooks:
       - id: mypy
         args:


### PR DESCRIPTION
issue #2341 

In this PR I update `mirrors-mypy` (from `v1.16.0 -> v1.17.1`) in `.pre-commit-config.yaml` file.
After the update, I ran make lint, and it executed successfully without any issues.

<img width="1022" height="313" alt="Screenshot from 2025-08-20 22-01-55" src="https://github.com/user-attachments/assets/5e5c6884-2301-4c2c-80bd-70f31874afca" />





