### PR TITLE
infra: notify on github workflow failure

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -57,5 +57,5 @@ notifications:
     commits:      commits@iceberg.apache.org
     issues:       issues@iceberg.apache.org
     pullrequests: issues@iceberg.apache.org
-    jobs:         kevinjqliu@apache.org
+    jobs:         ci-jobs@iceberg.apache.org
     jira_options: link label link label


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
nightly pypi silently fails (#2678) 
This PR adds notification when github workflow fails
Sent to `ci-jobs@iceberg.apache.org`

## Are these changes tested?

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
