### PR TITLE
fix: correct type mismatch in BinaryEncoder write

### DIFF
--- a/pyiceberg/avro/encoder.py
+++ b/pyiceberg/avro/encoder.py
@@ -39,15 +39,15 @@ class BinaryEncoder:
         Args:
             boolean: The boolean to write.
         """
-        self.write(bytearray([bool(boolean)]))
+        self.write(bytes([bool(boolean)]))
 
     def write_int(self, integer: int) -> None:
         """Integer and long values are written using variable-length zig-zag coding."""
         datum = (integer << 1) ^ (integer >> 63)
         while (datum & ~0x7F) != 0:
-            self.write(bytearray([(datum & 0x7F) | 0x80]))
+            self.write(bytes([(datum & 0x7F) | 0x80]))
             datum >>= 7
-        self.write(bytearray([datum]))
+        self.write(bytes([datum]))
 
     def write_float(self, f: float) -> None:
         """Write a float as 4 bytes."""


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->
<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

Some fsspec write implementations expect the input data to be `bytes`, such as in JuiceFS: https://github.com/juicedata/juicefs/blob/main/sdk/python/juicefs/juicefs/juicefs.py#L514.
But currently, some places in `BinaryEncoder` use `bytearray`, which can cause exceptions when writing the manifest.
```text
raise TypeError(f"a bytes-like object is required, not '{type(data).__name__}'")
TypeError: a bytes-like object is required, not 'bytearray'
```
I ran into this issue while adding Juice filesystem support, so this PR fixes the data type written by `BinaryEncoder` to `bytes` in order to resolve it.

Currently, `pyiceberg.io.OutputStream.write` is also annotated to accept data of type `bytes.`

## Are these changes tested?
It seems that the filesystems currently supported in pyiceberg do not strictly require the write input to be of type `bytes`, so I didn’t add a test. I tested this on our internal Juice filesystem, and it works.
## Are there any user-facing changes?
No

<!-- In the case of user-facing changes, please add the changelog label. -->
