### PR TITLE
Add namespace check on RestCatalog.rename_table

### DIFF
--- a/pyiceberg/catalog/rest/__init__.py
+++ b/pyiceberg/catalog/rest/__init__.py
@@ -656,8 +656,13 @@ class RestCatalog(Catalog):
         }
 
         # Ensure that namespaces exist on source and destination.
-        self.namespace_exists(self._split_identifier_for_json(from_identifier)["namespace"])
-        self.namespace_exists(self._split_identifier_for_json(to_identifier)["namespace"])
+        source_namespace = self._split_identifier_for_json(from_identifier)["namespace"]
+        if not self.namespace_exists(source_namespace):
+            raise NoSuchNamespaceError(f"Source namespace does not exist: {source_namespace}")
+
+        destination_namespace = self._split_identifier_for_json(to_identifier)["namespace"]
+        if not self.namespace_exists(destination_namespace):
+            raise NoSuchNamespaceError(f"Destination namespace does not exist: {destination_namespace}")
 
         response = self._session.post(self.url(Endpoints.rename_table), json=payload)
         try:


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
rename_table should throw NoSuchNamespaceError if the source / destination namespace does not exist.

# Rationale for this change
Better conformance with spec.

## Are these changes tested?
Unit tests added.

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
