### PR TITLE
use anon argument when configuring s3fs.S3FileSystem

### DIFF
--- a/pyiceberg/io/fsspec.py
+++ b/pyiceberg/io/fsspec.py
@@ -168,9 +168,11 @@ def _s3(properties: Properties) -> AbstractFileSystem:
         config_kwargs["read_timeout"] = float(request_timeout)
 
     if s3_anonymous := properties.get(S3_ANONYMOUS):
-        config_kwargs["anon"] = strtobool(s3_anonymous)
+        anon = strtobool(s3_anonymous)
+    else:
+        anon = False
 
-    fs = S3FileSystem(client_kwargs=client_kwargs, config_kwargs=config_kwargs)
+    fs = S3FileSystem(anon=anon, client_kwargs=client_kwargs, config_kwargs=config_kwargs)
 
     for event_name, event_function in register_events.items():
         fs.s3.meta.events.unregister(event_name, unique_id=1925)

--- a/tests/io/test_fsspec.py
+++ b/tests/io/test_fsspec.py
@@ -255,6 +255,7 @@ def test_fsspec_s3_session_properties() -> None:
         s3_fileio.new_input(location=f"s3://warehouse/{filename}")
 
         mock_s3fs.assert_called_with(
+            anon=False,
             client_kwargs={
                 "endpoint_url": "http://localhost:9000",
                 "aws_access_key_id": "admin",
@@ -309,6 +310,7 @@ def test_fsspec_unified_session_properties() -> None:
         s3_fileio.new_input(location=f"s3://warehouse/{filename}")
 
         mock_s3fs.assert_called_with(
+            anon=False,
             client_kwargs={
                 "endpoint_url": "http://localhost:9000",
                 "aws_access_key_id": "client.access-key-id",

--- a/tests/io/test_fsspec.py
+++ b/tests/io/test_fsspec.py
@@ -284,6 +284,7 @@ def test_fsspec_s3_session_properties_with_anonymous() -> None:
         s3_fileio.new_input(location=f"s3://warehouse/{filename}")
 
         mock_s3fs.assert_called_with(
+            anon=True,
             client_kwargs={
                 "endpoint_url": "http://localhost:9000",
                 "aws_access_key_id": "admin",
@@ -291,9 +292,7 @@ def test_fsspec_s3_session_properties_with_anonymous() -> None:
                 "region_name": "us-east-1",
                 "aws_session_token": "s3.session-token",
             },
-            config_kwargs={
-                "anon": True,
-            },
+            config_kwargs={},
         )
 
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
`s3fs.S3FileSystem` requires that we pass `anon` directly, it cannot be passed through `config_kwargs`.

## Are these changes tested?
yes, unit tests updated.

## Are there any user-facing changes?
no

<!-- In the case of user-facing changes, please add the changelog label. -->
