### PR TITLE
docs: Add installing guide for Datafusion API

### DIFF
--- a/mkdocs/docs/api.md
+++ b/mkdocs/docs/api.md
@@ -1928,7 +1928,7 @@ PyIceberg integrates with [Apache DataFusion](https://datafusion.apache.org/) th
 <!-- prettier-ignore-start -->
 
 !!! note "Requirements"
-    This requires [`datafusion` to be installed](index.md).
+    This requires [`datafusion` and `pyiceberg-core` to be installed](index.md).
 
 <!-- prettier-ignore-end -->
 

--- a/mkdocs/docs/index.md
+++ b/mkdocs/docs/index.md
@@ -61,6 +61,8 @@ You can mix and match optional dependencies depending on your needs:
 | snappy        | Support for snappy Avro compression                                       |
 | gcsfs         | GCSFS as a FileIO implementation to interact with the object store        |
 | rest-sigv4    | Support for generating AWS SIGv4 authentication headers for REST Catalogs |
+| pyiceberg-core | Installs iceberg-rust powered core                                       |
+| datafusion    | Installs both PyArrow and Apache DataFusion                               | 
 
 You either need to install `s3fs`, `adlfs`, `gcsfs`, or `pyarrow` to be able to fetch files from an object store.
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

[API with Apache DataFusion](https://py.iceberg.apache.org/api/#apache-datafusion) has been supported, but it's missing in the installation guide.

## Are these changes tested?
Doc change.

## Are there any user-facing changes?
No.

<!-- In the case of user-facing changes, please add the changelog label. -->
