### PR TITLE
docs: Note pyiceberg only works with datafusion `< 49`

### DIFF
--- a/mkdocs/docs/api.md
+++ b/mkdocs/docs/api.md
@@ -1939,7 +1939,7 @@ PyIceberg integrates with [Apache DataFusion](https://datafusion.apache.org/) th
 
     The integration has a few caveats:
 
-    - Only works with `datafusion >= 45`
+    - Only works with `datafusion >= 45, < 49`
     - Depends directly on `iceberg-rust` instead of PyIceberg's implementation
     - Has limited features compared to the full PyIceberg API
 


### PR DESCRIPTION

<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

[Datafusion >= 49 is not backward compatible](https://github.com/apache/iceberg-rust/issues/1647#issuecomment-3256135326) and [Datafusion API](https://py.iceberg.apache.org/api/#apache-datafusion) fails with `bus error`.

This also fixes trailing whitespace in index.md.

## Are these changes tested?
Doc changes.

## Are there any user-facing changes?
No.
<!-- In the case of user-facing changes, please add the changelog label. -->
