### PR TITLE
build: add poetry.lock to sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ include = [
   { path = "dev", format = "sdist" },
   { path = "pyiceberg/**/*.so", format = "wheel" },
   { path = "pyiceberg/**/*.pyd", format = "wheel" },
+  { path = "poetry.lock", format = "sdist" },
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
This PR explicitly add `poetry.lock` to the source distribution artifact so that we can build and test RCs with pinned dependencies.

We want to pin dependencies because we verify a release candidate (RC) by re-building the project from source distribution. We [unzip the artifact](https://py.iceberg.apache.org/verify-release/#verifying-license-documentation), [install the dependencies with `make install`, and then run tests](https://py.iceberg.apache.org/verify-release/#testing). 

Since `poetry.lock` is not automatically added to the source distribution, `make install` will install packages only based on `pyproject.toml`. The resolver will pull in the latest version by default, which can lead to compatibility issues. 
For example, in 0.10 RC2, we see that this pulled in the latest datafusion which caused an compatibility issue with pyiceberg-core. This is due to the breaking change in the FFI boundary, see https://github.com/apache/datafusion-python/issues/1217

Alternatively, we can restrict the upperbound of the dependencies, but that since these are optional dependencies, we want to give users the freedom to choose. 

## Are these changes tested?

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
