### PR TITLE
Allow for date->time promotion on v3

### DIFF
--- a/pyiceberg/table/update/schema.py
+++ b/pyiceberg/table/update/schema.py
@@ -470,7 +470,7 @@ class UpdateSchema(UpdateTableMetadata["UpdateSchema"]):
 
             if not self._allow_incompatible_changes and field.field_type != field_type:
                 try:
-                    promote(field.field_type, field_type)
+                    promote(field.field_type, field_type, format_version=self._transaction.table_metadata.format_version)
                 except ResolveError as e:
                     raise ValidationError(f"Cannot change column type: {full_name}: {field.field_type} -> {field_type}") from e
 
@@ -894,7 +894,9 @@ class _UnionByNameVisitor(SchemaWithPartnerVisitor[int, bool]):
             try:
                 # If the current type is wider than the new type, then
                 # we perform a noop
-                _ = promote(field.field_type, existing_field.field_type)
+                _ = promote(
+                    field.field_type, existing_field.field_type, self.update_schema._transaction.table_metadata.format_version
+                )
             except ResolveError:
                 # If this is not the case, perform the type evolution
                 self.update_schema.update_column(full_name, field_type=field.field_type)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,7 +72,7 @@ from pyiceberg.partitioning import PartitionField, PartitionSpec
 from pyiceberg.schema import Accessor, Schema
 from pyiceberg.serializers import ToOutputFile
 from pyiceberg.table import FileScanTask, Table
-from pyiceberg.table.metadata import TableMetadataV1, TableMetadataV2
+from pyiceberg.table.metadata import TableMetadataV1, TableMetadataV2, TableMetadataV3
 from pyiceberg.transforms import DayTransform, IdentityTransform
 from pyiceberg.types import (
     BinaryType,
@@ -2459,6 +2459,18 @@ def table_v1(example_table_metadata_v1: Dict[str, Any]) -> Table:
 @pytest.fixture
 def table_v2(example_table_metadata_v2: Dict[str, Any]) -> Table:
     table_metadata = TableMetadataV2(**example_table_metadata_v2)
+    return Table(
+        identifier=("database", "table"),
+        metadata=table_metadata,
+        metadata_location=f"{table_metadata.location}/uuid.metadata.json",
+        io=load_file_io(),
+        catalog=NoopCatalog("NoopCatalog"),
+    )
+
+
+@pytest.fixture
+def table_v3(example_table_metadata_v3: Dict[str, Any]) -> Table:
+    table_metadata = TableMetadataV3(**example_table_metadata_v3)
     return Table(
         identifier=("database", "table"),
         metadata=table_metadata,


### PR DESCRIPTION


<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
This allows date->time promotion on v3 tables only. It also adds a bunch of plumbing to ensure this only works on v3.

Relates to https://github.com/apache/iceberg/pull/14266 on the Java side

## Are these changes tested?
Tests included

## Are there any user-facing changes?
- Adds support for date->timestamp promotion on v3 tables.

<!-- In the case of user-facing changes, please add the changelog label. -->
