### PR TITLE
docs: add GCP BigLake Metastore Catalog configuration example

### DIFF
--- a/mkdocs/docs/configuration.md
+++ b/mkdocs/docs/configuration.md
@@ -558,7 +558,7 @@ catalog:
   biglake_catalog:
     type: rest
     uri: https://biglake.googleapis.com/iceberg/v1/restcatalog
-    warehouse: gs://<bucket-name>  # Use the bq:// format for federation option (see docs)
+    warehouse: gs://<bucket-name>  # Use bq://projects/<gcp-project-id> for federation option (see docs)
     auth:
       type: google
     header.x-goog-user-project: <gcp-project-id>


### PR DESCRIPTION
- Adds documentation example for configuring Google BigLake Metastore as a REST catalog
- Includes configuration example with proper authentication setup

# Rationale for this change

GCP had the GA release of the BigLake Metastore Catalog Iceberg REST api Nov 30 (see [release notes](https://docs.cloud.google.com/bigquery/docs/release-notes#October_30_2025)).  There are few GCP docs available how to set this up in general, and with pyiceberg specifically.  Ray Data and probably many other tools use pyiceberg under the hood, so documenting this would make it much easier for folks in the GCP cloud to use pyiceberg at scale. 

# Are these changes tested?
Yes, using the following test plan:

- [x] Configuration tested to work with pyiceberg 0.10.0 and Google BigLake Metastore (Nov 11, 2025)
- [x] Documentation builds successfully
- [x] Configuration example follows existing format and style
- [x] Added links are valid

# Are there any user-facing changes?
Would add a new section in the docs when docs are published.

