### PR TITLE
fix: incorrect descriptions of snapshot operations

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -566,7 +566,7 @@ class Transaction:
         An overwrite may produce zero or more snapshots based on the operation:
 
             - DELETE: In case existing Parquet files can be dropped completely.
-            - REPLACE: In case existing Parquet files need to be rewritten.
+            - OVERWRITE: In case existing Parquet files need to be rewritten to drop rows that match the overwrite filter.
             - APPEND: In case new data is being inserted into the table.
 
         Args:
@@ -626,7 +626,7 @@ class Transaction:
         A delete may produce zero or more snapshots based on the operation:
 
             - DELETE: In case existing Parquet files can be dropped completely.
-            - REPLACE: In case existing Parquet files need to be rewritten
+            - OVERWRITE: In case existing Parquet files need to be rewritten to drop rows that match the delete filter.
 
         Args:
             delete_filter: A boolean expression to delete rows from a table
@@ -1389,7 +1389,7 @@ class Table:
         An overwrite may produce zero or more snapshots based on the operation:
 
             - DELETE: In case existing Parquet files can be dropped completely.
-            - REPLACE: In case existing Parquet files need to be rewritten.
+            - OVERWRITE: In case existing Parquet files need to be rewritten to drop rows that match the overwrite filter..
             - APPEND: In case new data is being inserted into the table.
 
         Args:


### PR DESCRIPTION
…unctions.

<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
Currently, the documentation of these write functions contains some inaccuracies regarding snapshot operations. These update methods do not actually produce `replace` snapshots, but rather `overwrite` snapshots, because the rewrite here modifies the data (dropping the records that match the overwrite filter).

A `replace` snapshot is only generated when the table data itself is not changed, such as during data file rewrites or manifest rewrites.

https://iceberg.apache.org/spec/#snapshots

<img width="1536" height="418" alt="image" src="https://github.com/user-attachments/assets/a96b0e1c-86af-45da-98e5-58753e7f7482" />



## Are these changes tested?

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
