### PR TITLE
infra: remove outdated filterwarnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -347,14 +347,6 @@ markers = [
 # Turns a warning into an error
 filterwarnings = [
   "error",
-  # Remove this in a future release of PySpark.
-  "ignore:distutils Version classes are deprecated. Use packaging.version instead.",
-  # Remove this in a future release of PySpark. https://github.com/apache/iceberg-python/issues/1349
-  "ignore:datetime.datetime.utcfromtimestamp\\(\\) is deprecated and scheduled for removal in a future version.",
-  # Remove this once https://github.com/boto/boto3/issues/3889 is fixed.
-  "ignore:datetime.datetime.utcnow\\(\\) is deprecated and scheduled for removal in a future version.",
-  # Latest PySpark version (v3.5.3) throws this error, remove in a future release of PySpark (possibly v4.0.0).
-  "ignore:is_datetime64tz_dtype is deprecated and will be removed in a future version.",
 ]
 
 [tool.black]


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
Closes #1349

After we upgrade to use spark 4.x in #2566, we can remove these filterwarnings 

## Are these changes tested?

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
