### PR TITLE
Fix expression tests

### DIFF
--- a/tests/expressions/test_expressions.py
+++ b/tests/expressions/test_expressions.py
@@ -427,51 +427,33 @@ def test_bound_less_than_or_equal_invert(table_schema_simple: Schema) -> None:
 
 def test_not_equal_to_invert() -> None:
     bound = NotEqualTo(
-        term=BoundReference(  # type: ignore
-            field=NestedField(field_id=1, name="foo", field_type=StringType(), required=False),
-            accessor=Accessor(position=0, inner=None),
-        ),
+        term=Reference("foo"),
         literal="hello",
     )
     assert ~bound == EqualTo(
-        term=BoundReference(  # type: ignore
-            field=NestedField(field_id=1, name="foo", field_type=StringType(), required=False),
-            accessor=Accessor(position=0, inner=None),
-        ),
+        term=Reference("foo"),
         literal="hello",
     )
 
 
 def test_greater_than_or_equal_invert() -> None:
     bound = GreaterThanOrEqual(
-        term=BoundReference(  # type: ignore
-            field=NestedField(field_id=1, name="foo", field_type=StringType(), required=False),
-            accessor=Accessor(position=0, inner=None),
-        ),
+        term=Reference("foo"),
         literal="hello",
     )
     assert ~bound == LessThan(
-        term=BoundReference(  # type: ignore
-            field=NestedField(field_id=1, name="foo", field_type=StringType(), required=False),
-            accessor=Accessor(position=0, inner=None),
-        ),
+        term=Reference("foo"),
         literal="hello",
     )
 
 
 def test_less_than_or_equal_invert() -> None:
     bound = LessThanOrEqual(
-        term=BoundReference(  # type: ignore
-            field=NestedField(field_id=1, name="foo", field_type=StringType(), required=False),
-            accessor=Accessor(position=0, inner=None),
-        ),
+        term=Reference("foo"),
         literal="hello",
     )
     assert ~bound == GreaterThan(
-        term=BoundReference(  # type: ignore
-            field=NestedField(field_id=1, name="foo", field_type=StringType(), required=False),
-            accessor=Accessor(position=0, inner=None),
-        ),
+        term=Reference("foo"),
         literal="hello",
     )
 


### PR DESCRIPTION
`test_not_equal_to_invert` should test unbound References,

Bound one are tested here:

https://github.com/apache/iceberg-python/blob/d99936a6aa1758577c27532eb4f91bd15053ce92/tests/expressions/test_expressions.py#L363-L373

<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

## Are these changes tested?

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
