### PR TITLE
Make And expression JSON serializable using Pydantic

### DIFF
--- a/pyiceberg/expressions/__init__.py
+++ b/pyiceberg/expressions/__init__.py
@@ -32,6 +32,8 @@ from typing import (
     Union,
 )
 
+from pydantic import Field
+
 from pyiceberg.expressions.literals import (
     AboveMax,
     BelowMin,
@@ -39,7 +41,7 @@ from pyiceberg.expressions.literals import (
     literal,
 )
 from pyiceberg.schema import Accessor, Schema
-from pyiceberg.typedef import L, StructProtocol
+from pyiceberg.typedef import IcebergBaseModel, L, StructProtocol
 from pyiceberg.types import DoubleType, FloatType, NestedField
 from pyiceberg.utils.singleton import Singleton
 
@@ -247,9 +249,10 @@ class Reference(UnboundTerm[Any]):
         return BoundReference[L]
 
 
-class And(BooleanExpression):
+class And(BooleanExpression, IcebergBaseModel):
     """AND operation expression - logical conjunction."""
 
+    type: str = Field(default="and", alias="type")
     left: BooleanExpression
     right: BooleanExpression
 
@@ -288,6 +291,12 @@ class And(BooleanExpression):
     def __getnewargs__(self) -> Tuple[BooleanExpression, BooleanExpression]:
         """Pickle the And class."""
         return (self.left, self.right)
+
+    class Config:
+        """Pydantic configuration for And expression serialization."""
+
+        arbitrary_types_allowed = True
+        json_encoders = {BooleanExpression: lambda v: v.model_dump(by_alias=True) if isinstance(v, IcebergBaseModel) else str(v)}
 
 
 class Or(BooleanExpression):

--- a/tests/table/test_partitioning.py
+++ b/tests/table/test_partitioning.py
@@ -21,6 +21,7 @@ from uuid import UUID
 
 import pytest
 
+from pyiceberg.expressions import And, EqualTo
 from pyiceberg.partitioning import UNPARTITIONED_PARTITION_SPEC, PartitionField, PartitionSpec
 from pyiceberg.schema import Schema
 from pyiceberg.transforms import (
@@ -122,6 +123,13 @@ def test_serialize_partition_spec() -> None:
     assert (
         partitioned.model_dump_json()
         == """{"spec-id":3,"fields":[{"source-id":1,"field-id":1000,"transform":"truncate[19]","name":"str_truncate"},{"source-id":2,"field-id":1001,"transform":"bucket[25]","name":"int_bucket"}]}"""
+    )
+
+
+def test_serialize_and_expression() -> None:
+    expr = And(EqualTo("foo", 1), EqualTo("bar", 2))
+    assert expr.model_dump_json(by_alias=True) == (
+        '{"type":"and","left":{"type":"equal_to","term":"foo","literal":1},"right":{"type":"equal_to","term":"bar","literal":2}}'
     )
 
 


### PR DESCRIPTION
#2518 
This PR addresses issue by making the `And` expression in pyiceberg.expressions fully JSON serializable using Pydantic.
- Added a unit test to verify correct JSON serialization of the And expression.

Please let me know if my approach or fix needs any improvements . I’m open to feedback and happy to make changes based on suggestions.
Thank you !