### PR TITLE
Run Catalog integration tests against REST Catalog impls

### DIFF
--- a/mkdocs/docs/contributing.md
+++ b/mkdocs/docs/contributing.md
@@ -155,6 +155,18 @@ make test-integration-rebuild
 
 To rebuild the containers from scratch.
 
+#### Running Integration Tests against REST Catalogs
+
+PyIceberg supports the ability to run our catalog tests against an arbitrary REST Catalog.
+
+To do so, run the catalog integration tests with the `PYICEBERG_REST_CATALOG_PROPERTIES` environment variable.
+
+```sh
+PYICEBERG_REST_CATALOG_PROPERTIES='{"uri": "http://localhost:8181"}' poetry run pytest tests/integration/
+```
+
+`PYICEBERG_REST_CATALOG_PROPERTIES` should be a JSON-encoded string that contains any [catalog properties](https://py.iceberg.apache.org/configuration/#rest-catalog) necessary to interact with your REST Catalog implementation.
+
 ## Code standards
 
 Below are the formalized conventions that we adhere to in the PyIceberg project. The goal of this is to have a common agreement on how to evolve the codebase, but also using it as guidelines for newcomers to the project.

--- a/mkdocs/docs/contributing.md
+++ b/mkdocs/docs/contributing.md
@@ -157,9 +157,18 @@ To rebuild the containers from scratch.
 
 #### Running Integration Tests against REST Catalogs
 
+!!! warning "Do not run against production catalogs"
+    The integration tests will delete data throughout the entirety of your catalog. Running these integration tests against production catalogs will result in data loss.
+
 PyIceberg supports the ability to run our catalog tests against an arbitrary REST Catalog.
 
-You can set the test catalog in the ~/.pyiceberg.yaml file:
+In order to run the test catalog, you will need to specify which REST catalog to run against with the `PYICEBERG_TEST_CATALOG` environment variable
+
+```sh
+export PYICEBERG_TEST_CATALOG=test_catalog
+```
+
+The catalog in question can be configured either through the ~/.pyiceberg.yaml file or through environment variables.
 
 ```yaml
 catalog:
@@ -167,8 +176,6 @@ catalog:
     uri: http://rest-catalog/ws/
     credential: t-1234:secret
 ```
-
-You can additionally set the properties using environment variables
 
 ```sh
 export PYICEBERG_CATALOG__TEST_CATALOG__URI=thrift://localhost:9083

--- a/mkdocs/docs/contributing.md
+++ b/mkdocs/docs/contributing.md
@@ -159,13 +159,22 @@ To rebuild the containers from scratch.
 
 PyIceberg supports the ability to run our catalog tests against an arbitrary REST Catalog.
 
-To do so, run the catalog integration tests with the `PYICEBERG_REST_CATALOG_PROPERTIES` environment variable.
+You can set the test catalog in the ~/.pyiceberg.yaml file:
 
-```sh
-PYICEBERG_REST_CATALOG_PROPERTIES='{"uri": "http://localhost:8181"}' poetry run pytest tests/integration/
+```yaml
+catalog:
+  test_catalog:
+    uri: http://rest-catalog/ws/
+    credential: t-1234:secret
 ```
 
-`PYICEBERG_REST_CATALOG_PROPERTIES` should be a JSON-encoded string that contains any [catalog properties](https://py.iceberg.apache.org/configuration/#rest-catalog) necessary to interact with your REST Catalog implementation.
+You can additionally set the properties using environment variables
+
+```sh
+export PYICEBERG_CATALOG__TEST_CATALOG__URI=thrift://localhost:9083
+export PYICEBERG_CATALOG__TEST_CATALOG__ACCESS_KEY_ID=username
+export PYICEBERG_CATALOG__TEST_CATALOG__SECRET_ACCESS_KEY=password
+```
 
 ## Code standards
 

--- a/tests/integration/test_catalog.py
+++ b/tests/integration/test_catalog.py
@@ -76,13 +76,13 @@ def rest_catalog() -> Generator[Catalog, None, None]:
 
 
 @pytest.fixture(scope="function")
-def test_catalog() -> Generator[Catalog, None, None]:
+def rest_test_catalog() -> Generator[Catalog, None, None]:
     if test_catalog_name := os.environ.get("PYICEBERG_TEST_CATALOG"):
         test_catalog = load_catalog(test_catalog_name)
         yield test_catalog
         clean_up(test_catalog)
     else:
-        pytest.skip("Test catalog environment variables not set")
+        pytest.skip("PYICEBERG_TEST_CATALOG environment variables not set")
 
 
 @pytest.fixture(scope="function")
@@ -106,7 +106,7 @@ CATALOGS = [
     pytest.lazy_fixture("sqlite_catalog_file"),
     pytest.lazy_fixture("rest_catalog"),
     pytest.lazy_fixture("hive_catalog"),
-    pytest.lazy_fixture("test_catalog"),
+    pytest.lazy_fixture("rest_test_catalog"),
 ]
 
 

--- a/tests/integration/test_catalog.py
+++ b/tests/integration/test_catalog.py
@@ -15,6 +15,8 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+import json
+import os
 from pathlib import Path, PosixPath
 from typing import Generator, List
 
@@ -75,6 +77,21 @@ def rest_catalog() -> Generator[Catalog, None, None]:
 
 
 @pytest.fixture(scope="function")
+def rest_catalog_env() -> Generator[Catalog, None, None]:
+    properties_json = os.environ.get("PYICEBERG_REST_CATALOG_PROPERTIES")
+    if properties_json:
+        properties = json.loads(properties_json)
+        test_catalog = RestCatalog(
+            "rest_env",
+            **properties,
+        )
+        yield test_catalog
+        clean_up(test_catalog)
+    else:
+        pytest.skip("REST catalog environment variables not set")
+
+
+@pytest.fixture(scope="function")
 def hive_catalog() -> Generator[Catalog, None, None]:
     test_catalog = HiveCatalog(
         "test_hive_catalog",
@@ -95,6 +112,7 @@ CATALOGS = [
     pytest.lazy_fixture("sqlite_catalog_file"),
     pytest.lazy_fixture("rest_catalog"),
     pytest.lazy_fixture("hive_catalog"),
+    pytest.lazy_fixture("rest_catalog_env"),
 ]
 
 

--- a/tests/integration/test_catalog.py
+++ b/tests/integration/test_catalog.py
@@ -21,7 +21,7 @@ from typing import Generator, List
 
 import pytest
 
-from pyiceberg.catalog import Catalog, MetastoreCatalog
+from pyiceberg.catalog import Catalog, MetastoreCatalog, load_catalog
 from pyiceberg.catalog.hive import HiveCatalog
 from pyiceberg.catalog.memory import InMemoryCatalog
 from pyiceberg.catalog.rest import RestCatalog
@@ -78,7 +78,7 @@ def rest_catalog() -> Generator[Catalog, None, None]:
 @pytest.fixture(scope="function")
 def test_catalog() -> Generator[Catalog, None, None]:
     if test_catalog_name := os.environ.get("PYICEBERG_TEST_CATALOG"):
-        test_catalog = RestCatalog(test_catalog_name)
+        test_catalog = load_catalog(test_catalog_name)
         yield test_catalog
         clean_up(test_catalog)
     else:

--- a/tests/integration/test_catalog.py
+++ b/tests/integration/test_catalog.py
@@ -15,7 +15,6 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-import json
 import os
 from pathlib import Path, PosixPath
 from typing import Generator, List
@@ -77,17 +76,13 @@ def rest_catalog() -> Generator[Catalog, None, None]:
 
 
 @pytest.fixture(scope="function")
-def rest_catalog_env() -> Generator[Catalog, None, None]:
-    if properties_json := os.environ.get("PYICEBERG_REST_CATALOG_PROPERTIES"):
-        properties = json.loads(properties_json)
-        test_catalog = RestCatalog(
-            "rest_env",
-            **properties,
-        )
+def test_catalog() -> Generator[Catalog, None, None]:
+    if test_catalog_name := os.environ.get("PYICEBERG_TEST_CATALOG"):
+        test_catalog = RestCatalog(test_catalog_name)
         yield test_catalog
         clean_up(test_catalog)
     else:
-        pytest.skip("REST catalog environment variables not set")
+        pytest.skip("Test catalog environment variables not set")
 
 
 @pytest.fixture(scope="function")
@@ -111,7 +106,7 @@ CATALOGS = [
     pytest.lazy_fixture("sqlite_catalog_file"),
     pytest.lazy_fixture("rest_catalog"),
     pytest.lazy_fixture("hive_catalog"),
-    pytest.lazy_fixture("rest_catalog_env"),
+    pytest.lazy_fixture("test_catalog"),
 ]
 
 

--- a/tests/integration/test_catalog.py
+++ b/tests/integration/test_catalog.py
@@ -78,8 +78,7 @@ def rest_catalog() -> Generator[Catalog, None, None]:
 
 @pytest.fixture(scope="function")
 def rest_catalog_env() -> Generator[Catalog, None, None]:
-    properties_json = os.environ.get("PYICEBERG_REST_CATALOG_PROPERTIES")
-    if properties_json:
+    if properties_json := os.environ.get("PYICEBERG_REST_CATALOG_PROPERTIES"):
         properties = json.loads(properties_json)
         test_catalog = RestCatalog(
             "rest_env",


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
Closes #2481 

# Rationale for this change
This allows users to run our test suite against their REST Catalog implementations. 

## Are these changes tested?
Test-only change

## Are there any user-facing changes?
- Adds support for running catalog tests against REST Catalog implementations.

<!-- In the case of user-facing changes, please add the changelog label. -->
