### PR TITLE
fix: redirect only error output from makefile command to do not install uv if already present on system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ help: ## Display this help message
 ##@ Setup
 
 install-uv: ## Ensure uv is installed
-	@if ! command -v uv 2> /dev/null; then \
+	@if ! command -v uv > /dev/null 2>&1; then \
 		echo "uv not found. Installing..."; \
 		curl -LsSf https://astral.sh/uv/install.sh | sh; \
 	else \


### PR DESCRIPTION
 Closes #2741

# Rationale for this change

`make install` is currently trying to install `uv` even when is present locally:

```bash
$ make install
uv not found. Installing...
/home/raulcd/.local/bin/uv
^Cmake: *** [Makefile:62: install-uv] Interrupt

$ uv --version
uv 0.9.7
```

## Are these changes tested?

No, only validated locally on Debian 14 that it does not try to install:
```bash
$ PYTHON=3.12 make install
/home/raulcd/.local/bin/uv
uv is already installed.
uv venv --python 3.12
Using CPython 3.12.12
Creating virtual environment at: .venv
```

And validated in a clean docker container that if `uv` is not present it installs it:
```bash
root@9e4870fda91e:/app/iceberg-python# make install
uv not found. Installing...
downloading uv 0.9.8 x86_64-unknown-linux-gnu
no checksums to verify
installing to /root/.local/bin
```

## Are there any user-facing changes?

No
