### PR TITLE
Fix Azure-incompatible file paths in PyArrowFile

### DIFF
--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -210,6 +210,10 @@ UTC_ALIASES = {"UTC", "+00:00", "Etc/UTC", "Z"}
 
 T = TypeVar("T")
 
+def _remove_section_between_at_and_slash(s):
+    # Remove everything from "@" (inclusive) to the first following "/" (exclusive)
+    result = re.sub(r'@[^/]+/', '/', s)
+    return result
 
 @lru_cache
 def _cached_resolve_s3_region(bucket: str) -> Optional[str]:
@@ -279,7 +283,7 @@ class PyArrowFile(InputFile, OutputFile):
 
     def __init__(self, location: str, path: str, fs: FileSystem, buffer_size: int = ONE_MEGABYTE):
         self._filesystem = fs
-        self._path = path
+        self._path = _remove_section_between_at_and_slash(path)
         self._buffer_size = buffer_size
         super().__init__(location=location)
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

Starting from version 20, Pyarrow has support for Azure filesystems.

Azure table locations are typically of this format: "abfss://<bucket_name>@<account_name>.<dfs|blob>.core.windows.net/<namespace>/<table>/<file_path>". When creating a PyArrowFile, we simply retrieve table location and append table-relative path to it. This generates a path with "@<account_name>.<dfs|blob>.core.windows.net" part in it, which cannot be read/written by Pyarrow library. One has to truncate this part from Azure uris.

The proposed fix is just to start a conversation around the issue. I am not 100% sure how and where this should be fixed. 

We know this issue does not occur with Fsspec.

## Are these changes tested?

Hard to test, because with Azurite it works fine (unlike "real" Azure, Azurite does not have this part in uris). Do you have any ideas of an integration test in mind?
