### PR TITLE
Bump `codespell` in `.pre-commit-config.yaml` file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
           - --line-length
           - '99999'
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
       - id: codespell
 ci:


### PR DESCRIPTION
issue #2341

In this PR, I update codespell (from `v2.3.0 -> v2.4.1`) in `.pre-commit-comfig.yaml` file.

Testing:

<img width="927" height="325" alt="Screenshot from 2025-08-23 20-03-05" src="https://github.com/user-attachments/assets/016e0647-8b3f-4e74-adde-d70dea5bde9a" />

