### PR TITLE
Fix rest test with ssl_ca_bundle due to conflicts with OS environment

### DIFF
--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -1496,6 +1496,10 @@ def test_request_session_with_ssl_ca_bundle() -> None:
         },
     }
     with pytest.raises(OSError) as e:
+        if "REQUESTS_CA_BUNDLE" in os.environ:
+            os.environ.pop("REQUESTS_CA_BUNDLE")
+        if "CURL_CA_BUNDLE" in os.environ:
+            os.environ.pop("CURL_CA_BUNDLE")
         # Missing namespace
         RestCatalog("rest", **catalog_properties)  # type: ignore
     assert "Could not find a suitable TLS CA certificate bundle, invalid path: path_to_ca_bundle" in str(e.value)

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -1486,7 +1486,7 @@ def test_update_namespace_properties_invalid_namespace(rest_mock: Mocker) -> Non
     assert "Empty namespace identifier" in str(e.value)
 
 
-def test_request_session_with_ssl_ca_bundle(monkeypatch) -> None:
+def test_request_session_with_ssl_ca_bundle(monkeypatch: pytest.MonkeyPatch) -> None:
     # Given
     catalog_properties = {
         "uri": TEST_URI,

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -1486,7 +1486,7 @@ def test_update_namespace_properties_invalid_namespace(rest_mock: Mocker) -> Non
     assert "Empty namespace identifier" in str(e.value)
 
 
-def test_request_session_with_ssl_ca_bundle() -> None:
+def test_request_session_with_ssl_ca_bundle(monkeypatch) -> None:
     # Given
     catalog_properties = {
         "uri": TEST_URI,
@@ -1496,10 +1496,8 @@ def test_request_session_with_ssl_ca_bundle() -> None:
         },
     }
     with pytest.raises(OSError) as e:
-        if "REQUESTS_CA_BUNDLE" in os.environ:
-            os.environ.pop("REQUESTS_CA_BUNDLE")
-        if "CURL_CA_BUNDLE" in os.environ:
-            os.environ.pop("CURL_CA_BUNDLE")
+        monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+        monkeypatch.delenv("CURL_CA_BUNDLE", raising=False)
         # Missing namespace
         RestCatalog("rest", **catalog_properties)  # type: ignore
     assert "Could not find a suitable TLS CA certificate bundle, invalid path: path_to_ca_bundle" in str(e.value)


### PR DESCRIPTION
# Rationale for this change

Request sessions could load `REQUESTS_CA_BUNDLE` or `CURL_CA_BUNDLE` from OS environment such that cabundle passed in from the UT is not used.
https://github.com/psf/requests/blob/88dce9d854797c05d0ff296b70e0430535ef8aaf/src/requests/sessions.py#L766-L771

## Are these changes tested?
Yes

## Are there any user-facing changes?
No