### PR TITLE
sdist: remove .egg-info and setup.cfg from sdist

### DIFF
--- a/dev/.rat-excludes
+++ b/dev/.rat-excludes
@@ -5,5 +5,3 @@ build
 .gitignore
 uv.lock
 mkdocs/*
-setup.cfg
-(^|.*/)[^/]*\.egg-info(/.*)?$

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,23 @@
 import os
 
 from setuptools import Extension, find_packages, setup
+from setuptools.command.sdist import sdist as _sdist
+
+
+class sdist(_sdist):
+    """Custom sdist that excludes .egg-info and setup.cfg."""
+
+    def make_release_tree(self, base_dir: str, files: list[str]) -> None:
+        # Filter egg-info from the file manifest
+        files = [f for f in files if ".egg-info" not in f]
+
+        super().make_release_tree(base_dir, files)
+
+        # Remove setup.cfg after setuptools creates it
+        setup_cfg = os.path.join(base_dir, "setup.cfg")
+        if os.path.exists(setup_cfg):
+            os.remove(setup_cfg)
+
 
 allowed_to_fail = os.environ.get("CIBUILDWHEEL", "0") != "1"
 
@@ -69,4 +86,5 @@ setup(
     },
     include_package_data=True,
     ext_modules=ext_modules,
+    cmdclass={"sdist": sdist},
 )


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
Follow up to #2601 
clean up .egg-info/ and setup.cfg from sdist

## Are these changes tested?
Yes

Check the new sdist
```
rm -rf dist build pyiceberg.egg-info
uv build --sdist
tar -tzf dist/pyiceberg-*.tar.gz | grep -E "(build/|setup.cfg|\.egg-info)"
```

Diffed too
```
diff -qr ./dist/pyiceberg-0.10.0 ~/Downloads/nightly/sdist/ | sort

differ
    Files ./dist/pyiceberg-0.10.0/Makefile and /Users/kevinliu/Downloads/nightly/sdist/Makefile differ
    Files ./dist/pyiceberg-0.10.0/PKG-INFO and /Users/kevinliu/Downloads/nightly/sdist/PKG-INFO differ
    Files ./dist/pyiceberg-0.10.0/dev/.rat-excludes and /Users/kevinliu/Downloads/nightly/sdist/dev/.rat-excludes differ
    Files ./dist/pyiceberg-0.10.0/pyproject.toml and /Users/kevinliu/Downloads/nightly/sdist/pyproject.toml differ
new
    Only in ./dist/pyiceberg-0.10.0/tests: .DS_Store
    Only in ./dist/pyiceberg-0.10.0: MANIFEST.in
    Only in ./dist/pyiceberg-0.10.0: setup.py
removed
    Only in /Users/kevinliu/Downloads/nightly/sdist: build-module.py
    Only in /Users/kevinliu/Downloads/nightly/sdist: poetry.lock
```

In sdist, ran RAT check and tests
```
make check-license
make test-coverage
```

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
No