### PR TITLE
Fix StaticTable._metadata_location_from_version_hint metadata location format ERROR

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -1623,9 +1623,9 @@ class StaticTable(Table):
         if content.endswith(".metadata.json"):
             return os.path.join(metadata_location, "metadata", content)
         elif content.isnumeric():
-            return os.path.join(metadata_location, "metadata", "v%s.metadata.json").format(content)
+            return os.path.join(metadata_location, "metadata", f"v{content}.metadata.json")
         else:
-            return os.path.join(metadata_location, "metadata", "%s.metadata.json").format(content)
+            return os.path.join(metadata_location, "metadata", f"{content}.metadata.json")
 
     @classmethod
     def from_metadata(cls, metadata_location: str, properties: Properties = EMPTY_DICT) -> StaticTable:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1135,20 +1135,41 @@ def example_table_metadata_v3() -> Dict[str, Any]:
     return EXAMPLE_TABLE_METADATA_V3
 
 
-@pytest.fixture(scope="session")
-def table_location(tmp_path_factory: pytest.TempPathFactory) -> str:
+def generate_table_location_with_version_hint(
+    tmp_path_factory: pytest.TempPathFactory, content_in_version_hint: str, metadata_filename: str
+) -> str:
     from pyiceberg.io.pyarrow import PyArrowFileIO
 
-    metadata_filename = f"{uuid.uuid4()}.metadata.json"
     metadata_location = str(tmp_path_factory.getbasetemp() / "metadata" / metadata_filename)
     version_hint_location = str(tmp_path_factory.getbasetemp() / "metadata" / "version-hint.text")
     metadata = TableMetadataV2(**EXAMPLE_TABLE_METADATA_V2)
     ToOutputFile.table_metadata(metadata, PyArrowFileIO().new_output(location=metadata_location), overwrite=True)
 
     with PyArrowFileIO().new_output(location=version_hint_location).create(overwrite=True) as s:
-        s.write(metadata_filename.encode("utf-8"))
+        s.write(content_in_version_hint.encode("utf-8"))
 
     return str(tmp_path_factory.getbasetemp())
+
+
+@pytest.fixture(scope="session")
+def table_location_with_version_hint_full(tmp_path_factory: pytest.TempPathFactory) -> str:
+    content_in_version_hint = str(uuid.uuid4())
+    metadata_filename = f"{content_in_version_hint}.metadata.json"
+    return generate_table_location_with_version_hint(tmp_path_factory, content_in_version_hint, metadata_filename)
+
+
+@pytest.fixture(scope="session")
+def table_location_with_version_hint_numeric(tmp_path_factory: pytest.TempPathFactory) -> str:
+    content_in_version_hint = "1234567890"
+    metadata_filename = f"v{content_in_version_hint}.metadata.json"
+    return generate_table_location_with_version_hint(tmp_path_factory, content_in_version_hint, metadata_filename)
+
+
+@pytest.fixture(scope="session")
+def table_location_with_version_hint_non_numeric(tmp_path_factory: pytest.TempPathFactory) -> str:
+    content_in_version_hint = "non_numberic"
+    metadata_filename = f"{content_in_version_hint}.metadata.json"
+    return generate_table_location_with_version_hint(tmp_path_factory, content_in_version_hint, metadata_filename)
 
 
 @pytest.fixture(scope="session")

--- a/tests/table/test_init.py
+++ b/tests/table/test_init.py
@@ -356,10 +356,20 @@ def test_static_table_gz_same_as_table(table_v2: Table, metadata_location_gz: st
     assert static_table.metadata == table_v2.metadata
 
 
-def test_static_table_version_hint_same_as_table(table_v2: Table, table_location: str) -> None:
-    static_table = StaticTable.from_metadata(table_location)
-    assert isinstance(static_table, Table)
-    assert static_table.metadata == table_v2.metadata
+def test_static_table_version_hint_same_as_table(
+    table_v2: Table,
+    table_location_with_version_hint_full: str,
+    table_location_with_version_hint_numeric: str,
+    table_location_with_version_hint_non_numeric: str,
+) -> None:
+    for table_location in [
+        table_location_with_version_hint_full,
+        table_location_with_version_hint_numeric,
+        table_location_with_version_hint_non_numeric,
+    ]:
+        static_table = StaticTable.from_metadata(table_location)
+        assert isinstance(static_table, Table)
+        assert static_table.metadata == table_v2.metadata
 
 
 def test_static_table_io_does_not_exist(metadata_location: str) -> None:


### PR DESCRIPTION

<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->



# Rationale for this change
To fix StaticTable._metadata_location_from_version_hint metadata location format ERROR:
```python
        if content.endswith(".metadata.json"):
            return os.path.join(metadata_location, "metadata", content)
        elif content.isnumeric():
            return os.path.join(metadata_location, "metadata", "v%s.metadata.json").format(content)
        else:
            return os.path.join(metadata_location, "metadata", "%s.metadata.json").format(content)
```

Closes #2608 

## Are these changes tested?

Yes.

Added 2 more cases with numeric and non numeric metadata version hints.

## Are there any user-facing changes?

No

<!-- In the case of user-facing changes, please add the changelog label. -->
