### PR TITLE
Fix Python CLI describe table command for AWS Glue REST catalog

### DIFF
--- a/pyiceberg/catalog/rest/__init__.py
+++ b/pyiceberg/catalog/rest/__init__.py
@@ -785,7 +785,7 @@ class RestCatalog(Catalog):
         try:
             response.raise_for_status()
         except HTTPError as exc:
-            _handle_non_200_response(exc, {404: NoSuchNamespaceError})
+            _handle_non_200_response(exc, {404: NoSuchNamespaceError, 400: NoSuchNamespaceError})
 
         return NamespaceResponse.model_validate_json(response.text).properties
 


### PR DESCRIPTION
The PyIceberg CLI `describe` command for table  fails with AWS Glue REST catalog when interpreting multi-element identifiers.

## Problem
```bash
$ pyiceberg describe <namespace>.<table_name>
IllegalArgumentException: Invalid namespace name.
```

The `pyiceberg describe` command for table fails when using AWS Glue REST catalog with multi-element identifiers (e.g., `namespace.table`). The command's auto-detection feature attempts to interpret the identifier first as a namespace and fall back to interpreting it as a table if namespace was not found. However the fallback mechanism fails because AWS Glue returns an unexpected error code 400.

When PyIceberg queries a multi-level namespace, it joins the parts with `\x1f` (ASCII Unit Separator) as per the Iceberg REST specification. For example, `("namespace", "table")` becomes `namespace\x1ftable` in the REST request. AWS Glue returns 400 Bad Request for this format, but the current code only handles 404 errors.

## Solution
Extended `load_namespace_properties` to handle both 400 and 404 as `NoSuchNamespaceError`:

```python
_handle_non_200_response(exc, {404: NoSuchNamespaceError, 400: NoSuchNamespaceError})
```

### Why not change the separator?
While using `.` instead of `\x1f` (Unit Separator) would make AWS Glue return 404, changing the namespace separator would be a breaking change to the Iceberg REST specification compliance and affect all existing REST catalog implementations. This fix preserves compatibility by handling the error at the client level.

Closes #2606

## Are these changes tested?
- Added unit test for 400 error handling
- Verified with AWS Glue REST catalog
- All existing tests pass

## Are there any user-facing changes?
No