### PR TITLE
fix: upsert with null values in join columns

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -718,6 +718,7 @@ class Transaction:
         when_matched_update_all: bool = True,
         when_not_matched_insert_all: bool = True,
         case_sensitive: bool = True,
+        null_safe_eq: bool = False,
         branch: str | None = MAIN_BRANCH,
         snapshot_properties: dict[str, str] = EMPTY_DICT,
     ) -> UpsertResult:
@@ -732,6 +733,7 @@ class Transaction:
             when_not_matched_insert_all: Bool indicating new rows to be inserted that do not match any
                 existing rows in the table
             case_sensitive: Bool indicating if the match should be case-sensitive
+            null_safe_eq: Bool indicating if the equality operator should be null-safe (<=> instead of =)
             branch: Branch Reference to run the upsert operation
             snapshot_properties: Custom properties to be added to the snapshot summary
 
@@ -824,7 +826,7 @@ class Transaction:
                 # values have actually changed. We don't want to do just a blanket overwrite for matched
                 # rows if the actual non-key column data hasn't changed.
                 # this extra step avoids unnecessary IO and writes
-                rows_to_update = upsert_util.get_rows_to_update(df, rows, join_cols)
+                rows_to_update = upsert_util.get_rows_to_update(df, rows, join_cols, null_safe_eq=null_safe_eq)
 
                 if len(rows_to_update) > 0:
                     # build the match predicate filter
@@ -1320,6 +1322,7 @@ class Table:
         when_matched_update_all: bool = True,
         when_not_matched_insert_all: bool = True,
         case_sensitive: bool = True,
+        null_safe_eq: bool = False,
         branch: str | None = MAIN_BRANCH,
         snapshot_properties: dict[str, str] = EMPTY_DICT,
     ) -> UpsertResult:
@@ -1334,6 +1337,7 @@ class Table:
             when_not_matched_insert_all: Bool indicating new rows to be inserted that do not match any
                 existing rows in the table
             case_sensitive: Bool indicating if the match should be case-sensitive
+            null_safe_eq: Bool indicating if the equality operator should be null-safe (<=> instead of =)
             branch: Branch Reference to run the upsert operation
             snapshot_properties: Custom properties to be added to the snapshot summary
 
@@ -1368,6 +1372,7 @@ class Table:
                 when_matched_update_all=when_matched_update_all,
                 when_not_matched_insert_all=when_not_matched_insert_all,
                 case_sensitive=case_sensitive,
+                null_safe_eq=null_safe_eq,
                 branch=branch,
                 snapshot_properties=snapshot_properties,
             )

--- a/pyiceberg/table/upsert_util.py
+++ b/pyiceberg/table/upsert_util.py
@@ -14,8 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import functools
-import operator
+from math import isnan
+from typing import Any
 
 import pyarrow as pa
 from pyarrow import Table as pyarrow_table
@@ -23,29 +23,52 @@ from pyarrow import compute as pc
 
 from pyiceberg.expressions import (
     AlwaysFalse,
+    And,
     BooleanExpression,
     EqualTo,
     In,
+    IsNaN,
+    IsNull,
     Or,
 )
 
 
 def create_match_filter(df: pyarrow_table, join_cols: list[str]) -> BooleanExpression:
     unique_keys = df.select(join_cols).group_by(join_cols).aggregate([])
+    filters = []
 
     if len(join_cols) == 1:
-        return In(join_cols[0], unique_keys[0].to_pylist())
-    else:
-        filters = [
-            functools.reduce(operator.and_, [EqualTo(col, row[col]) for col in join_cols]) for row in unique_keys.to_pylist()
-        ]
+        column = join_cols[0]
+        values = set(unique_keys[0].to_pylist())
 
-        if len(filters) == 0:
-            return AlwaysFalse()
-        elif len(filters) == 1:
-            return filters[0]
-        else:
-            return Or(*filters)
+        if None in values:
+            filters.append(IsNull(column))
+            values.remove(None)
+
+        if nans := {v for v in values if isinstance(v, float) and isnan(v)}:
+            filters.append(IsNaN(column))
+            values -= nans
+
+        filters.append(In(column, values))
+    else:
+
+        def equals(column: str, value: Any) -> BooleanExpression:
+            if value is None:
+                return IsNull(column)
+
+            if isinstance(value, float) and isnan(value):
+                return IsNaN(column)
+
+            return EqualTo(column, value)
+
+        filters = [And(*[equals(col, row[col]) for col in join_cols]) for row in unique_keys.to_pylist()]
+
+    if len(filters) == 0:
+        return AlwaysFalse()
+    elif len(filters) == 1:
+        return filters[0]
+    else:
+        return Or(*filters)
 
 
 def has_duplicate_rows(df: pyarrow_table, join_cols: list[str]) -> bool:

--- a/pyiceberg/table/upsert_util.py
+++ b/pyiceberg/table/upsert_util.py
@@ -35,7 +35,7 @@ from pyiceberg.expressions import (
 
 def create_match_filter(df: pyarrow_table, join_cols: list[str]) -> BooleanExpression:
     unique_keys = df.select(join_cols).group_by(join_cols).aggregate([])
-    filters = []
+    filters: list[BooleanExpression] = []
 
     if len(join_cols) == 1:
         column = join_cols[0]

--- a/pyiceberg/table/upsert_util.py
+++ b/pyiceberg/table/upsert_util.py
@@ -76,7 +76,7 @@ def has_duplicate_rows(df: pyarrow_table, join_cols: list[str]) -> bool:
     return len(df.select(join_cols).group_by(join_cols).aggregate([([], "count_all")]).filter(pc.field("count_all") > 1)) > 0
 
 
-def get_rows_to_update(source_table: pa.Table, target_table: pa.Table, join_cols: list[str]) -> pa.Table:
+def get_rows_to_update(source_table: pa.Table, target_table: pa.Table, join_cols: list[str], null_safe_eq: bool) -> pa.Table:
     """
     Return a table with rows that need to be updated in the target table based on the join columns.
 
@@ -121,16 +121,20 @@ def get_rows_to_update(source_table: pa.Table, target_table: pa.Table, join_cols
     target_index = target_table.select(join_cols_set).append_column(TARGET_INDEX_COLUMN_NAME, pa.array(range(len(target_table))))
 
     # Step 3: Perform an inner join to find which rows from source exist in target
-    # PyArrow joins ignore null values, and we want null==null to hold, so we compute the join in Python.
-    # This is equivalent to:
-    # matching_indices = source_index.join(target_index, keys=list(join_cols_set), join_type="inner")
-    source_indices = {tuple(row[col] for col in join_cols): row[SOURCE_INDEX_COLUMN_NAME] for row in source_index.to_pylist()}
-    target_indices = {tuple(row[col] for col in join_cols): row[TARGET_INDEX_COLUMN_NAME] for row in target_index.to_pylist()}
-    matching_indices = [(s, t) for key, s in source_indices.items() if (t := target_indices.get(key)) is not None]
+    if null_safe_eq:
+        # PyArrow joins ignore null values, and we want null==null to hold, so we compute the join in Python.
+        source_indices = {tuple(row[col] for col in join_cols): row[SOURCE_INDEX_COLUMN_NAME] for row in source_index.to_pylist()}
+        target_indices = {tuple(row[col] for col in join_cols): row[TARGET_INDEX_COLUMN_NAME] for row in target_index.to_pylist()}
+        paired_indices = [(s, t) for key, s in source_indices.items() if (t := target_indices.get(key)) is not None]
+    else:
+        matching_indices = source_index.join(target_index, keys=list(join_cols_set), join_type="inner")
+        source_indices = matching_indices[SOURCE_INDEX_COLUMN_NAME].to_pylist()
+        target_indices = matching_indices[TARGET_INDEX_COLUMN_NAME].to_pylist()
+        paired_indices = list(zip(source_indices, target_indices, strict=True))
 
     # Step 4: Compare all rows using Python
     to_update_indices = []
-    for source_idx, target_idx in matching_indices:
+    for source_idx, target_idx in paired_indices:
         source_row = source_table.slice(source_idx, 1)
         target_row = target_table.slice(target_idx, 1)
 

--- a/tests/table/test_upsert.py
+++ b/tests/table/test_upsert.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 from pathlib import PosixPath
+from typing import Any
 
 import pyarrow as pa
 import pytest
@@ -497,7 +498,7 @@ def test_create_match_filter_single_condition() -> None:
         ),
     ],
 )
-def test_create_match_filter_with_nulls(data: list[dict], expected: BooleanExpression) -> None:
+def test_create_match_filter_with_nulls(data: list[dict[str, Any]], expected: BooleanExpression) -> None:
     schema = pa.schema([pa.field("x", pa.float64()), pa.field("y", pa.float64())])
     table = pa.Table.from_pylist(data, schema=schema)
     join_cols = sorted({col for record in data for col in record})

--- a/tests/table/test_upsert.py
+++ b/tests/table/test_upsert.py
@@ -448,6 +448,11 @@ def test_create_match_filter_single_condition() -> None:
     "data, expected",
     [
         pytest.param(
+            [{"x": 1.0}, {"x": 2.0}, {"x": 3.0}],
+            In(Reference(name="x"), {DoubleLiteral(1.0), DoubleLiteral(2.0), DoubleLiteral(3.0)}),
+            id="single-column-without-null",
+        ),
+        pytest.param(
             [{"x": 1.0}, {"x": 2.0}, {"x": None}, {"x": 4.0}, {"x": float("nan")}],
             Or(
                 left=IsNull(term=Reference(name="x")),
@@ -456,7 +461,7 @@ def test_create_match_filter_single_condition() -> None:
                     right=In(Reference(name="x"), {DoubleLiteral(1.0), DoubleLiteral(2.0), DoubleLiteral(4.0)}),
                 ),
             ),
-            id="single-column",
+            id="single-column-with-null",
         ),
         pytest.param(
             [
@@ -494,11 +499,11 @@ def test_create_match_filter_single_condition() -> None:
                     ),
                 ),
             ),
-            id="multi-column",
+            id="multi-column-with-null",
         ),
     ],
 )
-def test_create_match_filter_with_nulls(data: list[dict[str, Any]], expected: BooleanExpression) -> None:
+def test_create_match_filter(data: list[dict[str, Any]], expected: BooleanExpression) -> None:
     schema = pa.schema([pa.field("x", pa.float64()), pa.field("y", pa.float64())])
     table = pa.Table.from_pylist(data, schema=schema)
     join_cols = sorted({col for record in data for col in record})

--- a/tests/table/test_upsert.py
+++ b/tests/table/test_upsert.py
@@ -23,8 +23,8 @@ from pyarrow import Table as pa_table
 
 from pyiceberg.catalog import Catalog
 from pyiceberg.exceptions import NoSuchTableError
-from pyiceberg.expressions import AlwaysTrue, And, EqualTo, Reference
-from pyiceberg.expressions.literals import LongLiteral
+from pyiceberg.expressions import AlwaysTrue, And, BooleanExpression, EqualTo, In, IsNaN, IsNull, Or, Reference
+from pyiceberg.expressions.literals import DoubleLiteral, LongLiteral
 from pyiceberg.io.pyarrow import schema_to_pyarrow
 from pyiceberg.schema import Schema
 from pyiceberg.table import Table, UpsertResult
@@ -441,6 +441,70 @@ def test_create_match_filter_single_condition() -> None:
         EqualTo(term=Reference(name="order_id"), literal=LongLiteral(101)),
         EqualTo(term=Reference(name="order_line_id"), literal=LongLiteral(1)),
     )
+
+
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        pytest.param(
+            [{"x": 1.0}, {"x": 2.0}, {"x": None}, {"x": 4.0}, {"x": float("nan")}],
+            Or(
+                left=IsNull(term=Reference(name="x")),
+                right=Or(
+                    left=IsNaN(term=Reference(name="x")),
+                    right=In(Reference(name="x"), {DoubleLiteral(1.0), DoubleLiteral(2.0), DoubleLiteral(4.0)}),
+                ),
+            ),
+            id="single-column",
+        ),
+        pytest.param(
+            [
+                {"x": 1.0, "y": 9.0},
+                {"x": 2.0, "y": None},
+                {"x": None, "y": 7.0},
+                {"x": 4.0, "y": float("nan")},
+                {"x": float("nan"), "y": 0.0},
+            ],
+            Or(
+                left=Or(
+                    left=And(
+                        left=EqualTo(term=Reference(name="x"), literal=DoubleLiteral(1.0)),
+                        right=EqualTo(term=Reference(name="y"), literal=DoubleLiteral(9.0)),
+                    ),
+                    right=And(
+                        left=EqualTo(term=Reference(name="x"), literal=DoubleLiteral(2.0)),
+                        right=IsNull(term=Reference(name="y")),
+                    ),
+                ),
+                right=Or(
+                    left=And(
+                        left=IsNull(term=Reference(name="x")),
+                        right=EqualTo(term=Reference(name="y"), literal=DoubleLiteral(7.0)),
+                    ),
+                    right=Or(
+                        left=And(
+                            left=EqualTo(term=Reference(name="x"), literal=DoubleLiteral(4.0)),
+                            right=IsNaN(term=Reference(name="y")),
+                        ),
+                        right=And(
+                            left=IsNaN(term=Reference(name="x")),
+                            right=EqualTo(term=Reference(name="y"), literal=DoubleLiteral(0.0)),
+                        ),
+                    ),
+                ),
+            ),
+            id="multi-column",
+        ),
+    ],
+)
+def test_create_match_filter_with_nulls(data: list[dict], expected: BooleanExpression) -> None:
+    schema = pa.schema([pa.field("x", pa.float64()), pa.field("y", pa.float64())])
+    table = pa.Table.from_pylist(data, schema=schema)
+    join_cols = sorted({col for record in data for col in record})
+
+    expr = create_match_filter(table, join_cols)
+
+    assert expr == expected
 
 
 def test_upsert_with_duplicate_rows_in_table(catalog: Catalog) -> None:

--- a/tests/table/test_upsert.py
+++ b/tests/table/test_upsert.py
@@ -783,6 +783,20 @@ def test_upsert_with_nulls(catalog: Catalog) -> None:
         schema=schema,
     )
 
+
+def test_upsert_with_nulls_in_join_columns(catalog: Catalog) -> None:
+    identifier = "default.test_upsert_with_nulls_in_join_columns"
+    _drop_table(catalog, identifier)
+
+    schema = pa.schema(
+        [
+            ("foo", pa.string()),
+            ("bar", pa.int32()),
+            ("baz", pa.bool_()),
+        ]
+    )
+    table = catalog.create_table(identifier, schema)
+
     # upsert table with null value
     data_with_null = pa.Table.from_pylist(
         [
@@ -796,8 +810,6 @@ def test_upsert_with_nulls(catalog: Catalog) -> None:
     assert table.scan().to_arrow() == pa.Table.from_pylist(
         [
             {"foo": None, "bar": 1, "baz": False},
-            {"foo": "apple", "bar": 7, "baz": False},
-            {"foo": "banana", "bar": None, "baz": False},
         ],
         schema=schema,
     )
@@ -817,8 +829,6 @@ def test_upsert_with_nulls(catalog: Catalog) -> None:
         [
             {"foo": "lemon", "bar": None, "baz": False},
             {"foo": None, "bar": 1, "baz": True},
-            {"foo": "apple", "bar": 7, "baz": False},
-            {"foo": "banana", "bar": None, "baz": False},
         ],
         schema=schema,
     )

--- a/tests/table/test_upsert.py
+++ b/tests/table/test_upsert.py
@@ -810,7 +810,7 @@ def test_upsert_with_nulls_in_join_columns(catalog: Catalog) -> None:
         ],
         schema=schema,
     )
-    upd = table.upsert(data_with_null, join_cols=["foo"])
+    upd = table.upsert(data_with_null, join_cols=["foo"], null_safe_eq=True)
     assert upd.rows_updated == 0
     assert upd.rows_inserted == 1
     assert table.scan().to_arrow() == pa.Table.from_pylist(
@@ -828,7 +828,7 @@ def test_upsert_with_nulls_in_join_columns(catalog: Catalog) -> None:
         ],
         schema=schema,
     )
-    upd = table.upsert(data_with_null, join_cols=["foo", "bar"])
+    upd = table.upsert(data_with_null, join_cols=["foo", "bar"], null_safe_eq=True)
     assert upd.rows_updated == 1
     assert upd.rows_inserted == 1
     assert table.scan().to_arrow() == pa.Table.from_pylist(


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #2426 -->

# Rationale for this change

This fixes #2426. The upsert method now supports null values to be passed in the join columns.

## Are these changes tested?

Yes, I added unit tests.

## Are there any user-facing changes?

Yes, the upsert method is user-facing.

<!-- In the case of user-facing changes, please add the changelog label. -->
