### PR TITLE
Fix Nightly PyPi Artifact Wheels Build

### DIFF
--- a/.github/workflows/pypi-build-artifacts.yml
+++ b/.github/workflows/pypi-build-artifacts.yml
@@ -74,6 +74,7 @@ jobs:
           # Ignore tests for pypy since not all dependencies are compiled for it
           # and would require a local rust build chain
           CIBW_TEST_SKIP: "pp*"
+          # Skip free-threaded (PEP 703) builds until we evaluate decoder_fast support
           CIBW_SKIP: "cp3*t-*"
 
       - name: Add source distribution

--- a/.github/workflows/svn-build-artifacts.yml
+++ b/.github/workflows/svn-build-artifacts.yml
@@ -69,6 +69,8 @@ jobs:
           # Ignore tests for pypy since not all dependencies are compiled for it
           # and would require a local rust build chain
           CIBW_TEST_SKIP: "pp*"
+          # Skip free-threaded (PEP 703) builds until we evaluate decoder_fast support
+          CIBW_SKIP: "cp3*t-*"
 
       - name: Add source distribution
         if: startsWith(matrix.os, 'ubuntu')


### PR DESCRIPTION
# Rationale for this change

Nightly build has been failing for some time since dropping support [python 3.9 support.](https://github.com/apache/iceberg-python/pull/2554/files#diff-edbf927c810f310a669913604ffe71ffaecea1b9ef73f137f9d469491ea1c3d9L72) That PR included a change that dropped the upper bound of the python version.

```
-        CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9,<3.13"
+        CIBW_PROJECT_REQUIRES_PYTHON: ">=3.10"
```


That made cibuildwheel try Python 3.14 and sometimes the free-threaded *t builds. Those are part of the PEP 703 effort to allow Python without the GIL. Therefore, the avro related code would throw a message breaking the build and I don't think this has been evaluated yet. So this change adds `CIBW_SKIP: "cp3*t-*" ` to skip free-threaded ABIs for now, and we can continue building on new regular CPythons while avoiding PEP 703 no-GIL builds.

Bulld failures:
- https://github.com/apache/iceberg-python/actions/workflows/nightly-pypi-build.yml

```
   ../venv-test-arm64/lib/python3.14t/site-packages/_pytest/assertion/rewrite.py:178: in exec_module
      exec(co, module.__dict__)
  /Users/runner/work/iceberg-python/iceberg-python/tests/avro/test_decoder.py:29: in <module>
      from pyiceberg.avro.decoder_fast import CythonBinaryDecoder
  E   RuntimeWarning: The global interpreter lock (GIL) has been enabled to load module 'pyiceberg.avro.decoder_fast', which has not declared that it can run safely without the GIL. To override this behavior and keep the GIL disabled (at your own risk), run with PYTHON_GIL=0 or -Xgil=0.
  =========================== short test summary info ============================
  ERROR ../../../../../../../../../Users/runner/work/iceberg-python/iceberg-python/tests/avro/test_decoder.py - RuntimeWarning: The global interpreter lock (GIL) has been enabled to load module 'pyiceberg.avro.decoder_fast', which has not declared that it can run safely without the GIL. To override this behavior and keep the GIL disabled (at your own risk), run with PYTHON_GIL=0 or -Xgil=0.
  !!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
  =============================== 1 error in 0.13s ===============================

```

## Are these changes tested?
Yes

## Are there any user-facing changes?
No
