### PR TITLE
Add `close()` method to RestCatalog

### DIFF
--- a/pyiceberg/catalog/rest/__init__.py
+++ b/pyiceberg/catalog/rest/__init__.py
@@ -876,3 +876,10 @@ class RestCatalog(Catalog):
             response.raise_for_status()
         except HTTPError as exc:
             _handle_non_200_response(exc, {404: NoSuchViewError})
+
+    def close(self) -> None:
+        """Close the catalog and release Session connection adapters.
+
+        This method closes mounted HttpAdapters' pooled connections and any active Proxy pooled connections.
+        """
+        self._session.close()


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
Part of #2399 

# Rationale for this change

This PR introducs the implementation of  `close()` method to the `RestCatalog`. 

And add corresponding test case which following the test pattern in #2390

## Are these changes tested?

Yes

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
