### PR TITLE
Add analytics block on Pyiceberg website

### DIFF
--- a/mkdocs/mkdocs.yml
+++ b/mkdocs/mkdocs.yml
@@ -35,6 +35,7 @@ plugins:
 
 theme:
   name: material
+  custom_dir: overrides
   logo: assets/images/iceberg-logo-icon.png
   favicon: assets/images/iceberg-logo-icon.png
   font:

--- a/mkdocs/overrides/main.html
+++ b/mkdocs/overrides/main.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+  {{ super() }}
+  <!-- Matomo -->
+  <script>
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(["setDoNotTrack", true]);
+    _paq.push(["disableCookies"]);
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+      var u="https://analytics.apache.org/";
+      _paq.push(['setTrackerUrl', u+'matomo.php']);
+      _paq.push(['setSiteId', '82']);
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+  </script>
+  <!-- End Matomo -->
+{% endblock %}


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
Closes #2559 

# Rationale for this change
This adds the same Matomo script tag found in the Iceberg website to our Python documentation website.

## Are these changes tested?
<img width="1670" height="620" alt="Screenshot 2025-10-06 at 3 53 49 PM" src="https://github.com/user-attachments/assets/18b33bdb-0046-4c11-88da-a006246fab5f" />

Script tag found when served locally.

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
