### PR TITLE
Remove user flag from poetry installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,12 +58,12 @@ help: ## Display this help message
 install-poetry: ## Ensure Poetry is installed at the specified version
 	@if ! command -v ${POETRY} &> /dev/null; then \
 		echo "Poetry not found. Installing..."; \
-		${PIP} install --user poetry==$(POETRY_VERSION); \
+		${PIP} install poetry==$(POETRY_VERSION); \
 	else \
 		INSTALLED_VERSION=$$(${PIP} show poetry | grep Version | awk '{print $$2}'); \
 		if [ "$$INSTALLED_VERSION" != "$(POETRY_VERSION)" ]; then \
 			echo "Updating Poetry to version $(POETRY_VERSION)..."; \
-			${PIP} install --user --upgrade poetry==$(POETRY_VERSION); \
+			${PIP} install --upgrade poetry==$(POETRY_VERSION); \
 		else \
 			echo "Poetry version $(POETRY_VERSION) already installed."; \
 		fi; \


### PR DESCRIPTION
related to #2425

# Rationale for this change

Removing the user flag from the poetry installation to allow users who want to install poetry into a separate dedicated virtual environment.

This virtual environment must be separate from the environment in which we install the iceberg-python repo. 

## Are these changes tested?

Yes manual testing 

```
> python3 -m venv ~/.venvs/poetry

> source ~/.venvs/poetry/bin/activate

>  echo $VIRTUAL_ENV
/Users/geru/.venvs/poetry

> python -m pip install -U pip setuptools wheel

> poetry --version
Poetry (version 2.1.4)

> poetry show -v
Using virtualenv: /Users/geru/workspace/iceberg-python/.venv

> poetry install
SUCCESS

```

## Are there any user-facing changes?

no

cc: @kevinjqliu 