### PR TITLE
dev: add `make notebook`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,3 +170,7 @@ clean: ## Remove build artifacts and caches
 	@find . -name "*.pyd" -exec echo Deleting {} \; -delete
 	@find . -name "*.pyo" -exec echo Deleting {} \; -delete
 	@echo "Cleanup complete."
+
+notebook: ## Launch Jupyter Notebook
+	${POETRY} run pip install jupyter
+	${POETRY} run jupyter notebook


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
Add `make notebook` to spin up a jupyter notebook

With spark connect (#2491) and our testing setup, we can quickly spin up a local env with 
* spark
* iceberg rest catalog
* hive metastore
* minio

```
make test-integration-exec
make notebook
```

in the jupyter notebook, connect to spark easily
```
from pyspark.sql import SparkSession

# Create SparkSession against the remote Spark Connect server
spark = SparkSession.builder.remote("sc://localhost:15002").getOrCreate()
spark.sql("SHOW CATALOGS").show()
```

## Are these changes tested?

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
