### PR TITLE
Bump `flynt` in `.pre-commit-config.yaml` file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
         additional_dependencies:
           - tomli==2.0.1
   - repo: https://github.com/ikamensh/flynt
-    rev: 1.0.1
+    rev: 1.0.6
     hooks:
       - id: flynt
         args:


### PR DESCRIPTION
issue #2341 

In this PR, I update `flynt` (from`1.0.1 -> 1.0.6`) in `.pre-commit-comfig.yaml` file.

Testing:

<img width="941" height="333" alt="Screenshot from 2025-08-22 10-08-31" src="https://github.com/user-attachments/assets/abbff60c-f170-440e-8155-b8c44ff87bb0" />

