### PR TITLE
Bump `markdownlint-cli` in `.pre-commit-config.yaml` file

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,8 +7,8 @@ Thanks for opening a pull request!
 
 # Rationale for this change
 
-# Are these changes tested?
+## Are these changes tested?
 
-# Are there any user-facing changes?
+## Are there any user-facing changes?
 
 <!-- In the case of user-facing changes, please add the changelog label. -->

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
         args:
           [--install-types, --non-interactive, --config=pyproject.toml]
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.43.0
+    rev: v0.44.0
     hooks:
       - id: markdownlint
         args: ["--fix"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
         args:
           [--install-types, --non-interactive, --config=pyproject.toml]
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.44.0
+    rev: v0.45.0
     hooks:
       - id: markdownlint
         args: ["--fix"]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ PyIceberg is a Python library for programmatic access to Iceberg table metadata 
 
 The documentation is available at [https://py.iceberg.apache.org/](https://py.iceberg.apache.org/).
 
-# Get in Touch
+## Get in Touch
 
 - [Iceberg community](https://iceberg.apache.org/community/)

--- a/mkdocs/docs/how-to-release.md
+++ b/mkdocs/docs/how-to-release.md
@@ -397,7 +397,7 @@ Ensure to update the `PYICEBERG_VERSION` in the [Dockerfile](https://github.com/
 
 ### Set up GPG key and Upload to Apache Iceberg KEYS file
 
-To set up GPG key locally, see the instructions [here](http://www.apache.org/dev/openpgp.html#key-gen-generate-key).
+To set up GPG key locally, see the instructions [instructions link](http://www.apache.org/dev/openpgp.html#key-gen-generate-key).
 
 To install gpg on a M1 based Mac, a couple of additional steps are required: <https://gist.github.com/phortuin/cf24b1cca3258720c71ad42977e1ba57>.
 

--- a/mkdocs/docs/how-to-release.md
+++ b/mkdocs/docs/how-to-release.md
@@ -397,7 +397,7 @@ Ensure to update the `PYICEBERG_VERSION` in the [Dockerfile](https://github.com/
 
 ### Set up GPG key and Upload to Apache Iceberg KEYS file
 
-To set up GPG key locally, see the instructions [instructions link](http://www.apache.org/dev/openpgp.html#key-gen-generate-key).
+To set up GPG key locally, see the [instructions](http://www.apache.org/dev/openpgp.html#key-gen-generate-key).
 
 To install gpg on a M1 based Mac, a couple of additional steps are required: <https://gist.github.com/phortuin/cf24b1cca3258720c71ad42977e1ba57>.
 

--- a/mkdocs/docs/verify-release.md
+++ b/mkdocs/docs/verify-release.md
@@ -113,7 +113,7 @@ make test-coverage
 
 This will spin up Docker containers to facilitate running test coverage.
 
-# Cast the vote
+## Cast the vote
 
 Votes are cast by replying to the release candidate announcement email on the dev mailing list with either `+1`, `0`, or `-1`. For example :
 


### PR DESCRIPTION
issue #2341 

Initially, I updated `markdownlint-cli` from `v0.43.0 → v0.45.0`, but running `make lint` failed with errors:

<img width="1310" height="432" alt="Screenshot from 2025-08-21 09-58-10" src="https://github.com/user-attachments/assets/73785f76-f855-418a-b4c7-db95632579b0" />

After that, I downgraded slightly to `v0.44.0` (instead of `v0.45.0`), and `make lint` executed successfully:

<img width="949" height="261" alt="Screenshot from 2025-08-21 10-01-28" src="https://github.com/user-attachments/assets/69f56f9a-1bbb-4aa8-ae5e-51fd72b8fee0" />

