### PR TITLE
Add serializer for AssertRefSnapshotId allowing null json value

### DIFF
--- a/pyiceberg/table/update/__init__.py
+++ b/pyiceberg/table/update/__init__.py
@@ -24,7 +24,6 @@ from functools import singledispatch
 from typing import TYPE_CHECKING, Annotated, Any, Dict, Generic, List, Literal, Optional, Tuple, TypeVar, Union, cast
 
 from pydantic import Field, field_validator, model_validator, model_serializer
-from pydantic_core.core_schema import SerializerFunctionWrapHandler, SerializationInfo
 
 from pyiceberg.exceptions import CommitFailedException
 from pyiceberg.partitioning import PARTITION_FIELD_ID_START, PartitionSpec
@@ -731,6 +730,7 @@ class AssertRefSnapshotId(ValidatableTableRequirement):
     @model_serializer(mode="wrap")
     def serialize_model(self, handler) -> dict[str, Any]:
         partial_result = handler(self)
+        # Ensure "snapshot-id" is always present, even if value is None
         return {**partial_result, "snapshot-id": self.snapshot_id}
 
     def validate(self, base_metadata: Optional[TableMetadata]) -> None:

--- a/pyiceberg/table/update/__init__.py
+++ b/pyiceberg/table/update/__init__.py
@@ -25,9 +25,6 @@ from typing import TYPE_CHECKING, Annotated, Any, Dict, Generic, List, Literal, 
 
 from pydantic import Field, field_validator, model_serializer, model_validator
 
-if TYPE_CHECKING:
-    from pydantic.functional_serializers import ModelWrapSerializerWithoutInfo
-
 from pyiceberg.exceptions import CommitFailedException
 from pyiceberg.partitioning import PARTITION_FIELD_ID_START, PartitionSpec
 from pyiceberg.schema import Schema
@@ -55,6 +52,8 @@ from pyiceberg.utils.datetime import datetime_to_millis
 from pyiceberg.utils.properties import property_as_int
 
 if TYPE_CHECKING:
+    from pydantic.functional_serializers import ModelWrapSerializerWithoutInfo
+
     from pyiceberg.table import Transaction
 
 U = TypeVar("U")

--- a/pyiceberg/table/update/__init__.py
+++ b/pyiceberg/table/update/__init__.py
@@ -23,7 +23,8 @@ from datetime import datetime
 from functools import singledispatch
 from typing import TYPE_CHECKING, Annotated, Any, Dict, Generic, List, Literal, Optional, Tuple, TypeVar, Union, cast
 
-from pydantic import Field, field_validator, model_validator, model_serializer
+from pydantic import Field, field_validator, model_serializer, model_validator
+from pydantic.functional_serializers import ModelWrapSerializerWithoutInfo
 
 from pyiceberg.exceptions import CommitFailedException
 from pyiceberg.partitioning import PARTITION_FIELD_ID_START, PartitionSpec
@@ -728,7 +729,7 @@ class AssertRefSnapshotId(ValidatableTableRequirement):
     snapshot_id: Optional[int] = Field(default=None, alias="snapshot-id")
 
     @model_serializer(mode="wrap")
-    def serialize_model(self, handler) -> dict[str, Any]:
+    def serialize_model(self, handler: ModelWrapSerializerWithoutInfo) -> dict[str, Any]:
         partial_result = handler(self)
         # Ensure "snapshot-id" is always present, even if value is None
         return {**partial_result, "snapshot-id": self.snapshot_id}

--- a/pyiceberg/table/update/__init__.py
+++ b/pyiceberg/table/update/__init__.py
@@ -732,7 +732,7 @@ class AssertRefSnapshotId(ValidatableTableRequirement):
         return {
             "type": self.type,
             "ref": self.ref,
-            "snapshot_id": self.snapshot_id,
+            "snapshot-id": self.snapshot_id,
         }
 
     def validate(self, base_metadata: Optional[TableMetadata]) -> None:

--- a/pyiceberg/table/update/__init__.py
+++ b/pyiceberg/table/update/__init__.py
@@ -24,7 +24,9 @@ from functools import singledispatch
 from typing import TYPE_CHECKING, Annotated, Any, Dict, Generic, List, Literal, Optional, Tuple, TypeVar, Union, cast
 
 from pydantic import Field, field_validator, model_serializer, model_validator
-from pydantic.functional_serializers import ModelWrapSerializerWithoutInfo
+
+if TYPE_CHECKING:
+    from pydantic.functional_serializers import ModelWrapSerializerWithoutInfo
 
 from pyiceberg.exceptions import CommitFailedException
 from pyiceberg.partitioning import PARTITION_FIELD_ID_START, PartitionSpec

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -56,7 +56,7 @@ def test_null_serializer_field() -> None:
     class ExampleRequest(IcebergBaseModel):
         requirements: Tuple[TableRequirement, ...]
 
-    request = ExampleRequest(requirements=(AssertRefSnapshotId(ref="main"),))
+    request = ExampleRequest(requirements=(AssertRefSnapshotId(ref="main", snapshot_id=None),))
     dumped_json = request.model_dump_json()
     expected_json = """{"type":"assert-ref-snapshot-id","ref":"main","snapshot-id":null}"""
     assert expected_json in dumped_json


### PR DESCRIPTION
Closes #2342

# Rationale for this change

The last attempt at fixing this (#2343) did not actually end up serializing None values to `null`. This was b/c the `AssertRefSnapshotId` requirement was often a child object of some other `Request` object, which was actually getting the  `model_dump_json()` call. This meant that the `exclude_none=True` override would remove any `None`s _before_ any of the `Field`-specific configurations would be considered (like `exclude=False` or the model's own `model_dump_json` method).

I then investigated setting some `ConfigDict` settings on the model, but that also did not have any useful configurations.

I looked into setting `exclude_none=True` at all of the `model_json_dump()` callsites but there were too many and it would be easy to forget to set that value every time. The issue is that many values are _supposed to be absent_ to instruct the REST Catalog about what the client wants (things like filtering, for instance).

~The solution I ended up with was allowing `snapshot_id` to be a required `int` with a default value of `-1`, and adding a json-specific field serializer to write out `null` when dumping to json. This seems to work~ 

The solution that worked and allowed for `snapshot_id` to be set to `None` (as it's done in Ray Data), was to define a `model_serializer` method and always return the fields. This was based on conversations in https://github.com/pydantic/pydantic/issues/7326. 

## Are these changes tested?

Yes

## Are there any user-facing changes?

Actually allow `snapshot-id` to be null for `assert-ref-snapshot-id` requirements
