### PR TITLE
Make `ExecutorFactory` multi-process safe

### DIFF
--- a/pyiceberg/utils/concurrent.py
+++ b/pyiceberg/utils/concurrent.py
@@ -36,7 +36,7 @@ class ExecutorFactory:
     def get_or_create() -> Executor:
         """Return the same executor in each call."""
         # ThreadPoolExecutor cannot be shared across processes.  If a new pid is found it means
-        # there has been a fork so a new executor is needed.  Otherwise, the executor may be in
+        # there is a new process so a new executor is needed.  Otherwise, the executor may be in
         # an invalid state and tasks submitted will not be started.
         if ExecutorFactory._instance_pid != os.getpid():
             ExecutorFactory._instance_pid = os.getpid()

--- a/pyiceberg/utils/concurrent.py
+++ b/pyiceberg/utils/concurrent.py
@@ -35,9 +35,8 @@ class ExecutorFactory:
     @staticmethod
     def get_or_create() -> Executor:
         """Return the same executor in each call."""
-
         # ThreadPoolExecutor cannot be shared across processes.  If a new pid is found it means
-        # there has been a fork so a new exector is needed.  Otherwise, the executor may be in
+        # there has been a fork so a new executor is needed.  Otherwise, the executor may be in
         # an invalid state and tasks submitted will not be started.
         if ExecutorFactory._instance_pid != os.getpid():
             ExecutorFactory._instance_pid = os.getpid()

--- a/pyiceberg/utils/concurrent.py
+++ b/pyiceberg/utils/concurrent.py
@@ -16,6 +16,7 @@
 # under the License.
 """Concurrency concepts that support efficient multi-threading."""
 
+import os
 from concurrent.futures import Executor, ThreadPoolExecutor
 from typing import Optional
 
@@ -24,6 +25,7 @@ from pyiceberg.utils.config import Config
 
 class ExecutorFactory:
     _instance: Optional[Executor] = None
+    _instance_pid: Optional[int] = None
 
     @staticmethod
     def max_workers() -> Optional[int]:
@@ -33,6 +35,14 @@ class ExecutorFactory:
     @staticmethod
     def get_or_create() -> Executor:
         """Return the same executor in each call."""
+
+        # ThreadPoolExecutor cannot be shared across processes.  If a new pid is found it means
+        # there has been a fork so a new exector is needed.  Otherwise, the executor may be in
+        # an invalid state and tasks submitted will not be started.
+        if ExecutorFactory._instance_pid != os.getpid():
+            ExecutorFactory._instance_pid = os.getpid()
+            ExecutorFactory._instance = None
+
         if ExecutorFactory._instance is None:
             max_workers = ExecutorFactory.max_workers()
             ExecutorFactory._instance = ThreadPoolExecutor(max_workers=max_workers)

--- a/tests/utils/test_concurrent.py
+++ b/tests/utils/test_concurrent.py
@@ -15,8 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import multiprocessing
 import os
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from typing import Dict, Optional
 from unittest import mock
 
@@ -27,6 +28,39 @@ from pyiceberg.utils.concurrent import ExecutorFactory
 EMPTY_ENV: Dict[str, Optional[str]] = {}
 VALID_ENV = {"PYICEBERG_MAX_WORKERS": "5"}
 INVALID_ENV = {"PYICEBERG_MAX_WORKERS": "invalid"}
+
+@pytest.fixture
+def fork_process():
+    original = multiprocessing.get_start_method()
+    allowed = multiprocessing.get_all_start_methods()
+
+    assert "fork" in allowed
+
+    multiprocessing.set_start_method("fork", force=True)
+
+    yield
+
+    multiprocessing.set_start_method(original, force=True)
+
+
+@pytest.fixture
+def spawn_process():
+    original = multiprocessing.get_start_method()
+    allowed = multiprocessing.get_all_start_methods()
+
+    assert "spawn" in allowed
+
+    multiprocessing.set_start_method("spawn", force=True)
+
+    yield
+
+    multiprocessing.set_start_method(original, force=True)
+
+
+def _use_executor_to_return(value):
+    executor = ExecutorFactory.get_or_create()
+    future = executor.submit(lambda: value)
+    return future.result()
 
 
 def test_create_reused() -> None:
@@ -50,3 +84,40 @@ def test_max_workers() -> None:
 def test_max_workers_invalid() -> None:
     with pytest.raises(ValueError):
         ExecutorFactory.max_workers()
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    [
+        pytest.param(
+            "fork_process",
+            marks=pytest.mark.skipif(
+                "fork" not in multiprocessing.get_all_start_methods(), reason="Fork start method is not available"
+            ),
+        ),
+        pytest.param(
+            "spawn_process",
+            marks=pytest.mark.skipif(
+                "spawn" not in multiprocessing.get_all_start_methods(), reason="Spawn start method is not available"
+            ),
+        ),
+    ],
+)
+def test_use_executor_in_different_process(fixture, request):
+    # Use the fixture
+    request.getfixturevalue(fixture)
+
+    main_value = _use_executor_to_return(10)
+
+    with ProcessPoolExecutor() as process_executor:
+        future1 = process_executor.submit(_use_executor_to_return, 20)
+    with ProcessPoolExecutor() as process_executor:
+        future2 = process_executor.submit(_use_executor_to_return, 30)
+
+    assert main_value == 10
+    assert future1.result() == 20
+    assert future2.result() == 30
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
# Rationale for this change

`ExecutorFactor` can be left in an invalid state, which causes new `submit` calls to hang indefinitely in multiprocessing.  

Closes https://github.com/apache/iceberg-python/issues/2545

This PR detects when the executor is used in a new process and creates a new instance

## Are these changes tested?

Yes, new tests added to `test_concurrent.py`

## Are there any user-facing changes?

No
