### PR TITLE
use PyArrowFileIO as default for abfs and wasb schemes

### DIFF
--- a/pyiceberg/io/__init__.py
+++ b/pyiceberg/io/__init__.py
@@ -313,10 +313,10 @@ SCHEMA_TO_FILE_IO: Dict[str, List[str]] = {
     "file": [ARROW_FILE_IO, FSSPEC_FILE_IO],
     "hdfs": [ARROW_FILE_IO],
     "viewfs": [ARROW_FILE_IO],
-    "abfs": [ARROW_FILE_IO, FSSPEC_FILE_IO],
-    "abfss": [ARROW_FILE_IO, FSSPEC_FILE_IO],
-    "wasb": [ARROW_FILE_IO, FSSPEC_FILE_IO],
-    "wasbs": [ARROW_FILE_IO, FSSPEC_FILE_IO],
+    "abfs": [FSSPEC_FILE_IO, ARROW_FILE_IO],
+    "abfss": [FSSPEC_FILE_IO, ARROW_FILE_IO],
+    "wasb": [FSSPEC_FILE_IO, ARROW_FILE_IO],
+    "wasbs": [FSSPEC_FILE_IO, ARROW_FILE_IO],
     "hf": [FSSPEC_FILE_IO],
 }
 

--- a/pyiceberg/io/__init__.py
+++ b/pyiceberg/io/__init__.py
@@ -313,8 +313,10 @@ SCHEMA_TO_FILE_IO: Dict[str, List[str]] = {
     "file": [ARROW_FILE_IO, FSSPEC_FILE_IO],
     "hdfs": [ARROW_FILE_IO],
     "viewfs": [ARROW_FILE_IO],
-    "abfs": [FSSPEC_FILE_IO],
-    "abfss": [FSSPEC_FILE_IO],
+    "abfs": [ARROW_FILE_IO, FSSPEC_FILE_IO],
+    "abfss": [ARROW_FILE_IO, FSSPEC_FILE_IO],
+    "wasb": [ARROW_FILE_IO, FSSPEC_FILE_IO],
+    "wasbs": [ARROW_FILE_IO, FSSPEC_FILE_IO],
     "hf": [FSSPEC_FILE_IO],
 }
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

Now that [pyarrow FileIO supports ADLS](https://github.com/apache/iceberg-python/pull/2111), we can update the [SCHEMA_TO_FILE_IO](https://github.com/apache/iceberg-python/blob/370e770383c9c129aff2fe24cc92a68981688159/pyiceberg/io/__init__.py#L307-L319) mapping for `abfs` and `wasb` to use ARROW_FILE_IO, similar to how it’s handled for s3

We’re keeping FsspecFileIO as the preferred default, since the PyArrowFileIO implementation is only available in pyarrow >= 20.0.0

## Are these changes tested?

## Are there any user-facing changes?

Add mapping SCHEMA_TO_FILE_IO for `wasb` and `abfs` to `FsspecFileIO` and `PyArrowFileIO`

<!-- In the case of user-facing changes, please add the changelog label. -->
