### PR TITLE
Limit split so colons are allowed in the password

### DIFF
--- a/pyiceberg/catalog/rest/auth.py
+++ b/pyiceberg/catalog/rest/auth.py
@@ -95,7 +95,7 @@ class LegacyOAuth2AuthManager(AuthManager):
 
     def _fetch_access_token(self, credential: str) -> str:
         if COLON in credential:
-            client_id, client_secret = credential.split(COLON)
+            client_id, client_secret = credential.split(COLON, maxsplit=1)
         else:
             client_id, client_secret = None, credential
 

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -50,7 +50,7 @@ from pyiceberg.typedef import RecursiveDict
 from pyiceberg.utils.config import Config
 
 TEST_URI = "https://iceberg-test-catalog/"
-TEST_CREDENTIALS = "client:secret"
+TEST_CREDENTIALS = "client:secret_with:colon"
 TEST_OAUTH2_SERVER_URI = "https://auth-endpoint/"
 TEST_TOKEN = "some_jwt_token"
 TEST_SCOPE = "openid_offline_corpds_ds_profile"


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

As of now, pyiceberg will fail if the provided catalog secret contains a colon.
By limiting the split, this gets fixed.

## Are these changes tested? 

Yes, locally with `make test` (the test was modified to include a colon in the secret) and also with a live system.

## Are there any user-facing changes?

Not exactly, just a bug fix.

<!-- In the case of user-facing changes, please add the changelog label. -->
