### PR TITLE
BUG: Add assert spec id to requirements in spec update

### DIFF
--- a/pyiceberg/table/update/spec.py
+++ b/pyiceberg/table/update/spec.py
@@ -32,6 +32,7 @@ from pyiceberg.partitioning import (
 from pyiceberg.schema import Schema
 from pyiceberg.table.update import (
     AddPartitionSpecUpdate,
+    AssertDefaultSpecId,
     AssertLastAssignedPartitionId,
     SetDefaultSpecUpdate,
     TableRequirement,
@@ -169,7 +170,11 @@ class UpdateSpec(UpdateTableMetadata["UpdateSpec"]):
                 updates = (SetDefaultSpecUpdate(spec_id=new_spec.spec_id),)
 
             required_last_assigned_partitioned_id = self._transaction.table_metadata.last_partition_id
-            requirements = (AssertLastAssignedPartitionId(last_assigned_partition_id=required_last_assigned_partitioned_id),)
+            default_spec_id = self._transaction.table_metadata.default_spec_id
+            requirements = (
+                AssertLastAssignedPartitionId(last_assigned_partition_id=required_last_assigned_partitioned_id),
+                AssertDefaultSpecId(default_spec_id=default_spec_id),
+            )
 
         return updates, requirements
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

When doing a commit that evolves the partition spec we are missing a requirement for asserting that the base default spec id has not changed. 

## Are these changes tested?

This change comes from reviewing #2479 which adds catalog tests to test the behavior of spec evolutions, specifically, one of the tests that commits a spec update conflict fails since does not raise `CommitFailedException`

## Are there any user-facing changes?

No.

<!-- In the case of user-facing changes, please add the changelog label. -->
