### PR TITLE
pyproject.toml: move homepage and repo up

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,13 @@ dependencies = [
     "zstandard>=0.13.0,<1.0.0"
 ]
 
+[project.urls]
+Homepage = "https://py.iceberg.apache.org/"
+Repository = "https://github.com/apache/iceberg-python"
+
+[project.scripts]
+pyiceberg = "pyiceberg.cli.console:run"
+
 [project.optional-dependencies]
 pyarrow = [
     "pyarrow>=17.0.0",
@@ -92,13 +99,6 @@ hf = ["huggingface-hub>=0.24.0"]
 pyiceberg-core = ["pyiceberg-core>=0.5.1,<0.8.0"]
 datafusion = ["datafusion>=45,<49"]
 gcp-auth = ["google-auth>=2.4.0"]
-
-[project.urls]
-Homepage = "https://py.iceberg.apache.org/"
-Repository = "https://github.com/apache/iceberg-python"
-
-[project.scripts]
-pyiceberg = "pyiceberg.cli.console:run"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
Move these links up, otherwise its buried in the list of dependencies 

## Are these changes tested?
N/A

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
No