### PR TITLE
Enables linter rule UP006

### DIFF
--- a/pyiceberg/avro/codecs/__init__.py
+++ b/pyiceberg/avro/codecs/__init__.py
@@ -26,7 +26,7 @@ converting character sets (https://docs.python.org/3/library/codecs.html).
 
 from __future__ import annotations
 
-from typing import Dict, Literal, Type
+from typing import Literal
 
 from typing_extensions import TypeAlias
 
@@ -40,7 +40,7 @@ AvroCompressionCodec: TypeAlias = Literal["null", "bzip2", "snappy", "zstandard"
 
 AVRO_CODEC_KEY = "avro.codec"
 
-KNOWN_CODECS: Dict[AvroCompressionCodec, Type[Codec] | None] = {
+KNOWN_CODECS: dict[AvroCompressionCodec, type[Codec] | None] = {
     "null": None,
     "bzip2": BZip2Codec,
     "snappy": SnappyCodec,
@@ -49,4 +49,4 @@ KNOWN_CODECS: Dict[AvroCompressionCodec, Type[Codec] | None] = {
 }
 
 # Map to convert the naming from Iceberg to Avro
-CODEC_MAPPING_ICEBERG_TO_AVRO: Dict[str, str] = {"gzip": "deflate", "zstd": "zstandard"}
+CODEC_MAPPING_ICEBERG_TO_AVRO: dict[str, str] = {"gzip": "deflate", "zstd": "zstandard"}

--- a/pyiceberg/avro/decoder.py
+++ b/pyiceberg/avro/decoder.py
@@ -18,9 +18,6 @@ import io
 from abc import ABC, abstractmethod
 from io import SEEK_CUR
 from typing import (
-    Dict,
-    List,
-    Tuple,
     cast,
 )
 
@@ -67,11 +64,11 @@ class BinaryDecoder(ABC):
         datum = (n >> 1) ^ -(n & 1)
         return datum
 
-    def read_ints(self, n: int) -> Tuple[int, ...]:
+    def read_ints(self, n: int) -> tuple[int, ...]:
         """Read a list of integers."""
         return tuple(self.read_int() for _ in range(n))
 
-    def read_int_bytes_dict(self, n: int, dest: Dict[int, bytes]) -> None:
+    def read_int_bytes_dict(self, n: int, dest: dict[int, bytes]) -> None:
         """Read a dictionary of integers for keys and bytes for values into a destination dictionary."""
         for _ in range(n):
             k = self.read_int()
@@ -85,7 +82,7 @@ class BinaryDecoder(ABC):
         The float is converted into a 32-bit integer using a method equivalent to
         Java's floatToIntBits and then encoded in little-endian format.
         """
-        return float(cast(Tuple[float, ...], STRUCT_FLOAT.unpack(self.read(4)))[0])
+        return float(cast(tuple[float, ...], STRUCT_FLOAT.unpack(self.read(4)))[0])
 
     def read_double(self) -> float:
         """Read a value from the stream as a double.
@@ -94,7 +91,7 @@ class BinaryDecoder(ABC):
         The double is converted into a 64-bit integer using a method equivalent to
         Java's doubleToLongBits and then encoded in little-endian format.
         """
-        return float(cast(Tuple[float, ...], STRUCT_DOUBLE.unpack(self.read(8)))[0])
+        return float(cast(tuple[float, ...], STRUCT_DOUBLE.unpack(self.read(8)))[0])
 
     def read_bytes(self) -> bytes:
         """Bytes are encoded as a long followed by that many bytes of data."""
@@ -152,7 +149,7 @@ class StreamingBinaryDecoder(BinaryDecoder):
         """Read n bytes."""
         if n < 0:
             raise ValueError(f"Requested {n} bytes to read, expected positive integer.")
-        data: List[bytes] = []
+        data: list[bytes] = []
 
         n_remaining = n
         while n_remaining > 0:

--- a/pyiceberg/avro/file.py
+++ b/pyiceberg/avro/file.py
@@ -27,10 +27,7 @@ from enum import Enum
 from types import TracebackType
 from typing import (
     Callable,
-    Dict,
     Generic,
-    List,
-    Type,
     TypeVar,
 )
 
@@ -77,14 +74,14 @@ class AvroFileHeader(Record):
         return self._data[0]
 
     @property
-    def meta(self) -> Dict[str, str]:
+    def meta(self) -> dict[str, str]:
         return self._data[1]
 
     @property
     def sync(self) -> bytes:
         return self._data[2]
 
-    def compression_codec(self) -> Type[Codec] | None:
+    def compression_codec(self) -> type[Codec] | None:
         """Get the file's compression codec algorithm from the file's metadata.
 
         In the case of a null codec, we return a None indicating that we
@@ -146,8 +143,8 @@ class AvroFile(Generic[D]):
     )
     input_file: InputFile
     read_schema: Schema | None
-    read_types: Dict[int, Callable[..., StructProtocol]]
-    read_enums: Dict[int, Callable[..., Enum]]
+    read_types: dict[int, Callable[..., StructProtocol]]
+    read_enums: dict[int, Callable[..., Enum]]
     header: AvroFileHeader
     schema: Schema
     reader: Reader
@@ -159,8 +156,8 @@ class AvroFile(Generic[D]):
         self,
         input_file: InputFile,
         read_schema: Schema | None = None,
-        read_types: Dict[int, Callable[..., StructProtocol]] = EMPTY_DICT,
-        read_enums: Dict[int, Callable[..., Enum]] = EMPTY_DICT,
+        read_types: dict[int, Callable[..., StructProtocol]] = EMPTY_DICT,
+        read_enums: dict[int, Callable[..., Enum]] = EMPTY_DICT,
     ) -> None:
         self.input_file = input_file
         self.read_schema = read_schema
@@ -185,7 +182,7 @@ class AvroFile(Generic[D]):
 
         return self
 
-    def __exit__(self, exctype: Type[BaseException] | None, excinst: BaseException | None, exctb: TracebackType | None) -> None:
+    def __exit__(self, exctype: type[BaseException] | None, excinst: BaseException | None, exctb: TracebackType | None) -> None:
         """Perform cleanup when exiting the scope of a 'with' statement."""
 
     def __iter__(self) -> AvroFile[D]:
@@ -240,7 +237,7 @@ class AvroOutputFile(Generic[D]):
         file_schema: Schema,
         schema_name: str,
         record_schema: Schema | None = None,
-        metadata: Dict[str, str] = EMPTY_DICT,
+        metadata: dict[str, str] = EMPTY_DICT,
     ) -> None:
         self.output_file = output_file
         self.file_schema = file_schema
@@ -267,7 +264,7 @@ class AvroOutputFile(Generic[D]):
 
         return self
 
-    def __exit__(self, exctype: Type[BaseException] | None, excinst: BaseException | None, exctb: TracebackType | None) -> None:
+    def __exit__(self, exctype: type[BaseException] | None, excinst: BaseException | None, exctb: TracebackType | None) -> None:
         """Perform cleanup when exiting the scope of a 'with' statement."""
         self.output_stream.close()
 
@@ -284,7 +281,7 @@ class AvroOutputFile(Generic[D]):
         header = AvroFileHeader(MAGIC, meta, self.sync_bytes)
         construct_writer(META_SCHEMA).write(self.encoder, header)
 
-    def compression_codec(self) -> Type[Codec] | None:
+    def compression_codec(self) -> type[Codec] | None:
         """Get the file's compression codec algorithm from the file's metadata.
 
         In the case of a null codec, we return a None indicating that we
@@ -302,7 +299,7 @@ class AvroOutputFile(Generic[D]):
 
         return KNOWN_CODECS[codec_name]  # type: ignore
 
-    def write_block(self, objects: List[D]) -> None:
+    def write_block(self, objects: list[D]) -> None:
         in_memory = io.BytesIO()
         block_content_encoder = BinaryEncoder(output_stream=in_memory)
         for obj in objects:

--- a/pyiceberg/avro/reader.py
+++ b/pyiceberg/avro/reader.py
@@ -33,9 +33,7 @@ from decimal import Decimal
 from typing import (
     Any,
     Callable,
-    List,
     Mapping,
-    Tuple,
 )
 from uuid import UUID
 
@@ -319,14 +317,14 @@ class StructReader(Reader):
         "_hash",
         "_max_pos",
     )
-    field_readers: Tuple[Tuple[int | None, Reader], ...]
+    field_readers: tuple[tuple[int | None, Reader], ...]
     create_struct: Callable[..., StructProtocol]
     struct: StructType
-    field_reader_functions = Tuple[Tuple[str | None, int, Callable[[BinaryDecoder], Any] | None], ...]
+    field_reader_functions = tuple[tuple[str | None, int, Callable[[BinaryDecoder], Any] | None], ...]
 
     def __init__(
         self,
-        field_readers: Tuple[Tuple[int | None, Reader], ...],
+        field_readers: tuple[tuple[int | None, Reader], ...],
         create_struct: Callable[..., StructProtocol],
         struct: StructType,
     ) -> None:
@@ -338,7 +336,7 @@ class StructReader(Reader):
         if not isinstance(self.create_struct(), StructProtocol):
             raise ValueError(f"Incompatible with StructProtocol: {self.create_struct}")
 
-        reading_callbacks: List[Tuple[int | None, Callable[[BinaryDecoder], Any]]] = []
+        reading_callbacks: list[tuple[int | None, Callable[[BinaryDecoder], Any]]] = []
         max_pos = -1
         for pos, field in field_readers:
             if pos is not None:
@@ -394,8 +392,8 @@ class ListReader(Reader):
         self._hash = hash(self.element)
         self._is_int_list = isinstance(self.element, IntegerReader)
 
-    def read(self, decoder: BinaryDecoder) -> List[Any]:
-        read_items: List[Any] = []
+    def read(self, decoder: BinaryDecoder) -> list[Any]:
+        read_items: list[Any] = []
         block_count = decoder.read_int()
         while block_count != 0:
             if block_count < 0:
@@ -461,7 +459,7 @@ class MapReader(Reader):
         if block_count == 0:
             return EMPTY_DICT
 
-        contents_array: List[Tuple[int, ...]] = []
+        contents_array: list[tuple[int, ...]] = []
 
         while block_count != 0:
             if block_count < 0:

--- a/pyiceberg/avro/resolver.py
+++ b/pyiceberg/avro/resolver.py
@@ -18,9 +18,6 @@
 from enum import Enum
 from typing import (
     Callable,
-    Dict,
-    List,
-    Tuple,
 )
 
 from pyiceberg.avro.decoder import BinaryDecoder
@@ -114,7 +111,7 @@ STRUCT_ROOT = -1
 
 
 def construct_reader(
-    file_schema: Schema | IcebergType, read_types: Dict[int, Callable[..., StructProtocol]] = EMPTY_DICT
+    file_schema: Schema | IcebergType, read_types: dict[int, Callable[..., StructProtocol]] = EMPTY_DICT
 ) -> Reader:
     """Construct a reader from a file schema.
 
@@ -146,7 +143,7 @@ class ConstructWriter(SchemaVisitorPerPrimitiveType[Writer]):
     def schema(self, schema: Schema, struct_result: Writer) -> Writer:
         return struct_result
 
-    def struct(self, struct: StructType, field_results: List[Writer]) -> Writer:
+    def struct(self, struct: StructType, field_results: list[Writer]) -> Writer:
         return StructWriter(tuple((pos, result) for pos, result in enumerate(field_results)))
 
     def field(self, field: NestedField, field_result: Writer) -> Writer:
@@ -234,8 +231,8 @@ def resolve_writer(
 def resolve_reader(
     file_schema: Schema | IcebergType,
     read_schema: Schema | IcebergType,
-    read_types: Dict[int, Callable[..., StructProtocol]] = EMPTY_DICT,
-    read_enums: Dict[int, Callable[..., Enum]] = EMPTY_DICT,
+    read_types: dict[int, Callable[..., StructProtocol]] = EMPTY_DICT,
+    read_enums: dict[int, Callable[..., Enum]] = EMPTY_DICT,
 ) -> Reader:
     """Resolve the file and read schema to produce a reader.
 
@@ -274,12 +271,12 @@ class WriteSchemaResolver(PrimitiveWithPartnerVisitor[IcebergType, Writer]):
     def schema(self, file_schema: Schema, record_schema: IcebergType | None, result: Writer) -> Writer:
         return result
 
-    def struct(self, file_schema: StructType, record_struct: IcebergType | None, file_writers: List[Writer]) -> Writer:
+    def struct(self, file_schema: StructType, record_struct: IcebergType | None, file_writers: list[Writer]) -> Writer:
         if not isinstance(record_struct, StructType):
             raise ResolveError(f"File/write schema are not aligned for struct, got {record_struct}")
 
-        record_struct_positions: Dict[int, int] = {field.field_id: pos for pos, field in enumerate(record_struct.fields)}
-        results: List[Tuple[int | None, Writer]] = []
+        record_struct_positions: dict[int, int] = {field.field_id: pos for pos, field in enumerate(record_struct.fields)}
+        results: list[tuple[int | None, Writer]] = []
 
         for writer, file_field in zip(file_writers, file_schema.fields, strict=True):
             if file_field.field_id in record_struct_positions:
@@ -367,14 +364,14 @@ class WriteSchemaResolver(PrimitiveWithPartnerVisitor[IcebergType, Writer]):
 
 class ReadSchemaResolver(PrimitiveWithPartnerVisitor[IcebergType, Reader]):
     __slots__ = ("read_types", "read_enums", "context")
-    read_types: Dict[int, Callable[..., StructProtocol]]
-    read_enums: Dict[int, Callable[..., Enum]]
-    context: List[int]
+    read_types: dict[int, Callable[..., StructProtocol]]
+    read_enums: dict[int, Callable[..., Enum]]
+    context: list[int]
 
     def __init__(
         self,
-        read_types: Dict[int, Callable[..., StructProtocol]] = EMPTY_DICT,
-        read_enums: Dict[int, Callable[..., Enum]] = EMPTY_DICT,
+        read_types: dict[int, Callable[..., StructProtocol]] = EMPTY_DICT,
+        read_enums: dict[int, Callable[..., Enum]] = EMPTY_DICT,
     ) -> None:
         self.read_types = read_types
         self.read_enums = read_enums
@@ -389,7 +386,7 @@ class ReadSchemaResolver(PrimitiveWithPartnerVisitor[IcebergType, Reader]):
     def after_field(self, field: NestedField, field_partner: NestedField | None) -> None:
         self.context.pop()
 
-    def struct(self, struct: StructType, expected_struct: IcebergType | None, field_readers: List[Reader]) -> Reader:
+    def struct(self, struct: StructType, expected_struct: IcebergType | None, field_readers: list[Reader]) -> Reader:
         read_struct_id = self.context[STRUCT_ROOT] if len(self.context) > 0 else STRUCT_ROOT
         struct_callable = self.read_types.get(read_struct_id, Record)
 
@@ -399,10 +396,10 @@ class ReadSchemaResolver(PrimitiveWithPartnerVisitor[IcebergType, Reader]):
         if not isinstance(expected_struct, StructType):
             raise ResolveError(f"File/read schema are not aligned for struct, got {expected_struct}")
 
-        expected_positions: Dict[int, int] = {field.field_id: pos for pos, field in enumerate(expected_struct.fields)}
+        expected_positions: dict[int, int] = {field.field_id: pos for pos, field in enumerate(expected_struct.fields)}
 
         # first, add readers for the file fields that must be in order
-        results: List[Tuple[int | None, Reader]] = [
+        results: list[tuple[int | None, Reader]] = [
             (
                 expected_positions.get(field.field_id),
                 # Check if we need to convert it to an Enum

--- a/pyiceberg/avro/writer.py
+++ b/pyiceberg/avro/writer.py
@@ -28,9 +28,6 @@ from dataclasses import dataclass
 from dataclasses import field as dataclassfield
 from typing import (
     Any,
-    Dict,
-    List,
-    Tuple,
 )
 from uuid import UUID
 
@@ -186,7 +183,7 @@ class OptionWriter(Writer):
 
 @dataclass(frozen=True)
 class StructWriter(Writer):
-    field_writers: Tuple[Tuple[int | None, Writer], ...] = dataclassfield()
+    field_writers: tuple[tuple[int | None, Writer], ...] = dataclassfield()
 
     def write(self, encoder: BinaryEncoder, val: Record) -> None:
         for pos, writer in self.field_writers:
@@ -210,7 +207,7 @@ class StructWriter(Writer):
 class ListWriter(Writer):
     element_writer: Writer
 
-    def write(self, encoder: BinaryEncoder, val: List[Any]) -> None:
+    def write(self, encoder: BinaryEncoder, val: list[Any]) -> None:
         encoder.write_int(len(val))
         for v in val:
             self.element_writer.write(encoder, v)
@@ -223,7 +220,7 @@ class MapWriter(Writer):
     key_writer: Writer
     value_writer: Writer
 
-    def write(self, encoder: BinaryEncoder, val: Dict[Any, Any]) -> None:
+    def write(self, encoder: BinaryEncoder, val: dict[Any, Any]) -> None:
         encoder.write_int(len(val))
         for k, v in val.items():
             self.key_writer.write(encoder, k)

--- a/pyiceberg/catalog/__init__.py
+++ b/pyiceberg/catalog/__init__.py
@@ -28,11 +28,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Dict,
-    List,
-    Set,
-    Tuple,
-    Type,
     cast,
 )
 
@@ -268,16 +263,16 @@ def load_catalog(name: str | None = None, **properties: str | None) -> Catalog:
         catalog_type = infer_catalog_type(name, conf)
 
     if catalog_type:
-        return AVAILABLE_CATALOGS[catalog_type](name, cast(Dict[str, str], conf))
+        return AVAILABLE_CATALOGS[catalog_type](name, cast(dict[str, str], conf))
 
     raise ValueError(f"Could not initialize catalog with the following properties: {properties}")
 
 
-def list_catalogs() -> List[str]:
+def list_catalogs() -> list[str]:
     return _ENV_CONFIG.get_known_catalogs()
 
 
-def delete_files(io: FileIO, files_to_delete: Set[str], file_type: str) -> None:
+def delete_files(io: FileIO, files_to_delete: set[str], file_type: str) -> None:
     """Delete files.
 
     Log warnings if failing to delete any file.
@@ -294,7 +289,7 @@ def delete_files(io: FileIO, files_to_delete: Set[str], file_type: str) -> None:
             logger.warning(msg=f"Failed to delete {file_type} file {file}", exc_info=exc)
 
 
-def delete_data_files(io: FileIO, manifests_to_delete: List[ManifestFile]) -> None:
+def delete_data_files(io: FileIO, manifests_to_delete: list[ManifestFile]) -> None:
     """Delete data files linked to given manifests.
 
     Log warnings if failing to delete any file.
@@ -331,9 +326,9 @@ def _import_catalog(name: str, catalog_impl: str, properties: Properties) -> Cat
 
 @dataclass
 class PropertiesUpdateSummary:
-    removed: List[str]
-    updated: List[str]
-    missing: List[str]
+    removed: list[str]
+    updated: list[str]
+    missing: list[str]
 
 
 class Catalog(ABC):
@@ -531,7 +526,7 @@ class Catalog(ABC):
 
     @abstractmethod
     def commit_table(
-        self, table: Table, requirements: Tuple[TableRequirement, ...], updates: Tuple[TableUpdate, ...]
+        self, table: Table, requirements: tuple[TableRequirement, ...], updates: tuple[TableUpdate, ...]
     ) -> CommitTableResponse:
         """Commit updates to a table.
 
@@ -586,7 +581,7 @@ class Catalog(ABC):
         """
 
     @abstractmethod
-    def list_tables(self, namespace: str | Identifier) -> List[Identifier]:
+    def list_tables(self, namespace: str | Identifier) -> list[Identifier]:
         """List tables under the given namespace in the catalog.
 
         Args:
@@ -600,7 +595,7 @@ class Catalog(ABC):
         """
 
     @abstractmethod
-    def list_namespaces(self, namespace: str | Identifier = ()) -> List[Identifier]:
+    def list_namespaces(self, namespace: str | Identifier = ()) -> list[Identifier]:
         """List namespaces from the given namespace. If not given, list top-level namespaces from the catalog.
 
         Args:
@@ -614,7 +609,7 @@ class Catalog(ABC):
         """
 
     @abstractmethod
-    def list_views(self, namespace: str | Identifier) -> List[Identifier]:
+    def list_views(self, namespace: str | Identifier) -> list[Identifier]:
         """List views under the given namespace in the catalog.
 
         Args:
@@ -643,7 +638,7 @@ class Catalog(ABC):
 
     @abstractmethod
     def update_namespace_properties(
-        self, namespace: str | Identifier, removals: Set[str] | None = None, updates: Properties = EMPTY_DICT
+        self, namespace: str | Identifier, removals: set[str] | None = None, updates: Properties = EMPTY_DICT
     ) -> PropertiesUpdateSummary:
         """Remove provided property keys and updates properties for a namespace.
 
@@ -707,7 +702,7 @@ class Catalog(ABC):
         return Catalog.identifier_to_tuple(identifier)[:-1]
 
     @staticmethod
-    def namespace_to_string(identifier: str | Identifier, err: Type[ValueError] | Type[NoSuchNamespaceError] = ValueError) -> str:
+    def namespace_to_string(identifier: str | Identifier, err: type[ValueError] | type[NoSuchNamespaceError] = ValueError) -> str:
         """Transform a namespace identifier into a string.
 
         Args:
@@ -729,7 +724,7 @@ class Catalog(ABC):
 
     @staticmethod
     def identifier_to_database(
-        identifier: str | Identifier, err: Type[ValueError] | Type[NoSuchNamespaceError] = ValueError
+        identifier: str | Identifier, err: type[ValueError] | type[NoSuchNamespaceError] = ValueError
     ) -> str:
         tuple_identifier = Catalog.identifier_to_tuple(identifier)
         if len(tuple_identifier) != 1:
@@ -740,8 +735,8 @@ class Catalog(ABC):
     @staticmethod
     def identifier_to_database_and_table(
         identifier: str | Identifier,
-        err: Type[ValueError] | Type[NoSuchTableError] | Type[NoSuchNamespaceError] = ValueError,
-    ) -> Tuple[str, str]:
+        err: type[ValueError] | type[NoSuchTableError] | type[NoSuchNamespaceError] = ValueError,
+    ) -> tuple[str, str]:
         tuple_identifier = Catalog.identifier_to_tuple(identifier)
         if len(tuple_identifier) != 2:
             raise err(f"Invalid path, hierarchical namespaces are not supported: {identifier}")
@@ -852,7 +847,7 @@ class MetastoreCatalog(Catalog, ABC):
         io = load_file_io(self.properties, table.metadata_location)
         metadata = table.metadata
         manifest_lists_to_delete = set()
-        manifests_to_delete: List[ManifestFile] = []
+        manifests_to_delete: list[ManifestFile] = []
         for snapshot in metadata.snapshots:
             manifests_to_delete += snapshot.manifests(io)
             manifest_lists_to_delete.add(snapshot.manifest_list)
@@ -914,8 +909,8 @@ class MetastoreCatalog(Catalog, ABC):
         self,
         current_table: Table | None,
         table_identifier: Identifier,
-        requirements: Tuple[TableRequirement, ...],
-        updates: Tuple[TableUpdate, ...],
+        requirements: tuple[TableRequirement, ...],
+        updates: tuple[TableUpdate, ...],
     ) -> StagedTable:
         for requirement in requirements:
             requirement.validate(current_table.metadata if current_table else None)
@@ -940,13 +935,13 @@ class MetastoreCatalog(Catalog, ABC):
         )
 
     def _get_updated_props_and_update_summary(
-        self, current_properties: Properties, removals: Set[str] | None, updates: Properties
-    ) -> Tuple[PropertiesUpdateSummary, Properties]:
+        self, current_properties: Properties, removals: set[str] | None, updates: Properties
+    ) -> tuple[PropertiesUpdateSummary, Properties]:
         self._check_for_overlap(updates=updates, removals=removals)
         updated_properties = dict(current_properties)
 
-        removed: Set[str] = set()
-        updated: Set[str] = set()
+        removed: set[str] = set()
+        updated: set[str] = set()
 
         if removals:
             for key in removals:
@@ -1028,7 +1023,7 @@ class MetastoreCatalog(Catalog, ABC):
             return -1
 
     @staticmethod
-    def _check_for_overlap(removals: Set[str] | None, updates: Properties) -> None:
+    def _check_for_overlap(removals: set[str] | None, updates: Properties) -> None:
         if updates and removals:
             overlap = set(removals) & set(updates.keys())
             if overlap:

--- a/pyiceberg/catalog/bigquery_metastore.py
+++ b/pyiceberg/catalog/bigquery_metastore.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import json
-from typing import TYPE_CHECKING, Any, List, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, Union
 
 from google.api_core.exceptions import NotFound
 from google.cloud.bigquery import Client, Dataset, DatasetReference, TableReference
@@ -227,7 +227,7 @@ class BigQueryMetastoreCatalog(MetastoreCatalog):
             raise NoSuchTableError(f"Table does not exist: {dataset_name}.{table_name}") from e
 
     def commit_table(
-        self, table: Table, requirements: Tuple[TableRequirement, ...], updates: Tuple[TableUpdate, ...]
+        self, table: Table, requirements: tuple[TableRequirement, ...], updates: tuple[TableUpdate, ...]
     ) -> CommitTableResponse:
         raise NotImplementedError
 
@@ -244,9 +244,9 @@ class BigQueryMetastoreCatalog(MetastoreCatalog):
         except NotFound as e:
             raise NoSuchNamespaceError(f"Namespace {namespace} does not exist.") from e
 
-    def list_tables(self, namespace: str | Identifier) -> List[Identifier]:
+    def list_tables(self, namespace: str | Identifier) -> list[Identifier]:
         database_name = self.identifier_to_database(namespace)
-        iceberg_tables: List[Identifier] = []
+        iceberg_tables: list[Identifier] = []
         try:
             dataset_ref = DatasetReference(project=self.project_id, dataset_id=database_name)
             # The list_tables method returns an iterator of TableListItem
@@ -258,7 +258,7 @@ class BigQueryMetastoreCatalog(MetastoreCatalog):
             raise NoSuchNamespaceError(f"Namespace (dataset) '{database_name}' not found.") from None
         return iceberg_tables
 
-    def list_namespaces(self, namespace: str | Identifier = ()) -> List[Identifier]:
+    def list_namespaces(self, namespace: str | Identifier = ()) -> list[Identifier]:
         # Since this catalog only supports one-level namespaces, it always returns an empty list unless
         # passed an empty namespace to list all namespaces within the catalog.
         if namespace:
@@ -299,7 +299,7 @@ class BigQueryMetastoreCatalog(MetastoreCatalog):
 
         return self.load_table(identifier=identifier)
 
-    def list_views(self, namespace: str | Identifier) -> List[Identifier]:
+    def list_views(self, namespace: str | Identifier) -> list[Identifier]:
         raise NotImplementedError
 
     def drop_view(self, identifier: str | Identifier) -> None:
@@ -321,7 +321,7 @@ class BigQueryMetastoreCatalog(MetastoreCatalog):
         return {}
 
     def update_namespace_properties(
-        self, namespace: str | Identifier, removals: Set[str] | None = None, updates: Properties = EMPTY_DICT
+        self, namespace: str | Identifier, removals: set[str] | None = None, updates: Properties = EMPTY_DICT
     ) -> PropertiesUpdateSummary:
         raise NotImplementedError
 

--- a/pyiceberg/catalog/glue.py
+++ b/pyiceberg/catalog/glue.py
@@ -19,11 +19,7 @@
 from typing import (
     TYPE_CHECKING,
     Any,
-    Dict,
-    List,
     Optional,
-    Set,
-    Tuple,
     Union,
     cast,
 )
@@ -178,7 +174,7 @@ class _IcebergSchemaToGlueType(SchemaVisitor[str]):
     def schema(self, schema: Schema, struct_result: str) -> str:
         return struct_result
 
-    def struct(self, struct: StructType, field_results: List[str]) -> str:
+    def struct(self, struct: StructType, field_results: list[str]) -> str:
         return f"struct<{','.join(field_results)}>"
 
     def field(self, field: NestedField, field_result: str) -> str:
@@ -198,8 +194,8 @@ class _IcebergSchemaToGlueType(SchemaVisitor[str]):
         return GLUE_PRIMITIVE_TYPES[primitive_type]
 
 
-def _to_columns(metadata: TableMetadata) -> List["ColumnTypeDef"]:
-    results: Dict[str, ColumnTypeDef] = {}
+def _to_columns(metadata: TableMetadata) -> list["ColumnTypeDef"]:
+    results: dict[str, ColumnTypeDef] = {}
 
     def _append_to_results(field: NestedField, is_current: bool) -> None:
         if field.name in results:
@@ -305,7 +301,7 @@ def _register_glue_catalog_id_with_glue_client(glue: "GlueClient", glue_catalog_
     """
     event_system = glue.meta.events
 
-    def add_glue_catalog_id(params: Dict[str, str], **kwargs: Any) -> None:
+    def add_glue_catalog_id(params: dict[str, str], **kwargs: Any) -> None:
         if "CatalogId" not in params:
             params["CatalogId"] = glue_catalog_id
 
@@ -487,7 +483,7 @@ class GlueCatalog(MetastoreCatalog):
         return self.load_table(identifier=identifier)
 
     def commit_table(
-        self, table: Table, requirements: Tuple[TableRequirement, ...], updates: Tuple[TableUpdate, ...]
+        self, table: Table, requirements: tuple[TableRequirement, ...], updates: tuple[TableUpdate, ...]
     ) -> CommitTableResponse:
         """Commit updates to a table.
 
@@ -705,7 +701,7 @@ class GlueCatalog(MetastoreCatalog):
                 )
         self.glue.delete_database(Name=database_name)
 
-    def list_tables(self, namespace: str | Identifier) -> List[Identifier]:
+    def list_tables(self, namespace: str | Identifier) -> list[Identifier]:
         """List Iceberg tables under the given namespace in the catalog.
 
         Args:
@@ -718,7 +714,7 @@ class GlueCatalog(MetastoreCatalog):
             NoSuchNamespaceError: If a namespace with the given name does not exist, or the identifier is invalid.
         """
         database_name = self.identifier_to_database(namespace, NoSuchNamespaceError)
-        table_list: List[TableTypeDef] = []
+        table_list: list[TableTypeDef] = []
         next_token: str | None = None
         try:
             while True:
@@ -736,7 +732,7 @@ class GlueCatalog(MetastoreCatalog):
             raise NoSuchNamespaceError(f"Database does not exist: {database_name}") from e
         return [(database_name, table["Name"]) for table in table_list if self.__is_iceberg_table(table)]
 
-    def list_namespaces(self, namespace: str | Identifier = ()) -> List[Identifier]:
+    def list_namespaces(self, namespace: str | Identifier = ()) -> list[Identifier]:
         """List namespaces from the given namespace. If not given, list top-level namespaces from the catalog.
 
         Returns:
@@ -746,7 +742,7 @@ class GlueCatalog(MetastoreCatalog):
         if namespace:
             return []
 
-        database_list: List[DatabaseTypeDef] = []
+        database_list: list[DatabaseTypeDef] = []
         next_token: str | None = None
 
         while True:
@@ -789,7 +785,7 @@ class GlueCatalog(MetastoreCatalog):
         return properties
 
     def update_namespace_properties(
-        self, namespace: str | Identifier, removals: Set[str] | None = None, updates: Properties = EMPTY_DICT
+        self, namespace: str | Identifier, removals: set[str] | None = None, updates: Properties = EMPTY_DICT
     ) -> PropertiesUpdateSummary:
         """Remove provided property keys and updates properties for a namespace.
 
@@ -812,7 +808,7 @@ class GlueCatalog(MetastoreCatalog):
 
         return properties_update_summary
 
-    def list_views(self, namespace: str | Identifier) -> List[Identifier]:
+    def list_views(self, namespace: str | Identifier) -> list[Identifier]:
         raise NotImplementedError
 
     def drop_view(self, identifier: str | Identifier) -> None:

--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -22,11 +22,6 @@ from types import TracebackType
 from typing import (
     TYPE_CHECKING,
     Any,
-    Dict,
-    List,
-    Set,
-    Tuple,
-    Type,
     Union,
 )
 from urllib.parse import urlparse
@@ -148,7 +143,7 @@ class _HiveClient:
     """Helper class to nicely open and close the transport."""
 
     _transport: TTransport
-    _ugi: List[str] | None
+    _ugi: list[str] | None
 
     def __init__(
         self,
@@ -194,7 +189,7 @@ class _HiveClient:
                 self._transport.open()
         return self._client()  # recreate the client
 
-    def __exit__(self, exctype: Type[BaseException] | None, excinst: BaseException | None, exctb: TracebackType | None) -> None:
+    def __exit__(self, exctype: type[BaseException] | None, excinst: BaseException | None, exctb: TracebackType | None) -> None:
         """Close transport if it was opened."""
         if self._transport.isOpen():
             self._transport.close()
@@ -223,7 +218,7 @@ DEFAULT_PROPERTIES = {TableProperties.PARQUET_COMPRESSION: TableProperties.PARQU
 
 def _construct_parameters(
     metadata_location: str, previous_metadata_location: str | None = None, metadata_properties: Properties | None = None
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     properties = {PROP_EXTERNAL: "TRUE", PROP_TABLE_TYPE: "ICEBERG", PROP_METADATA_LOCATION: metadata_location}
     if previous_metadata_location:
         properties[PROP_PREVIOUS_METADATA_LOCATION] = previous_metadata_location
@@ -276,7 +271,7 @@ class SchemaToHiveConverter(SchemaVisitor[str]):
     def schema(self, schema: Schema, struct_result: str) -> str:
         return struct_result
 
-    def struct(self, struct: StructType, field_results: List[str]) -> str:
+    def struct(self, struct: StructType, field_results: list[str]) -> str:
         return f"struct<{','.join(field_results)}>"
 
     def field(self, field: NestedField, field_result: str) -> str:
@@ -315,7 +310,7 @@ class HiveCatalog(MetastoreCatalog):
         )
 
     @staticmethod
-    def _create_hive_client(properties: Dict[str, str]) -> _HiveClient:
+    def _create_hive_client(properties: dict[str, str]) -> _HiveClient:
         last_exception = None
         for uri in properties[URI].split(","):
             try:
@@ -333,7 +328,7 @@ class HiveCatalog(MetastoreCatalog):
             raise ValueError(f"Unable to connect to hive using uri: {properties[URI]}")
 
     def _convert_hive_into_iceberg(self, table: HiveTable) -> Table:
-        properties: Dict[str, str] = table.parameters
+        properties: dict[str, str] = table.parameters
         if TABLE_TYPE not in properties:
             raise NoSuchPropertyException(
                 f"Property table_type missing, could not determine type: {table.dbName}.{table.tableName}"
@@ -469,7 +464,7 @@ class HiveCatalog(MetastoreCatalog):
 
         return self._convert_hive_into_iceberg(hive_table)
 
-    def list_views(self, namespace: str | Identifier) -> List[Identifier]:
+    def list_views(self, namespace: str | Identifier) -> list[Identifier]:
         raise NotImplementedError
 
     def view_exists(self, identifier: str | Identifier) -> bool:
@@ -505,7 +500,7 @@ class HiveCatalog(MetastoreCatalog):
         return _do_wait_for_lock()
 
     def commit_table(
-        self, table: Table, requirements: Tuple[TableRequirement, ...], updates: Tuple[TableUpdate, ...]
+        self, table: Table, requirements: tuple[TableRequirement, ...], updates: tuple[TableUpdate, ...]
     ) -> CommitTableResponse:
         """Commit updates to a table.
 
@@ -715,7 +710,7 @@ class HiveCatalog(MetastoreCatalog):
         except MetaException as e:
             raise NoSuchNamespaceError(f"Database does not exists: {database_name}") from e
 
-    def list_tables(self, namespace: str | Identifier) -> List[Identifier]:
+    def list_tables(self, namespace: str | Identifier) -> list[Identifier]:
         """List Iceberg tables under the given namespace in the catalog.
 
         When the database doesn't exist, it will just return an empty list.
@@ -739,7 +734,7 @@ class HiveCatalog(MetastoreCatalog):
                 if table.parameters.get(TABLE_TYPE, "").lower() == ICEBERG
             ]
 
-    def list_namespaces(self, namespace: str | Identifier = ()) -> List[Identifier]:
+    def list_namespaces(self, namespace: str | Identifier = ()) -> list[Identifier]:
         """List namespaces from the given namespace. If not given, list top-level namespaces from the catalog.
 
         Returns:
@@ -777,7 +772,7 @@ class HiveCatalog(MetastoreCatalog):
             raise NoSuchNamespaceError(f"Database does not exists: {database_name}") from e
 
     def update_namespace_properties(
-        self, namespace: str | Identifier, removals: Set[str] | None = None, updates: Properties = EMPTY_DICT
+        self, namespace: str | Identifier, removals: set[str] | None = None, updates: Properties = EMPTY_DICT
     ) -> PropertiesUpdateSummary:
         """Remove provided property keys and update properties for a namespace.
 
@@ -799,8 +794,8 @@ class HiveCatalog(MetastoreCatalog):
             except NoSuchObjectException as e:
                 raise NoSuchNamespaceError(f"Database does not exists: {database_name}") from e
 
-            removed: Set[str] = set()
-            updated: Set[str] = set()
+            removed: set[str] = set()
+            updated: set[str] = set()
 
             if removals:
                 for key in removals:

--- a/pyiceberg/catalog/noop.py
+++ b/pyiceberg/catalog/noop.py
@@ -16,9 +16,6 @@
 #  under the License.
 from typing import (
     TYPE_CHECKING,
-    List,
-    Set,
-    Tuple,
     Union,
 )
 
@@ -95,7 +92,7 @@ class NoopCatalog(Catalog):
         raise NotImplementedError
 
     def commit_table(
-        self, table: Table, requirements: Tuple[TableRequirement, ...], updates: Tuple[TableUpdate, ...]
+        self, table: Table, requirements: tuple[TableRequirement, ...], updates: tuple[TableUpdate, ...]
     ) -> CommitTableResponse:
         raise NotImplementedError
 
@@ -105,21 +102,21 @@ class NoopCatalog(Catalog):
     def drop_namespace(self, namespace: str | Identifier) -> None:
         raise NotImplementedError
 
-    def list_tables(self, namespace: str | Identifier) -> List[Identifier]:
+    def list_tables(self, namespace: str | Identifier) -> list[Identifier]:
         raise NotImplementedError
 
-    def list_namespaces(self, namespace: str | Identifier = ()) -> List[Identifier]:
+    def list_namespaces(self, namespace: str | Identifier = ()) -> list[Identifier]:
         raise NotImplementedError
 
     def load_namespace_properties(self, namespace: str | Identifier) -> Properties:
         raise NotImplementedError
 
     def update_namespace_properties(
-        self, namespace: str | Identifier, removals: Set[str] | None = None, updates: Properties = EMPTY_DICT
+        self, namespace: str | Identifier, removals: set[str] | None = None, updates: Properties = EMPTY_DICT
     ) -> PropertiesUpdateSummary:
         raise NotImplementedError
 
-    def list_views(self, namespace: str | Identifier) -> List[Identifier]:
+    def list_views(self, namespace: str | Identifier) -> list[Identifier]:
         raise NotImplementedError
 
     def view_exists(self, identifier: str | Identifier) -> bool:

--- a/pyiceberg/catalog/rest/auth.py
+++ b/pyiceberg/catalog/rest/auth.py
@@ -22,7 +22,7 @@ import threading
 import time
 from abc import ABC, abstractmethod
 from functools import cached_property
-from typing import Any, Dict, List, Type
+from typing import Any
 
 import requests
 from requests import HTTPError, PreparedRequest, Session
@@ -76,7 +76,7 @@ class LegacyOAuth2AuthManager(AuthManager):
     _auth_url: str | None
     _token: str | None
     _credential: str | None
-    _optional_oauth_params: Dict[str, str] | None
+    _optional_oauth_params: dict[str, str] | None
 
     def __init__(
         self,
@@ -84,7 +84,7 @@ class LegacyOAuth2AuthManager(AuthManager):
         auth_url: str | None = None,
         credential: str | None = None,
         initial_token: str | None = None,
-        optional_oauth_params: Dict[str, str] | None = None,
+        optional_oauth_params: dict[str, str] | None = None,
     ):
         self._session = session
         self._auth_url = auth_url
@@ -220,7 +220,7 @@ class OAuth2AuthManager(AuthManager):
 class GoogleAuthManager(AuthManager):
     """An auth manager that is responsible for handling Google credentials."""
 
-    def __init__(self, credentials_path: str | None = None, scopes: List[str] | None = None):
+    def __init__(self, credentials_path: str | None = None, scopes: list[str] | None = None):
         """
         Initialize GoogleAuthManager.
 
@@ -280,10 +280,10 @@ class AuthManagerAdapter(AuthBase):
 
 
 class AuthManagerFactory:
-    _registry: Dict[str, Type["AuthManager"]] = {}
+    _registry: dict[str, type["AuthManager"]] = {}
 
     @classmethod
-    def register(cls, name: str, auth_manager_class: Type["AuthManager"]) -> None:
+    def register(cls, name: str, auth_manager_class: type["AuthManager"]) -> None:
         """
         Register a string name to a known AuthManager class.
 
@@ -297,7 +297,7 @@ class AuthManagerFactory:
         cls._registry[name] = auth_manager_class
 
     @classmethod
-    def create(cls, class_or_name: str, config: Dict[str, Any]) -> AuthManager:
+    def create(cls, class_or_name: str, config: dict[str, Any]) -> AuthManager:
         """
         Create an AuthManager by name or fully-qualified class path.
 

--- a/pyiceberg/catalog/rest/response.py
+++ b/pyiceberg/catalog/rest/response.py
@@ -15,7 +15,7 @@
 #  specific language governing permissions and limitations
 #  under the License.
 from json import JSONDecodeError
-from typing import Dict, Literal, Type
+from typing import Literal
 
 from pydantic import Field, ValidationError
 from requests import HTTPError
@@ -60,8 +60,8 @@ class OAuthErrorResponse(IcebergBaseModel):
     error_uri: str | None = None
 
 
-def _handle_non_200_response(exc: HTTPError, error_handler: Dict[int, Type[Exception]]) -> None:
-    exception: Type[Exception]
+def _handle_non_200_response(exc: HTTPError, error_handler: dict[int, type[Exception]]) -> None:
+    exception: type[Exception]
 
     if exc.response is None:
         raise ValueError("Did not receive a response")

--- a/pyiceberg/catalog/sql.py
+++ b/pyiceberg/catalog/sql.py
@@ -17,9 +17,6 @@
 
 from typing import (
     TYPE_CHECKING,
-    List,
-    Set,
-    Tuple,
     Union,
 )
 
@@ -402,7 +399,7 @@ class SqlCatalog(MetastoreCatalog):
         return self.load_table(to_identifier)
 
     def commit_table(
-        self, table: Table, requirements: Tuple[TableRequirement, ...], updates: Tuple[TableUpdate, ...]
+        self, table: Table, requirements: tuple[TableRequirement, ...], updates: tuple[TableUpdate, ...]
     ) -> CommitTableResponse:
         """Commit updates to a table.
 
@@ -583,7 +580,7 @@ class SqlCatalog(MetastoreCatalog):
             )
             session.commit()
 
-    def list_tables(self, namespace: str | Identifier) -> List[Identifier]:
+    def list_tables(self, namespace: str | Identifier) -> list[Identifier]:
         """List tables under the given namespace in the catalog.
 
         Args:
@@ -604,7 +601,7 @@ class SqlCatalog(MetastoreCatalog):
             result = session.scalars(stmt)
             return [(Catalog.identifier_to_tuple(table.table_namespace) + (table.table_name,)) for table in result]
 
-    def list_namespaces(self, namespace: str | Identifier = ()) -> List[Identifier]:
+    def list_namespaces(self, namespace: str | Identifier = ()) -> list[Identifier]:
         """List namespaces from the given namespace. If not given, list top-level namespaces from the catalog.
 
         Args:
@@ -669,7 +666,7 @@ class SqlCatalog(MetastoreCatalog):
             return {props.property_key: props.property_value for props in result}
 
     def update_namespace_properties(
-        self, namespace: str | Identifier, removals: Set[str] | None = None, updates: Properties = EMPTY_DICT
+        self, namespace: str | Identifier, removals: set[str] | None = None, updates: Properties = EMPTY_DICT
     ) -> PropertiesUpdateSummary:
         """Remove provided property keys and update properties for a namespace.
 
@@ -724,7 +721,7 @@ class SqlCatalog(MetastoreCatalog):
             session.commit()
         return properties_update_summary
 
-    def list_views(self, namespace: str | Identifier) -> List[Identifier]:
+    def list_views(self, namespace: str | Identifier) -> list[Identifier]:
         raise NotImplementedError
 
     def view_exists(self, identifier: str | Identifier) -> bool:

--- a/pyiceberg/cli/console.py
+++ b/pyiceberg/cli/console.py
@@ -19,9 +19,7 @@ from functools import wraps
 from typing import (
     Any,
     Callable,
-    Dict,
     Literal,
-    Tuple,
 )
 
 import click
@@ -97,7 +95,7 @@ def run(
         ctx.exit(1)
 
 
-def _catalog_and_output(ctx: Context) -> Tuple[Catalog, Output]:
+def _catalog_and_output(ctx: Context) -> tuple[Catalog, Output]:
     """Small helper to set the types."""
     return ctx.obj["catalog"], ctx.obj["output"]
 
@@ -430,7 +428,7 @@ def list_refs(ctx: Context, identifier: str, type: str, verbose: bool) -> None:
     output.describe_refs(relevant_refs)
 
 
-def _retention_properties(ref: SnapshotRef, table_properties: Dict[str, str]) -> Dict[str, str]:
+def _retention_properties(ref: SnapshotRef, table_properties: dict[str, str]) -> dict[str, str]:
     retention_properties = {}
     if ref.snapshot_ref_type == SnapshotRefType.BRANCH:
         default_min_snapshots_to_keep = property_as_int(

--- a/pyiceberg/cli/output.py
+++ b/pyiceberg/cli/output.py
@@ -18,9 +18,6 @@ import json
 from abc import ABC, abstractmethod
 from typing import (
     Any,
-    Dict,
-    List,
-    Tuple,
 )
 from uuid import UUID
 
@@ -43,7 +40,7 @@ class Output(ABC):
     def exception(self, ex: Exception) -> None: ...
 
     @abstractmethod
-    def identifiers(self, identifiers: List[Identifier]) -> None: ...
+    def identifiers(self, identifiers: list[Identifier]) -> None: ...
 
     @abstractmethod
     def describe_table(self, table: Table) -> None: ...
@@ -70,7 +67,7 @@ class Output(ABC):
     def version(self, version: str) -> None: ...
 
     @abstractmethod
-    def describe_refs(self, refs: List[Tuple[str, SnapshotRefType, Dict[str, str]]]) -> None: ...
+    def describe_refs(self, refs: list[tuple[str, SnapshotRefType, dict[str, str]]]) -> None: ...
 
 
 class ConsoleOutput(Output):
@@ -91,7 +88,7 @@ class ConsoleOutput(Output):
         else:
             Console(stderr=True).print(ex)
 
-    def identifiers(self, identifiers: List[Identifier]) -> None:
+    def identifiers(self, identifiers: list[Identifier]) -> None:
         table = self._table
         for identifier in identifiers:
             table.add_row(".".join(identifier))
@@ -174,7 +171,7 @@ class ConsoleOutput(Output):
     def version(self, version: str) -> None:
         Console().print(version)
 
-    def describe_refs(self, ref_details: List[Tuple[str, SnapshotRefType, Dict[str, str]]]) -> None:
+    def describe_refs(self, ref_details: list[tuple[str, SnapshotRefType, dict[str, str]]]) -> None:
         refs_table = RichTable(title="Snapshot Refs")
         refs_table.add_column("Ref")
         refs_table.add_column("Type")
@@ -202,7 +199,7 @@ class JsonOutput(Output):
     def exception(self, ex: Exception) -> None:
         self._out({"type": ex.__class__.__name__, "message": str(ex)})
 
-    def identifiers(self, identifiers: List[Identifier]) -> None:
+    def identifiers(self, identifiers: list[Identifier]) -> None:
         self._out([".".join(identifier) for identifier in identifiers])
 
     def describe_table(self, table: Table) -> None:
@@ -240,7 +237,7 @@ class JsonOutput(Output):
     def version(self, version: str) -> None:
         self._out({"version": version})
 
-    def describe_refs(self, refs: List[Tuple[str, SnapshotRefType, Dict[str, str]]]) -> None:
+    def describe_refs(self, refs: list[tuple[str, SnapshotRefType, dict[str, str]]]) -> None:
         self._out(
             [
                 {"name": name, "type": type, detail_key: detail_val}

--- a/pyiceberg/expressions/literals.py
+++ b/pyiceberg/expressions/literals.py
@@ -27,7 +27,7 @@ from datetime import date, datetime, time
 from decimal import ROUND_HALF_UP, Decimal
 from functools import singledispatchmethod
 from math import isnan
-from typing import Any, Generic, Type
+from typing import Any, Generic
 from uuid import UUID
 
 from pydantic import Field, model_serializer
@@ -73,7 +73,7 @@ class Literal(IcebergRootModel[L], Generic[L], ABC):  # type: ignore
 
     root: L = Field()
 
-    def __init__(self, value: L, value_type: Type[L], /, **data):  # type: ignore
+    def __init__(self, value: L, value_type: type[L], /, **data):  # type: ignore
         if value is None:
             raise TypeError("Invalid literal value: None")
 

--- a/pyiceberg/io/__init__.py
+++ b/pyiceberg/io/__init__.py
@@ -32,10 +32,7 @@ from abc import ABC, abstractmethod
 from io import SEEK_SET
 from types import TracebackType
 from typing import (
-    Dict,
-    List,
     Protocol,
-    Type,
     runtime_checkable,
 )
 from urllib.parse import urlparse
@@ -126,7 +123,7 @@ class InputStream(Protocol):
         """Provide setup when opening an InputStream using a 'with' statement."""
 
     @abstractmethod
-    def __exit__(self, exctype: Type[BaseException] | None, excinst: BaseException | None, exctb: TracebackType | None) -> None:
+    def __exit__(self, exctype: type[BaseException] | None, excinst: BaseException | None, exctb: TracebackType | None) -> None:
         """Perform cleanup when exiting the scope of a 'with' statement."""
 
 
@@ -149,7 +146,7 @@ class OutputStream(Protocol):  # pragma: no cover
         """Provide setup when opening an OutputStream using a 'with' statement."""
 
     @abstractmethod
-    def __exit__(self, exctype: Type[BaseException] | None, excinst: BaseException | None, exctb: TracebackType | None) -> None:
+    def __exit__(self, exctype: type[BaseException] | None, excinst: BaseException | None, exctb: TracebackType | None) -> None:
         """Perform cleanup when exiting the scope of a 'with' statement."""
 
 
@@ -298,7 +295,7 @@ FSSPEC_FILE_IO = "pyiceberg.io.fsspec.FsspecFileIO"
 
 # Mappings from the Java FileIO impl to a Python one. The list is ordered by preference.
 # If an implementation isn't installed, it will fall back to the next one.
-SCHEMA_TO_FILE_IO: Dict[str, List[str]] = {
+SCHEMA_TO_FILE_IO: dict[str, list[str]] = {
     "s3": [ARROW_FILE_IO, FSSPEC_FILE_IO],
     "s3a": [ARROW_FILE_IO, FSSPEC_FILE_IO],
     "s3n": [ARROW_FILE_IO, FSSPEC_FILE_IO],

--- a/pyiceberg/io/fsspec.py
+++ b/pyiceberg/io/fsspec.py
@@ -28,8 +28,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Dict,
-    Type,
 )
 from urllib.parse import urlparse
 
@@ -148,7 +146,7 @@ class S3V4RestSigner(S3RequestSigner):
         request.url = response_json["uri"]
 
 
-SIGNERS: Dict[str, Type[S3RequestSigner]] = {"S3V4RestSigner": S3V4RestSigner}
+SIGNERS: dict[str, type[S3RequestSigner]] = {"S3V4RestSigner": S3V4RestSigner}
 
 
 def _file(_: Properties) -> LocalFileSystem:
@@ -166,7 +164,7 @@ def _s3(properties: Properties) -> AbstractFileSystem:
         "region_name": get_first_property_value(properties, S3_REGION, AWS_REGION),
     }
     config_kwargs = {}
-    register_events: Dict[str, Callable[[AWSRequest], None]] = {}
+    register_events: dict[str, Callable[[AWSRequest], None]] = {}
 
     if signer := properties.get(S3_SIGNER):
         logger.info("Loading signer %s", signer)
@@ -455,13 +453,13 @@ class FsspecFileIO(FileIO):
             raise ValueError(f"No registered filesystem for scheme: {scheme}")
         return self._scheme_to_fs[scheme](self.properties)
 
-    def __getstate__(self) -> Dict[str, Any]:
+    def __getstate__(self) -> dict[str, Any]:
         """Create a dictionary of the FsSpecFileIO fields used when pickling."""
         fileio_copy = copy(self.__dict__)
         del fileio_copy["_thread_locals"]
         return fileio_copy
 
-    def __setstate__(self, state: Dict[str, Any]) -> None:
+    def __setstate__(self, state: dict[str, Any]) -> None:
         """Deserialize the state into a FsSpecFileIO instance."""
         self.__dict__ = state
         self._thread_locals = threading.local()

--- a/pyiceberg/manifest.py
+++ b/pyiceberg/manifest.py
@@ -24,12 +24,8 @@ from enum import Enum
 from types import TracebackType
 from typing import (
     Any,
-    Dict,
     Iterator,
-    List,
     Literal,
-    Tuple,
-    Type,
 )
 
 from cachetools import LRUCache, cached
@@ -111,7 +107,7 @@ class FileFormat(str, Enum):
         return f"FileFormat.{self.name}"
 
 
-DATA_FILE_TYPE: Dict[int, StructType] = {
+DATA_FILE_TYPE: dict[int, StructType] = {
     1: StructType(
         NestedField(field_id=100, name="file_path", field_type=StringType(), required=True, doc="Location URI with FS scheme"),
         NestedField(
@@ -475,27 +471,27 @@ class DataFile(Record):
         return self._data[5]
 
     @property
-    def column_sizes(self) -> Dict[int, int]:
+    def column_sizes(self) -> dict[int, int]:
         return self._data[6]
 
     @property
-    def value_counts(self) -> Dict[int, int]:
+    def value_counts(self) -> dict[int, int]:
         return self._data[7]
 
     @property
-    def null_value_counts(self) -> Dict[int, int]:
+    def null_value_counts(self) -> dict[int, int]:
         return self._data[8]
 
     @property
-    def nan_value_counts(self) -> Dict[int, int]:
+    def nan_value_counts(self) -> dict[int, int]:
         return self._data[9]
 
     @property
-    def lower_bounds(self) -> Dict[int, bytes]:
+    def lower_bounds(self) -> dict[int, bytes]:
         return self._data[10]
 
     @property
-    def upper_bounds(self) -> Dict[int, bytes]:
+    def upper_bounds(self) -> dict[int, bytes]:
         return self._data[11]
 
     @property
@@ -503,11 +499,11 @@ class DataFile(Record):
         return self._data[12]
 
     @property
-    def split_offsets(self) -> List[int] | None:
+    def split_offsets(self) -> list[int] | None:
         return self._data[13]
 
     @property
-    def equality_ids(self) -> List[int] | None:
+    def equality_ids(self) -> list[int] | None:
         return self._data[14]
 
     @property
@@ -690,7 +686,7 @@ class PartitionFieldStats:
                 self._min = min(self._min, value)
 
 
-def construct_partition_summaries(spec: PartitionSpec, schema: Schema, partitions: List[Record]) -> List[PartitionFieldSummary]:
+def construct_partition_summaries(spec: PartitionSpec, schema: Schema, partitions: list[Record]) -> list[PartitionFieldSummary]:
     types = [field.field_type for field in spec.partition_type(schema).fields]
     field_stats = [PartitionFieldStats(field_type) for field_type in types]
     for partition_keys in partitions:
@@ -702,7 +698,7 @@ def construct_partition_summaries(spec: PartitionSpec, schema: Schema, partition
     return [field.to_summary() for field in field_stats]
 
 
-MANIFEST_LIST_FILE_SCHEMAS: Dict[int, Schema] = {
+MANIFEST_LIST_FILE_SCHEMAS: dict[int, Schema] = {
     1: Schema(
         NestedField(500, "manifest_path", StringType(), required=True, doc="Location URI with FS scheme"),
         NestedField(501, "manifest_length", LongType(), required=True),
@@ -828,7 +824,7 @@ class ManifestFile(Record):
         return self._data[12]
 
     @property
-    def partitions(self) -> List[PartitionFieldSummary] | None:
+    def partitions(self) -> list[PartitionFieldSummary] | None:
         return self._data[13]
 
     @property
@@ -841,7 +837,7 @@ class ManifestFile(Record):
     def has_existing_files(self) -> bool:
         return self.existing_files_count is None or self.existing_files_count > 0
 
-    def fetch_manifest_entry(self, io: FileIO, discard_deleted: bool = True) -> List[ManifestEntry]:
+    def fetch_manifest_entry(self, io: FileIO, discard_deleted: bool = True) -> list[ManifestEntry]:
         """
         Read the manifest entries from the manifest file.
 
@@ -875,11 +871,11 @@ class ManifestFile(Record):
 
 
 # Global cache for manifest lists
-_manifest_cache: LRUCache[Any, Tuple[ManifestFile, ...]] = LRUCache(maxsize=128)
+_manifest_cache: LRUCache[Any, tuple[ManifestFile, ...]] = LRUCache(maxsize=128)
 
 
 @cached(cache=_manifest_cache, key=lambda io, manifest_list: hashkey(manifest_list), lock=threading.RLock())
-def _manifests(io: FileIO, manifest_list: str) -> Tuple[ManifestFile, ...]:
+def _manifests(io: FileIO, manifest_list: str) -> tuple[ManifestFile, ...]:
     """Read and cache manifests from the given manifest list, returning a tuple to prevent modification."""
     file = io.new_input(manifest_list)
     return tuple(read_manifest_list(file))
@@ -957,7 +953,7 @@ class ManifestWriter(ABC):
     _deleted_files: int
     _deleted_rows: int
     _min_sequence_number: int | None
-    _partitions: List[Record]
+    _partitions: list[Record]
     _compression: AvroCompressionCodec
 
     def __init__(
@@ -992,7 +988,7 @@ class ManifestWriter(ABC):
 
     def __exit__(
         self,
-        exc_type: Type[BaseException] | None,
+        exc_type: type[BaseException] | None,
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
@@ -1012,7 +1008,7 @@ class ManifestWriter(ABC):
     def version(self) -> TableVersion: ...
 
     @property
-    def _meta(self) -> Dict[str, str]:
+    def _meta(self) -> dict[str, str]:
         return {
             "schema": self._schema.model_dump_json(),
             "partition-spec": to_json(self._spec.fields).decode("utf-8"),
@@ -1167,7 +1163,7 @@ class ManifestWriterV2(ManifestWriter):
         return 2
 
     @property
-    def _meta(self) -> Dict[str, str]:
+    def _meta(self) -> dict[str, str]:
         return {
             **super()._meta,
             "content": "data",
@@ -1201,12 +1197,12 @@ def write_manifest(
 class ManifestListWriter(ABC):
     _format_version: TableVersion
     _output_file: OutputFile
-    _meta: Dict[str, str]
-    _manifest_files: List[ManifestFile]
+    _meta: dict[str, str]
+    _manifest_files: list[ManifestFile]
     _commit_snapshot_id: int
     _writer: AvroOutputFile[ManifestFile]
 
-    def __init__(self, format_version: TableVersion, output_file: OutputFile, meta: Dict[str, Any]):
+    def __init__(self, format_version: TableVersion, output_file: OutputFile, meta: dict[str, Any]):
         self._format_version = format_version
         self._output_file = output_file
         self._meta = meta
@@ -1226,7 +1222,7 @@ class ManifestListWriter(ABC):
 
     def __exit__(
         self,
-        exc_type: Type[BaseException] | None,
+        exc_type: type[BaseException] | None,
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
@@ -1237,7 +1233,7 @@ class ManifestListWriter(ABC):
     @abstractmethod
     def prepare_manifest(self, manifest_file: ManifestFile) -> ManifestFile: ...
 
-    def add_manifests(self, manifest_files: List[ManifestFile]) -> ManifestListWriter:
+    def add_manifests(self, manifest_files: list[ManifestFile]) -> ManifestListWriter:
         self._writer.write_block([self.prepare_manifest(manifest_file) for manifest_file in manifest_files])
         return self
 

--- a/pyiceberg/partitioning.py
+++ b/pyiceberg/partitioning.py
@@ -21,7 +21,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import date, datetime, time
 from functools import cached_property, singledispatch
-from typing import Annotated, Any, Dict, Generic, List, Set, Tuple, TypeVar
+from typing import Annotated, Any, Generic, TypeVar
 from urllib.parse import quote_plus
 
 from pydantic import (
@@ -131,7 +131,7 @@ class PartitionSpec(IcebergBaseModel):
     """
 
     spec_id: int = Field(alias="spec-id", default=INITIAL_PARTITION_SPEC_ID)
-    fields: Tuple[PartitionField, ...] = Field(default_factory=tuple)
+    fields: tuple[PartitionField, ...] = Field(default_factory=tuple)
 
     def __init__(
         self,
@@ -181,15 +181,15 @@ class PartitionSpec(IcebergBaseModel):
         return PARTITION_FIELD_ID_START - 1
 
     @cached_property
-    def source_id_to_fields_map(self) -> Dict[int, List[PartitionField]]:
-        source_id_to_fields_map: Dict[int, List[PartitionField]] = {}
+    def source_id_to_fields_map(self) -> dict[int, list[PartitionField]]:
+        source_id_to_fields_map: dict[int, list[PartitionField]] = {}
         for partition_field in self.fields:
             existing = source_id_to_fields_map.get(partition_field.source_id, [])
             existing.append(partition_field)
             source_id_to_fields_map[partition_field.source_id] = existing
         return source_id_to_fields_map
 
-    def fields_by_source_id(self, field_id: int) -> List[PartitionField]:
+    def fields_by_source_id(self, field_id: int) -> list[PartitionField]:
         return self.source_id_to_fields_map.get(field_id, [])
 
     def compatible_with(self, other: PartitionSpec) -> bool:
@@ -254,7 +254,7 @@ def validate_partition_name(
     partition_transform: Transform[Any, Any],
     source_id: int,
     schema: Schema,
-    partition_names: Set[str],
+    partition_names: set[str],
 ) -> None:
     """Validate that a partition field name doesn't conflict with schema field names."""
     try:
@@ -372,7 +372,7 @@ R = TypeVar("R")
 
 
 @singledispatch
-def _visit(spec: PartitionSpec, schema: Schema, visitor: PartitionSpecVisitor[R]) -> List[R]:
+def _visit(spec: PartitionSpec, schema: Schema, visitor: PartitionSpecVisitor[R]) -> list[R]:
     return [_visit_partition_field(schema, field, visitor) for field in spec.fields]
 
 
@@ -412,7 +412,7 @@ class PartitionFieldValue:
 
 @dataclass(frozen=True)
 class PartitionKey:
-    field_values: List[PartitionFieldValue]
+    field_values: list[PartitionFieldValue]
     partition_spec: PartitionSpec
     schema: Schema
 

--- a/pyiceberg/schema.py
+++ b/pyiceberg/schema.py
@@ -17,6 +17,7 @@
 # pylint: disable=W0511
 from __future__ import annotations
 
+import builtins
 import itertools
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -25,12 +26,8 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Dict,
     Generic,
-    List,
     Literal,
-    Set,
-    Tuple,
     TypeVar,
 )
 
@@ -89,11 +86,11 @@ class Schema(IcebergBaseModel):
     """
 
     type: Literal["struct"] = "struct"
-    fields: Tuple[NestedField, ...] = Field(default_factory=tuple)
+    fields: tuple[NestedField, ...] = Field(default_factory=tuple)
     schema_id: int = Field(alias="schema-id", default=INITIAL_SCHEMA_ID)
-    identifier_field_ids: List[int] = Field(alias="identifier-field-ids", default_factory=list)
+    identifier_field_ids: list[int] = Field(alias="identifier-field-ids", default_factory=list)
 
-    _name_to_id: Dict[str, int] = PrivateAttr()
+    _name_to_id: dict[str, int] = PrivateAttr()
 
     def __init__(self, *fields: NestedField, **data: Any):
         if fields:
@@ -138,12 +135,12 @@ class Schema(IcebergBaseModel):
         return self
 
     @property
-    def columns(self) -> Tuple[NestedField, ...]:
+    def columns(self) -> tuple[NestedField, ...]:
         """A tuple of the top-level fields."""
         return self.fields
 
     @cached_property
-    def _lazy_id_to_field(self) -> Dict[int, NestedField]:
+    def _lazy_id_to_field(self) -> dict[int, NestedField]:
         """Return an index of field ID to NestedField instance.
 
         This is calculated once when called for the first time. Subsequent calls to this method will use a cached index.
@@ -151,7 +148,7 @@ class Schema(IcebergBaseModel):
         return index_by_id(self)
 
     @cached_property
-    def _lazy_id_to_parent(self) -> Dict[int, int]:
+    def _lazy_id_to_parent(self) -> dict[int, int]:
         """Returns an index of field ID to parent field IDs.
 
         This is calculated once when called for the first time. Subsequent calls to this method will use a cached index.
@@ -159,7 +156,7 @@ class Schema(IcebergBaseModel):
         return _index_parents(self)
 
     @cached_property
-    def _lazy_name_to_id_lower(self) -> Dict[str, int]:
+    def _lazy_name_to_id_lower(self) -> dict[str, int]:
         """Return an index of lower-case field names to field IDs.
 
         This is calculated once when called for the first time. Subsequent calls to this method will use a cached index.
@@ -167,7 +164,7 @@ class Schema(IcebergBaseModel):
         return {name.lower(): field_id for name, field_id in self._name_to_id.items()}
 
     @cached_property
-    def _lazy_id_to_name(self) -> Dict[int, str]:
+    def _lazy_id_to_name(self) -> dict[int, str]:
         """Return an index of field ID to full name.
 
         This is calculated once when called for the first time. Subsequent calls to this method will use a cached index.
@@ -175,7 +172,7 @@ class Schema(IcebergBaseModel):
         return index_name_by_id(self)
 
     @cached_property
-    def _lazy_id_to_accessor(self) -> Dict[int, Accessor]:
+    def _lazy_id_to_accessor(self) -> dict[int, Accessor]:
         """Return an index of field ID to accessor.
 
         This is calculated once when called for the first time. Subsequent calls to this method will use a cached index.
@@ -257,7 +254,7 @@ class Schema(IcebergBaseModel):
         return self._lazy_id_to_name.get(column_id)
 
     @property
-    def column_names(self) -> List[str]:
+    def column_names(self) -> list[str]:
         """
         Return a list of all the column names, including nested fields.
 
@@ -285,7 +282,7 @@ class Schema(IcebergBaseModel):
 
         return self._lazy_id_to_accessor[field_id]
 
-    def identifier_field_names(self) -> Set[str]:
+    def identifier_field_names(self) -> set[str]:
         """Return the names of the identifier fields.
 
         Returns:
@@ -324,7 +321,7 @@ class Schema(IcebergBaseModel):
         return prune_columns(self, ids)
 
     @property
-    def field_ids(self) -> Set[int]:
+    def field_ids(self) -> set[int]:
         """Return the IDs of the current schema."""
         return set(self._name_to_id.values())
 
@@ -350,7 +347,7 @@ class Schema(IcebergBaseModel):
         # Check whether the nested field is in a chain of required struct fields
         # Exploring from root for better error message for list and map types
         parent_id = self._lazy_id_to_parent.get(field.field_id)
-        fields: List[int] = []
+        fields: list[int] = []
         while parent_id is not None:
             fields.append(parent_id)
             parent_id = self._lazy_id_to_parent.get(parent_id)
@@ -417,7 +414,7 @@ class SchemaVisitor(Generic[T], ABC):
         """Visit a Schema."""
 
     @abstractmethod
-    def struct(self, struct: StructType, field_results: List[T]) -> T:
+    def struct(self, struct: StructType, field_results: builtins.list[T]) -> T:
         """Visit a StructType."""
 
     @abstractmethod
@@ -443,7 +440,7 @@ class PreOrderSchemaVisitor(Generic[T], ABC):
         """Visit a Schema."""
 
     @abstractmethod
-    def struct(self, struct: StructType, field_results: List[Callable[[], T]]) -> T:
+    def struct(self, struct: StructType, field_results: builtins.list[Callable[[], T]]) -> T:
         """Visit a StructType."""
 
     @abstractmethod
@@ -499,7 +496,7 @@ class SchemaWithPartnerVisitor(Generic[P, T], ABC):
         """Visit a schema with a partner."""
 
     @abstractmethod
-    def struct(self, struct: StructType, struct_partner: P | None, field_results: List[T]) -> T:
+    def struct(self, struct: StructType, struct_partner: P | None, field_results: builtins.list[T]) -> T:
         """Visit a struct type with a partner."""
 
     @abstractmethod
@@ -979,41 +976,41 @@ def _(obj: PrimitiveType, visitor: PreOrderSchemaVisitor[T]) -> T:
     return visitor.primitive(obj)
 
 
-class _IndexById(SchemaVisitor[Dict[int, NestedField]]):
+class _IndexById(SchemaVisitor[dict[int, NestedField]]):
     """A schema visitor for generating a field ID to NestedField index."""
 
     def __init__(self) -> None:
-        self._index: Dict[int, NestedField] = {}
+        self._index: dict[int, NestedField] = {}
 
-    def schema(self, schema: Schema, struct_result: Dict[int, NestedField]) -> Dict[int, NestedField]:
+    def schema(self, schema: Schema, struct_result: dict[int, NestedField]) -> dict[int, NestedField]:
         return self._index
 
-    def struct(self, struct: StructType, field_results: List[Dict[int, NestedField]]) -> Dict[int, NestedField]:
+    def struct(self, struct: StructType, field_results: builtins.list[dict[int, NestedField]]) -> dict[int, NestedField]:
         return self._index
 
-    def field(self, field: NestedField, field_result: Dict[int, NestedField]) -> Dict[int, NestedField]:
+    def field(self, field: NestedField, field_result: dict[int, NestedField]) -> dict[int, NestedField]:
         """Add the field ID to the index."""
         self._index[field.field_id] = field
         return self._index
 
-    def list(self, list_type: ListType, element_result: Dict[int, NestedField]) -> Dict[int, NestedField]:
+    def list(self, list_type: ListType, element_result: dict[int, NestedField]) -> dict[int, NestedField]:
         """Add the list element ID to the index."""
         self._index[list_type.element_field.field_id] = list_type.element_field
         return self._index
 
     def map(
-        self, map_type: MapType, key_result: Dict[int, NestedField], value_result: Dict[int, NestedField]
-    ) -> Dict[int, NestedField]:
+        self, map_type: MapType, key_result: dict[int, NestedField], value_result: dict[int, NestedField]
+    ) -> dict[int, NestedField]:
         """Add the key ID and value ID as individual items in the index."""
         self._index[map_type.key_field.field_id] = map_type.key_field
         self._index[map_type.value_field.field_id] = map_type.value_field
         return self._index
 
-    def primitive(self, primitive: PrimitiveType) -> Dict[int, NestedField]:
+    def primitive(self, primitive: PrimitiveType) -> dict[int, NestedField]:
         return self._index
 
 
-def index_by_id(schema_or_type: Schema | IcebergType) -> Dict[int, NestedField]:
+def index_by_id(schema_or_type: Schema | IcebergType) -> dict[int, NestedField]:
     """Generate an index of field IDs to NestedField instances.
 
     Args:
@@ -1025,10 +1022,10 @@ def index_by_id(schema_or_type: Schema | IcebergType) -> Dict[int, NestedField]:
     return visit(schema_or_type, _IndexById())
 
 
-class _IndexParents(SchemaVisitor[Dict[int, int]]):
+class _IndexParents(SchemaVisitor[dict[int, int]]):
     def __init__(self) -> None:
-        self.id_to_parent: Dict[int, int] = {}
-        self.id_stack: List[int] = []
+        self.id_to_parent: dict[int, int] = {}
+        self.id_stack: list[int] = []
 
     def before_field(self, field: NestedField) -> None:
         self.id_stack.append(field.field_id)
@@ -1036,10 +1033,10 @@ class _IndexParents(SchemaVisitor[Dict[int, int]]):
     def after_field(self, field: NestedField) -> None:
         self.id_stack.pop()
 
-    def schema(self, schema: Schema, struct_result: Dict[int, int]) -> Dict[int, int]:
+    def schema(self, schema: Schema, struct_result: dict[int, int]) -> dict[int, int]:
         return self.id_to_parent
 
-    def struct(self, struct: StructType, field_results: List[Dict[int, int]]) -> Dict[int, int]:
+    def struct(self, struct: StructType, field_results: builtins.list[dict[int, int]]) -> dict[int, int]:
         for field in struct.fields:
             parent_id = self.id_stack[-1] if self.id_stack else None
             if parent_id is not None:
@@ -1048,23 +1045,23 @@ class _IndexParents(SchemaVisitor[Dict[int, int]]):
 
         return self.id_to_parent
 
-    def field(self, field: NestedField, field_result: Dict[int, int]) -> Dict[int, int]:
+    def field(self, field: NestedField, field_result: dict[int, int]) -> dict[int, int]:
         return self.id_to_parent
 
-    def list(self, list_type: ListType, element_result: Dict[int, int]) -> Dict[int, int]:
+    def list(self, list_type: ListType, element_result: dict[int, int]) -> dict[int, int]:
         self.id_to_parent[list_type.element_id] = self.id_stack[-1]
         return self.id_to_parent
 
-    def map(self, map_type: MapType, key_result: Dict[int, int], value_result: Dict[int, int]) -> Dict[int, int]:
+    def map(self, map_type: MapType, key_result: dict[int, int], value_result: dict[int, int]) -> dict[int, int]:
         self.id_to_parent[map_type.key_id] = self.id_stack[-1]
         self.id_to_parent[map_type.value_id] = self.id_stack[-1]
         return self.id_to_parent
 
-    def primitive(self, primitive: PrimitiveType) -> Dict[int, int]:
+    def primitive(self, primitive: PrimitiveType) -> dict[int, int]:
         return self.id_to_parent
 
 
-def _index_parents(schema_or_type: Schema | IcebergType) -> Dict[int, int]:
+def _index_parents(schema_or_type: Schema | IcebergType) -> dict[int, int]:
     """Generate an index of field IDs to their parent field IDs.
 
     Args:
@@ -1076,15 +1073,15 @@ def _index_parents(schema_or_type: Schema | IcebergType) -> Dict[int, int]:
     return visit(schema_or_type, _IndexParents())
 
 
-class _IndexByName(SchemaVisitor[Dict[str, int]]):
+class _IndexByName(SchemaVisitor[dict[str, int]]):
     """A schema visitor for generating a field name to field ID index."""
 
     def __init__(self) -> None:
-        self._index: Dict[str, int] = {}
-        self._short_name_to_id: Dict[str, int] = {}
-        self._combined_index: Dict[str, int] = {}
-        self._field_names: List[str] = []
-        self._short_field_names: List[str] = []
+        self._index: dict[str, int] = {}
+        self._short_name_to_id: dict[str, int] = {}
+        self._combined_index: dict[str, int] = {}
+        self._field_names: list[str] = []
+        self._short_field_names: list[str] = []
 
     def before_map_value(self, value: NestedField) -> None:
         if not isinstance(value.field_type, StructType):
@@ -1117,23 +1114,23 @@ class _IndexByName(SchemaVisitor[Dict[str, int]]):
         self._field_names.pop()
         self._short_field_names.pop()
 
-    def schema(self, schema: Schema, struct_result: Dict[str, int]) -> Dict[str, int]:
+    def schema(self, schema: Schema, struct_result: dict[str, int]) -> dict[str, int]:
         return self._index
 
-    def struct(self, struct: StructType, field_results: List[Dict[str, int]]) -> Dict[str, int]:
+    def struct(self, struct: StructType, field_results: builtins.list[dict[str, int]]) -> dict[str, int]:
         return self._index
 
-    def field(self, field: NestedField, field_result: Dict[str, int]) -> Dict[str, int]:
+    def field(self, field: NestedField, field_result: dict[str, int]) -> dict[str, int]:
         """Add the field name to the index."""
         self._add_field(field.name, field.field_id)
         return self._index
 
-    def list(self, list_type: ListType, element_result: Dict[str, int]) -> Dict[str, int]:
+    def list(self, list_type: ListType, element_result: dict[str, int]) -> dict[str, int]:
         """Add the list element name to the index."""
         self._add_field(list_type.element_field.name, list_type.element_field.field_id)
         return self._index
 
-    def map(self, map_type: MapType, key_result: Dict[str, int], value_result: Dict[str, int]) -> Dict[str, int]:
+    def map(self, map_type: MapType, key_result: dict[str, int], value_result: dict[str, int]) -> dict[str, int]:
         """Add the key name and value name as individual items in the index."""
         self._add_field(map_type.key_field.name, map_type.key_field.field_id)
         self._add_field(map_type.value_field.name, map_type.value_field.field_id)
@@ -1162,10 +1159,10 @@ class _IndexByName(SchemaVisitor[Dict[str, int]]):
             short_name = ".".join([".".join(self._short_field_names), name])
             self._short_name_to_id[short_name] = field_id
 
-    def primitive(self, primitive: PrimitiveType) -> Dict[str, int]:
+    def primitive(self, primitive: PrimitiveType) -> dict[str, int]:
         return self._index
 
-    def by_name(self) -> Dict[str, int]:
+    def by_name(self) -> dict[str, int]:
         """Return an index of combined full and short names.
 
         Note: Only short names that do not conflict with full names are included.
@@ -1174,13 +1171,13 @@ class _IndexByName(SchemaVisitor[Dict[str, int]]):
         combined_index.update(self._index)
         return combined_index
 
-    def by_id(self) -> Dict[int, str]:
+    def by_id(self) -> dict[int, str]:
         """Return an index of ID to full names."""
         id_to_full_name = {value: key for key, value in self._index.items()}
         return id_to_full_name
 
 
-def index_by_name(schema_or_type: Schema | IcebergType) -> Dict[str, int]:
+def index_by_name(schema_or_type: Schema | IcebergType) -> dict[str, int]:
     """Generate an index of field names to field IDs.
 
     Args:
@@ -1197,7 +1194,7 @@ def index_by_name(schema_or_type: Schema | IcebergType) -> Dict[str, int]:
         return EMPTY_DICT
 
 
-def index_name_by_id(schema_or_type: Schema | IcebergType) -> Dict[int, str]:
+def index_name_by_id(schema_or_type: Schema | IcebergType) -> dict[int, str]:
     """Generate an index of field IDs full field names.
 
     Args:
@@ -1214,7 +1211,7 @@ def index_name_by_id(schema_or_type: Schema | IcebergType) -> Dict[int, str]:
 Position = int
 
 
-class _BuildPositionAccessors(SchemaVisitor[Dict[Position, Accessor]]):
+class _BuildPositionAccessors(SchemaVisitor[dict[Position, Accessor]]):
     """A schema visitor for generating a field ID to accessor index.
 
     Example:
@@ -1247,10 +1244,10 @@ class _BuildPositionAccessors(SchemaVisitor[Dict[Position, Accessor]]):
         True
     """
 
-    def schema(self, schema: Schema, struct_result: Dict[Position, Accessor]) -> Dict[Position, Accessor]:
+    def schema(self, schema: Schema, struct_result: dict[Position, Accessor]) -> dict[Position, Accessor]:
         return struct_result
 
-    def struct(self, struct: StructType, field_results: List[Dict[Position, Accessor]]) -> Dict[Position, Accessor]:
+    def struct(self, struct: StructType, field_results: builtins.list[dict[Position, Accessor]]) -> dict[Position, Accessor]:
         result = {}
 
         for position, field in enumerate(struct.fields):
@@ -1261,22 +1258,22 @@ class _BuildPositionAccessors(SchemaVisitor[Dict[Position, Accessor]]):
 
         return result
 
-    def field(self, field: NestedField, field_result: Dict[Position, Accessor]) -> Dict[Position, Accessor]:
+    def field(self, field: NestedField, field_result: dict[Position, Accessor]) -> dict[Position, Accessor]:
         return field_result
 
-    def list(self, list_type: ListType, element_result: Dict[Position, Accessor]) -> Dict[Position, Accessor]:
+    def list(self, list_type: ListType, element_result: dict[Position, Accessor]) -> dict[Position, Accessor]:
         return {}
 
     def map(
-        self, map_type: MapType, key_result: Dict[Position, Accessor], value_result: Dict[Position, Accessor]
-    ) -> Dict[Position, Accessor]:
+        self, map_type: MapType, key_result: dict[Position, Accessor], value_result: dict[Position, Accessor]
+    ) -> dict[Position, Accessor]:
         return {}
 
-    def primitive(self, primitive: PrimitiveType) -> Dict[Position, Accessor]:
+    def primitive(self, primitive: PrimitiveType) -> dict[Position, Accessor]:
         return {}
 
 
-def build_position_accessors(schema_or_type: Schema | IcebergType) -> Dict[int, Accessor]:
+def build_position_accessors(schema_or_type: Schema | IcebergType) -> dict[int, Accessor]:
     """Generate an index of field IDs to schema position accessors.
 
     Args:
@@ -1296,7 +1293,7 @@ def assign_fresh_schema_ids(schema_or_type: Schema | IcebergType, next_id: Calla
 class _SetFreshIDs(PreOrderSchemaVisitor[IcebergType]):
     """Traverses the schema and assigns monotonically increasing ids."""
 
-    old_id_to_new_id: Dict[int, int]
+    old_id_to_new_id: dict[int, int]
 
     def __init__(self, next_id_func: Callable[[], int] | None = None) -> None:
         self.old_id_to_new_id = {}
@@ -1314,7 +1311,7 @@ class _SetFreshIDs(PreOrderSchemaVisitor[IcebergType]):
             identifier_field_ids=[self.old_id_to_new_id[field_id] for field_id in schema.identifier_field_ids],
         )
 
-    def struct(self, struct: StructType, field_results: List[Callable[[], IcebergType]]) -> StructType:
+    def struct(self, struct: StructType, field_results: builtins.list[Callable[[], IcebergType]]) -> StructType:
         new_ids = [self._get_and_increment(field.field_id) for field in struct.fields]
         new_fields = []
         for field_id, field, field_type in zip(new_ids, struct.fields, field_results, strict=True):
@@ -1445,7 +1442,7 @@ class _SanitizeColumnsVisitor(SchemaVisitor[IcebergType | None]):
             required=field.required,
         )
 
-    def struct(self, struct: StructType, field_results: List[IcebergType | None]) -> IcebergType | None:
+    def struct(self, struct: StructType, field_results: builtins.list[IcebergType | None]) -> IcebergType | None:
         return StructType(*[field for field in field_results if field is not None])
 
     def list(self, list_type: ListType, element_result: IcebergType | None) -> IcebergType | None:
@@ -1464,7 +1461,7 @@ class _SanitizeColumnsVisitor(SchemaVisitor[IcebergType | None]):
         return primitive
 
 
-def prune_columns(schema: Schema, selected: Set[int], select_full_types: bool = True) -> Schema:
+def prune_columns(schema: Schema, selected: set[int], select_full_types: bool = True) -> Schema:
     """Prunes a column by only selecting a set of field-ids.
 
     Args:
@@ -1484,17 +1481,17 @@ def prune_columns(schema: Schema, selected: Set[int], select_full_types: bool = 
 
 
 class _PruneColumnsVisitor(SchemaVisitor[IcebergType | None]):
-    selected: Set[int]
+    selected: set[int]
     select_full_types: bool
 
-    def __init__(self, selected: Set[int], select_full_types: bool):
+    def __init__(self, selected: set[int], select_full_types: bool):
         self.selected = selected
         self.select_full_types = select_full_types
 
     def schema(self, schema: Schema, struct_result: IcebergType | None) -> IcebergType | None:
         return struct_result
 
-    def struct(self, struct: StructType, field_results: List[IcebergType | None]) -> IcebergType | None:
+    def struct(self, struct: StructType, field_results: builtins.list[IcebergType | None]) -> IcebergType | None:
         fields = struct.fields
         selected_fields = []
         same_type = True
@@ -1781,7 +1778,7 @@ class _SchemaCompatibilityVisitor(PreOrderSchemaVisitor[bool]):
             raise ValueError(f"Mismatch in fields:\n{self.console.export_text()}")
         return result
 
-    def struct(self, struct: StructType, field_results: List[Callable[[], bool]]) -> bool:
+    def struct(self, struct: StructType, field_results: builtins.list[Callable[[], bool]]) -> bool:
         results = [result() for result in field_results]
         return all(results)
 

--- a/pyiceberg/table/inspect.py
+++ b/pyiceberg/table/inspect.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import itertools
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Set, Tuple
+from typing import TYPE_CHECKING, Any, Iterator
 
 from pyiceberg.conversions import from_bytes
 from pyiceberg.expressions import AlwaysTrue, BooleanExpression
@@ -308,7 +308,7 @@ class InspectTable:
             snapshot_id=snapshot.snapshot_id,
         )
 
-        partitions_map: Dict[Tuple[str, Any], Any] = {}
+        partitions_map: dict[tuple[str, Any], Any] = {}
 
         for entry in itertools.chain.from_iterable(scan.scan_plan_helper()):
             partition = entry.data_file.partition
@@ -327,9 +327,9 @@ class InspectTable:
 
     def _update_partitions_map_from_manifest_entry(
         self,
-        partitions_map: Dict[Tuple[str, Any], Any],
+        partitions_map: dict[tuple[str, Any], Any],
         file: DataFile,
-        partition_record_dict: Dict[str, Any],
+        partition_record_dict: dict[str, Any],
         snapshot: Snapshot | None,
     ) -> None:
         partition_record_key = _convert_to_hashable_type(partition_record_dict)
@@ -409,8 +409,8 @@ class InspectTable:
         import pyarrow as pa
 
         def _partition_summaries_to_rows(
-            spec: PartitionSpec, partition_summaries: List[PartitionFieldSummary]
-        ) -> List[Dict[str, Any]]:
+            spec: PartitionSpec, partition_summaries: list[PartitionFieldSummary]
+        ) -> list[dict[str, Any]]:
             rows = []
             for i, field_summary in enumerate(partition_summaries):
                 field = spec.fields[i]
@@ -492,7 +492,7 @@ class InspectTable:
             ]
         )
 
-        def metadata_log_entry_to_row(metadata_entry: MetadataLogEntry) -> Dict[str, Any]:
+        def metadata_log_entry_to_row(metadata_entry: MetadataLogEntry) -> dict[str, Any]:
             latest_snapshot = self.tbl.snapshot_as_of_timestamp(metadata_entry.timestamp_ms)
             return {
                 "timestamp": metadata_entry.timestamp_ms,
@@ -545,7 +545,7 @@ class InspectTable:
         return pa.Table.from_pylist(history, schema=history_schema)
 
     def _get_files_from_manifest(
-        self, manifest_list: ManifestFile, data_file_filter: Set[DataFileContent] | None = None
+        self, manifest_list: ManifestFile, data_file_filter: set[DataFileContent] | None = None
     ) -> pa.Table:
         import pyarrow as pa
 
@@ -663,7 +663,7 @@ class InspectTable:
         )
         return files_schema
 
-    def _files(self, snapshot_id: int | None = None, data_file_filter: Set[DataFileContent] | None = None) -> pa.Table:
+    def _files(self, snapshot_id: int | None = None, data_file_filter: set[DataFileContent] | None = None) -> pa.Table:
         import pyarrow as pa
 
         if not snapshot_id and not self.tbl.metadata.current_snapshot():
@@ -702,7 +702,7 @@ class InspectTable:
         )
         return pa.concat_tables(manifests_by_snapshots)
 
-    def _all_files(self, data_file_filter: Set[DataFileContent] | None = None) -> pa.Table:
+    def _all_files(self, data_file_filter: set[DataFileContent] | None = None) -> pa.Table:
         import pyarrow as pa
 
         snapshots = self.tbl.snapshots()

--- a/pyiceberg/table/metadata.py
+++ b/pyiceberg/table/metadata.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import datetime
 import uuid
 from copy import copy
-from typing import Annotated, Any, Dict, List, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import Field, field_serializer, field_validator, model_validator
 from pydantic import ValidationError as PydanticValidationError
@@ -68,7 +68,7 @@ DEFAULT_SCHEMA_ID = 0
 SUPPORTED_TABLE_FORMAT_VERSION = 2
 
 
-def cleanup_snapshot_id(data: Dict[str, Any]) -> Dict[str, Any]:
+def cleanup_snapshot_id(data: dict[str, Any]) -> dict[str, Any]:
     """Run before validation."""
     if CURRENT_SNAPSHOT_ID in data and data[CURRENT_SNAPSHOT_ID] == -1:
         # We treat -1 and None the same, by cleaning this up
@@ -92,7 +92,7 @@ def check_partition_specs(table_metadata: TableMetadata) -> TableMetadata:
     """Check if the default-spec-id is present in partition-specs."""
     default_spec_id = table_metadata.default_spec_id
 
-    partition_specs: List[PartitionSpec] = table_metadata.partition_specs
+    partition_specs: list[PartitionSpec] = table_metadata.partition_specs
     for spec in partition_specs:
         if spec.spec_id == default_spec_id:
             return table_metadata
@@ -105,7 +105,7 @@ def check_sort_orders(table_metadata: TableMetadata) -> TableMetadata:
     default_sort_order_id: int = table_metadata.default_sort_order_id
 
     if default_sort_order_id != UNSORTED_SORT_ORDER_ID:
-        sort_orders: List[SortOrder] = table_metadata.sort_orders
+        sort_orders: list[SortOrder] = table_metadata.sort_orders
         for sort_order in sort_orders:
             if sort_order.order_id == default_sort_order_id:
                 return table_metadata
@@ -151,13 +151,13 @@ class TableMetadataCommonFields(IcebergBaseModel):
     This is used to ensure fields are always assigned an unused ID
     when evolving schemas."""
 
-    schemas: List[Schema] = Field(default_factory=list)
+    schemas: list[Schema] = Field(default_factory=list)
     """A list of schemas, stored as objects with schema-id."""
 
     current_schema_id: int = Field(alias="current-schema-id", default=DEFAULT_SCHEMA_ID)
     """ID of the table’s current schema."""
 
-    partition_specs: List[PartitionSpec] = Field(alias="partition-specs", default_factory=list)
+    partition_specs: list[PartitionSpec] = Field(alias="partition-specs", default_factory=list)
     """A list of partition specs, stored as full partition spec objects."""
 
     default_spec_id: int = Field(alias="default-spec-id", default=INITIAL_SPEC_ID)
@@ -168,7 +168,7 @@ class TableMetadataCommonFields(IcebergBaseModel):
     partition specs for the table. This is used to ensure partition fields
     are always assigned an unused ID when evolving specs."""
 
-    properties: Dict[str, str] = Field(default_factory=dict)
+    properties: dict[str, str] = Field(default_factory=dict)
     """A string to string map of table properties. This is used to
     control settings that affect reading and writing and is not intended
     to be used for arbitrary metadata. For example, commit.retry.num-retries
@@ -177,13 +177,13 @@ class TableMetadataCommonFields(IcebergBaseModel):
     current_snapshot_id: int | None = Field(alias="current-snapshot-id", default=None)
     """ID of the current table snapshot."""
 
-    snapshots: List[Snapshot] = Field(default_factory=list)
+    snapshots: list[Snapshot] = Field(default_factory=list)
     """A list of valid snapshots. Valid snapshots are snapshots for which
     all data files exist in the file system. A data file must not be
     deleted from the file system until the last snapshot in which it was
     listed is garbage collected."""
 
-    snapshot_log: List[SnapshotLogEntry] = Field(alias="snapshot-log", default_factory=list)
+    snapshot_log: list[SnapshotLogEntry] = Field(alias="snapshot-log", default_factory=list)
     """A list (optional) of timestamp and snapshot ID pairs that encodes
     changes to the current snapshot for the table. Each time the
     current-snapshot-id is changed, a new entry should be added with the
@@ -191,7 +191,7 @@ class TableMetadataCommonFields(IcebergBaseModel):
     expired from the list of valid snapshots, all entries before a snapshot
     that has expired should be removed."""
 
-    metadata_log: List[MetadataLogEntry] = Field(alias="metadata-log", default_factory=list)
+    metadata_log: list[MetadataLogEntry] = Field(alias="metadata-log", default_factory=list)
     """A list (optional) of timestamp and metadata file location pairs that
     encodes changes to the previous metadata files for the table. Each time
     a new metadata file is created, a new entry of the previous metadata
@@ -199,7 +199,7 @@ class TableMetadataCommonFields(IcebergBaseModel):
     remove oldest metadata log entries and keep a fixed-size log of the most
     recent entries after a commit."""
 
-    sort_orders: List[SortOrder] = Field(alias="sort-orders", default_factory=list)
+    sort_orders: list[SortOrder] = Field(alias="sort-orders", default_factory=list)
     """A list of sort orders, stored as full sort order objects."""
 
     default_sort_order_id: int = Field(alias="default-sort-order-id", default=UNSORTED_SORT_ORDER_ID)
@@ -207,14 +207,14 @@ class TableMetadataCommonFields(IcebergBaseModel):
     writers, but is not used when reading because reads use the specs stored
      in manifest files."""
 
-    refs: Dict[str, SnapshotRef] = Field(default_factory=dict)
+    refs: dict[str, SnapshotRef] = Field(default_factory=dict)
     """A map of snapshot references.
     The map keys are the unique snapshot reference names in the table,
     and the map values are snapshot reference objects.
     There is always a main branch reference pointing to the
     current-snapshot-id even if the refs map is null."""
 
-    statistics: List[StatisticsFile] = Field(default_factory=list)
+    statistics: list[StatisticsFile] = Field(default_factory=list)
     """A optional list of table statistics files.
     Table statistics files are valid Puffin files. Statistics are
     informational. A reader can choose to ignore statistics
@@ -222,7 +222,7 @@ class TableMetadataCommonFields(IcebergBaseModel):
     table correctly. A table can contain many statistics files
     associated with different table snapshots."""
 
-    partition_statistics: List[PartitionStatisticsFile] = Field(alias="partition-statistics", default_factory=list)
+    partition_statistics: list[PartitionStatisticsFile] = Field(alias="partition-statistics", default_factory=list)
     """A optional list of partition statistics files.
     Partition statistics are not required for reading or planning
     and readers may ignore them. Each table snapshot may be associated
@@ -232,7 +232,7 @@ class TableMetadataCommonFields(IcebergBaseModel):
 
     # validators
     @field_validator("properties", mode="before")
-    def transform_properties_dict_value_to_str(cls, properties: Properties) -> Dict[str, str]:
+    def transform_properties_dict_value_to_str(cls, properties: Properties) -> dict[str, str]:
         return transform_dict_value_to_str(properties)
 
     def snapshot_by_id(self, snapshot_id: int) -> Snapshot | None:
@@ -258,7 +258,7 @@ class TableMetadataCommonFields(IcebergBaseModel):
         """Return the partition spec of this table."""
         return next(spec for spec in self.partition_specs if spec.spec_id == self.default_spec_id)
 
-    def specs(self) -> Dict[int, PartitionSpec]:
+    def specs(self) -> dict[int, PartitionSpec]:
         """Return a dict the partition specs this table."""
         return {spec.spec_id: spec for spec in self.partition_specs}
 
@@ -323,7 +323,7 @@ class TableMetadataCommonFields(IcebergBaseModel):
         return current_snapshot_id
 
     @field_serializer("snapshots")
-    def serialize_snapshots(self, snapshots: List[Snapshot]) -> List[Snapshot]:
+    def serialize_snapshots(self, snapshots: list[Snapshot]) -> list[Snapshot]:
         # Snapshot field `sequence-number` should not be written for v1 metadata
         if self.format_version == 1:
             return [snapshot.model_copy(update={"sequence_number": None}) for snapshot in snapshots]
@@ -361,7 +361,7 @@ class TableMetadataV1(TableMetadataCommonFields, IcebergBaseModel):
     # to the owner of the table.
 
     @model_validator(mode="before")
-    def cleanup_snapshot_id(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+    def cleanup_snapshot_id(cls, data: dict[str, Any]) -> dict[str, Any]:
         return cleanup_snapshot_id(data)
 
     @model_validator(mode="after")
@@ -369,7 +369,7 @@ class TableMetadataV1(TableMetadataCommonFields, IcebergBaseModel):
         return construct_refs(self)
 
     @model_validator(mode="before")
-    def set_v2_compatible_defaults(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+    def set_v2_compatible_defaults(cls, data: dict[str, Any]) -> dict[str, Any]:
         """Set default values to be compatible with the format v2.
 
         Args:
@@ -387,7 +387,7 @@ class TableMetadataV1(TableMetadataCommonFields, IcebergBaseModel):
         return data
 
     @model_validator(mode="before")
-    def construct_schemas(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+    def construct_schemas(cls, data: dict[str, Any]) -> dict[str, Any]:
         """Convert the schema into schemas.
 
         For V1 schemas is optional, and if they aren't set, we'll set them
@@ -406,7 +406,7 @@ class TableMetadataV1(TableMetadataCommonFields, IcebergBaseModel):
         return data
 
     @model_validator(mode="before")
-    def construct_partition_specs(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+    def construct_partition_specs(cls, data: dict[str, Any]) -> dict[str, Any]:
         """Convert the partition_spec into partition_specs.
 
         For V1 partition_specs is optional, and if they aren't set, we'll set them
@@ -441,7 +441,7 @@ class TableMetadataV1(TableMetadataCommonFields, IcebergBaseModel):
         return data
 
     @model_validator(mode="before")
-    def set_sort_orders(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+    def set_sort_orders(cls, data: dict[str, Any]) -> dict[str, Any]:
         """Set the sort_orders if not provided.
 
         For V1 sort_orders is optional, and if they aren't set, we'll set them
@@ -470,7 +470,7 @@ class TableMetadataV1(TableMetadataCommonFields, IcebergBaseModel):
     """The table’s current schema. (Deprecated: use schemas and
     current-schema-id instead)."""
 
-    partition_spec: List[Dict[str, Any]] = Field(alias="partition-spec", default_factory=list)
+    partition_spec: list[dict[str, Any]] = Field(alias="partition-spec", default_factory=list)
     """The table’s current partition spec, stored as only fields.
     Note that this is used by writers to partition data, but is
     not used when reading because reads use the specs stored in
@@ -490,7 +490,7 @@ class TableMetadataV2(TableMetadataCommonFields, IcebergBaseModel):
     """
 
     @model_validator(mode="before")
-    def cleanup_snapshot_id(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+    def cleanup_snapshot_id(cls, data: dict[str, Any]) -> dict[str, Any]:
         return cleanup_snapshot_id(data)
 
     @model_validator(mode="after")
@@ -534,7 +534,7 @@ class TableMetadataV3(TableMetadataCommonFields, IcebergBaseModel):
     """
 
     @model_validator(mode="before")
-    def cleanup_snapshot_id(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+    def cleanup_snapshot_id(cls, data: dict[str, Any]) -> dict[str, Any]:
         return cleanup_snapshot_id(data)
 
     @model_validator(mode="after")
@@ -655,7 +655,7 @@ class TableMetadataUtil:
             raise ValidationError(e) from e
 
     @staticmethod
-    def parse_obj(data: Dict[str, Any]) -> TableMetadata:
+    def parse_obj(data: dict[str, Any]) -> TableMetadata:
         if "format-version" not in data:
             raise ValidationError(f"Missing format-version in TableMetadata: {data}")
         format_version = data["format-version"]

--- a/pyiceberg/table/puffin.py
+++ b/pyiceberg/table/puffin.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import math
-from typing import TYPE_CHECKING, Dict, List, Literal
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import Field
 from pyroaring import BitMap, FrozenBitMap
@@ -32,7 +32,7 @@ MAX_JAVA_SIGNED = int(math.pow(2, 31)) - 1
 PROPERTY_REFERENCED_DATA_FILE = "referenced-data-file"
 
 
-def _deserialize_bitmap(pl: bytes) -> List[BitMap]:
+def _deserialize_bitmap(pl: bytes) -> list[BitMap]:
     number_of_bitmaps = int.from_bytes(pl[0:8], byteorder="little")
     pl = pl[8:]
 
@@ -64,21 +64,21 @@ def _deserialize_bitmap(pl: bytes) -> List[BitMap]:
 
 class PuffinBlobMetadata(IcebergBaseModel):
     type: Literal["deletion-vector-v1"] = Field()
-    fields: List[int] = Field()
+    fields: list[int] = Field()
     snapshot_id: int = Field(alias="snapshot-id")
     sequence_number: int = Field(alias="sequence-number")
     offset: int = Field()
     length: int = Field()
     compression_codec: str | None = Field(alias="compression-codec", default=None)
-    properties: Dict[str, str] = Field(default_factory=dict)
+    properties: dict[str, str] = Field(default_factory=dict)
 
 
 class Footer(IcebergBaseModel):
-    blobs: List[PuffinBlobMetadata] = Field()
-    properties: Dict[str, str] = Field(default_factory=dict)
+    blobs: list[PuffinBlobMetadata] = Field()
+    properties: dict[str, str] = Field(default_factory=dict)
 
 
-def _bitmaps_to_chunked_array(bitmaps: List[BitMap]) -> "pa.ChunkedArray":
+def _bitmaps_to_chunked_array(bitmaps: list[BitMap]) -> "pa.ChunkedArray":
     import pyarrow as pa
 
     return pa.chunked_array([(key_pos << 32) + pos for pos in bitmap] for key_pos, bitmap in enumerate(bitmaps))
@@ -86,7 +86,7 @@ def _bitmaps_to_chunked_array(bitmaps: List[BitMap]) -> "pa.ChunkedArray":
 
 class PuffinFile:
     footer: Footer
-    _deletion_vectors: Dict[str, List[BitMap]]
+    _deletion_vectors: dict[str, list[BitMap]]
 
     def __init__(self, puffin: bytes) -> None:
         for magic_bytes in [puffin[:4], puffin[-4:]]:
@@ -112,5 +112,5 @@ class PuffinFile:
             for blob in self.footer.blobs
         }
 
-    def to_vector(self) -> Dict[str, "pa.ChunkedArray"]:
+    def to_vector(self) -> dict[str, "pa.ChunkedArray"]:
         return {path: _bitmaps_to_chunked_array(bitmaps) for path, bitmaps in self._deletion_vectors.items()}

--- a/pyiceberg/table/snapshots.py
+++ b/pyiceberg/table/snapshots.py
@@ -20,7 +20,7 @@ import time
 import warnings
 from collections import defaultdict
 from enum import Enum
-from typing import TYPE_CHECKING, Any, DefaultDict, Dict, Iterable, List, Mapping
+from typing import TYPE_CHECKING, Any, Iterable, Mapping
 
 from pydantic import Field, PrivateAttr, model_serializer
 
@@ -154,8 +154,8 @@ class UpdateMetrics:
         else:
             raise ValueError(f"Unknown data file content: {data_file.content}")
 
-    def to_dict(self) -> Dict[str, str]:
-        properties: Dict[str, str] = {}
+    def to_dict(self) -> dict[str, str]:
+        properties: dict[str, str] = {}
         set_when_positive(properties, self.added_file_size, ADDED_FILE_SIZE)
         set_when_positive(properties, self.removed_file_size, REMOVED_FILE_SIZE)
         set_when_positive(properties, self.added_data_files, ADDED_DATA_FILES)
@@ -183,7 +183,7 @@ class Summary(IcebergBaseModel, Mapping[str, str]):
     """
 
     operation: Operation = Field()
-    _additional_properties: Dict[str, str] = PrivateAttr()
+    _additional_properties: dict[str, str] = PrivateAttr()
 
     def __init__(self, operation: Operation | None = None, **data: Any) -> None:
         if operation is None:
@@ -212,14 +212,14 @@ class Summary(IcebergBaseModel, Mapping[str, str]):
         return 1 + len(self._additional_properties)
 
     @model_serializer
-    def ser_model(self) -> Dict[str, str]:
+    def ser_model(self) -> dict[str, str]:
         return {
             "operation": str(self.operation.value),
             **self._additional_properties,
         }
 
     @property
-    def additional_properties(self) -> Dict[str, str]:
+    def additional_properties(self) -> dict[str, str]:
         return self._additional_properties
 
     def __repr__(self) -> str:
@@ -275,7 +275,7 @@ class Snapshot(IcebergBaseModel):
         filtered_fields = [field for field in fields if field is not None]
         return f"Snapshot({', '.join(filtered_fields)})"
 
-    def manifests(self, io: FileIO) -> List[ManifestFile]:
+    def manifests(self, io: FileIO) -> list[ManifestFile]:
         """Return the manifests for the given snapshot."""
         return list(_manifests(io, self.manifest_list))
 
@@ -292,7 +292,7 @@ class SnapshotLogEntry(IcebergBaseModel):
 
 class SnapshotSummaryCollector:
     metrics: UpdateMetrics
-    partition_metrics: DefaultDict[str, UpdateMetrics]
+    partition_metrics: defaultdict[str, UpdateMetrics]
     max_changed_partitions_for_summaries: int
 
     def __init__(self, partition_summary_limit: int = 0) -> None:
@@ -324,7 +324,7 @@ class SnapshotSummaryCollector:
         else:
             partition_metrics.remove_file(file)
 
-    def build(self) -> Dict[str, str]:
+    def build(self) -> dict[str, str]:
         properties = self.metrics.to_dict()
         changed_partitions_size = len(self.partition_metrics)
         set_when_positive(properties, changed_partitions_size, CHANGED_PARTITION_COUNT_PROP)
@@ -447,7 +447,7 @@ def update_snapshot_summaries(
     return summary
 
 
-def set_when_positive(properties: Dict[str, str], num: int, property_name: str) -> None:
+def set_when_positive(properties: dict[str, str], num: int, property_name: str) -> None:
     if num > 0:
         properties[property_name] = str(num)
 

--- a/pyiceberg/table/sorting.py
+++ b/pyiceberg/table/sorting.py
@@ -16,7 +16,7 @@
 # under the License.
 # pylint: disable=keyword-arg-before-vararg
 from enum import Enum
-from typing import Annotated, Any, Callable, Dict, List
+from typing import Annotated, Any, Callable
 
 from pydantic import (
     BeforeValidator,
@@ -88,7 +88,7 @@ class SortField(IcebergBaseModel):
         super().__init__(**data)
 
     @model_validator(mode="before")
-    def set_null_order(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+    def set_null_order(cls, values: dict[str, Any]) -> dict[str, Any]:
         values["direction"] = values["direction"] if values.get("direction") else SortDirection.ASC
         if not values.get("null-order"):
             values["null-order"] = NullOrder.NULLS_FIRST if values["direction"] == SortDirection.ASC else NullOrder.NULLS_LAST
@@ -144,7 +144,7 @@ class SortOrder(IcebergBaseModel):
     """
 
     order_id: int = Field(alias="order-id", default=INITIAL_SORT_ORDER_ID)
-    fields: List[SortField] = Field(default_factory=list)
+    fields: list[SortField] = Field(default_factory=list)
 
     def __init__(self, *fields: SortField, **data: Any):
         if fields:

--- a/pyiceberg/table/statistics.py
+++ b/pyiceberg/table/statistics.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Dict, List, Literal
+from typing import Literal
 
 from pydantic import Field
 
@@ -25,8 +25,8 @@ class BlobMetadata(IcebergBaseModel):
     type: Literal["apache-datasketches-theta-v1", "deletion-vector-v1"]
     snapshot_id: int = Field(alias="snapshot-id")
     sequence_number: int = Field(alias="sequence-number")
-    fields: List[int]
-    properties: Dict[str, str] | None = None
+    fields: list[int]
+    properties: dict[str, str] | None = None
 
 
 class StatisticsCommonFields(IcebergBaseModel):
@@ -40,7 +40,7 @@ class StatisticsCommonFields(IcebergBaseModel):
 class StatisticsFile(StatisticsCommonFields):
     file_footer_size_in_bytes: int = Field(alias="file-footer-size-in-bytes")
     key_metadata: str | None = Field(alias="key-metadata", default=None)
-    blob_metadata: List[BlobMetadata] = Field(alias="blob-metadata")
+    blob_metadata: list[BlobMetadata] = Field(alias="blob-metadata")
 
 
 class PartitionStatisticsFile(StatisticsCommonFields):
@@ -48,7 +48,7 @@ class PartitionStatisticsFile(StatisticsCommonFields):
 
 
 def filter_statistics_by_snapshot_id(
-    statistics: List[StatisticsFile | PartitionStatisticsFile],
+    statistics: list[StatisticsFile | PartitionStatisticsFile],
     reject_snapshot_id: int,
-) -> List[StatisticsFile | PartitionStatisticsFile]:
+) -> list[StatisticsFile | PartitionStatisticsFile]:
     return [stat for stat in statistics if stat.snapshot_id != reject_snapshot_id]

--- a/pyiceberg/table/update/snapshot.py
+++ b/pyiceberg/table/update/snapshot.py
@@ -24,7 +24,7 @@ from collections import defaultdict
 from concurrent.futures import Future
 from datetime import datetime
 from functools import cached_property
-from typing import TYPE_CHECKING, Callable, Dict, Generic, List, Set, Tuple
+from typing import TYPE_CHECKING, Callable, Generic
 
 from sortedcontainers import SortedList
 
@@ -106,9 +106,9 @@ class _SnapshotProducer(UpdateTableMetadata[U], Generic[U]):
     _operation: Operation
     _snapshot_id: int
     _parent_snapshot_id: int | None
-    _added_data_files: List[DataFile]
+    _added_data_files: list[DataFile]
     _manifest_num_counter: itertools.count[int]
-    _deleted_data_files: Set[DataFile]
+    _deleted_data_files: set[DataFile]
     _compression: AvroCompressionCodec
     _target_branch: str | None
 
@@ -118,7 +118,7 @@ class _SnapshotProducer(UpdateTableMetadata[U], Generic[U]):
         transaction: Transaction,
         io: FileIO,
         commit_uuid: uuid.UUID | None = None,
-        snapshot_properties: Dict[str, str] = EMPTY_DICT,
+        snapshot_properties: dict[str, str] = EMPTY_DICT,
         branch: str | None = MAIN_BRANCH,
     ) -> None:
         super().__init__(transaction)
@@ -157,7 +157,7 @@ class _SnapshotProducer(UpdateTableMetadata[U], Generic[U]):
         self._deleted_data_files.add(data_file)
         return self
 
-    def _calculate_added_rows(self, manifests: List[ManifestFile]) -> int:
+    def _calculate_added_rows(self, manifests: list[ManifestFile]) -> int:
         """Calculate the number of added rows from a list of manifest files."""
         added_rows = 0
         for manifest in manifests:
@@ -171,17 +171,17 @@ class _SnapshotProducer(UpdateTableMetadata[U], Generic[U]):
         return added_rows
 
     @abstractmethod
-    def _deleted_entries(self) -> List[ManifestEntry]: ...
+    def _deleted_entries(self) -> list[ManifestEntry]: ...
 
     @abstractmethod
-    def _existing_manifests(self) -> List[ManifestFile]: ...
+    def _existing_manifests(self) -> list[ManifestFile]: ...
 
-    def _process_manifests(self, manifests: List[ManifestFile]) -> List[ManifestFile]:
+    def _process_manifests(self, manifests: list[ManifestFile]) -> list[ManifestFile]:
         """To perform any post-processing on the manifests before writing them to the new snapshot."""
         return manifests
 
-    def _manifests(self) -> List[ManifestFile]:
-        def _write_added_manifest() -> List[ManifestFile]:
+    def _manifests(self) -> list[ManifestFile]:
+        def _write_added_manifest() -> list[ManifestFile]:
             if self._added_data_files:
                 with write_manifest(
                     format_version=self._transaction.table_metadata.format_version,
@@ -205,12 +205,12 @@ class _SnapshotProducer(UpdateTableMetadata[U], Generic[U]):
             else:
                 return []
 
-        def _write_delete_manifest() -> List[ManifestFile]:
+        def _write_delete_manifest() -> list[ManifestFile]:
             # Check if we need to mark the files as deleted
             deleted_entries = self._deleted_entries()
             if len(deleted_entries) > 0:
                 deleted_manifests = []
-                partition_groups: Dict[int, List[ManifestEntry]] = defaultdict(list)
+                partition_groups: dict[int, list[ManifestEntry]] = defaultdict(list)
                 for deleted_entry in deleted_entries:
                     partition_groups[deleted_entry.data_file.spec_id].append(deleted_entry)
                 for spec_id, entries in partition_groups.items():
@@ -237,7 +237,7 @@ class _SnapshotProducer(UpdateTableMetadata[U], Generic[U]):
 
         return self._process_manifests(added_manifests.result() + delete_manifests.result() + existing_manifests.result())
 
-    def _summary(self, snapshot_properties: Dict[str, str] = EMPTY_DICT) -> Summary:
+    def _summary(self, snapshot_properties: dict[str, str] = EMPTY_DICT) -> Summary:
         from pyiceberg.table import TableProperties
 
         # avoid copying metadata for each data file
@@ -364,7 +364,7 @@ class _SnapshotProducer(UpdateTableMetadata[U], Generic[U]):
         file_path = location_provider.new_metadata_location(file_name)
         return self._io.new_output(file_path)
 
-    def fetch_manifest_entry(self, manifest: ManifestFile, discard_deleted: bool = True) -> List[ManifestEntry]:
+    def fetch_manifest_entry(self, manifest: ManifestFile, discard_deleted: bool = True) -> list[ManifestEntry]:
         return manifest.fetch_manifest_entry(io=self._io, discard_deleted=discard_deleted)
 
 
@@ -388,7 +388,7 @@ class _DeleteFiles(_SnapshotProducer["_DeleteFiles"]):
         io: FileIO,
         branch: str | None = MAIN_BRANCH,
         commit_uuid: uuid.UUID | None = None,
-        snapshot_properties: Dict[str, str] = EMPTY_DICT,
+        snapshot_properties: dict[str, str] = EMPTY_DICT,
     ):
         super().__init__(operation, transaction, io, commit_uuid, snapshot_properties, branch)
         self._predicate = AlwaysFalse()
@@ -421,7 +421,7 @@ class _DeleteFiles(_SnapshotProducer["_DeleteFiles"]):
         self._case_sensitive = case_sensitive
 
     @cached_property
-    def _compute_deletes(self) -> Tuple[List[ManifestFile], List[ManifestEntry], bool]:
+    def _compute_deletes(self) -> tuple[list[ManifestFile], list[ManifestEntry], bool]:
         """Computes all the delete operation and cache it when nothing changes.
 
         Returns:
@@ -441,7 +441,7 @@ class _DeleteFiles(_SnapshotProducer["_DeleteFiles"]):
                 data_file=entry.data_file,
             )
 
-        manifest_evaluators: Dict[int, Callable[[ManifestFile], bool]] = KeyDefaultDict(self._build_manifest_evaluator)
+        manifest_evaluators: dict[int, Callable[[ManifestFile], bool]] = KeyDefaultDict(self._build_manifest_evaluator)
         strict_metrics_evaluator = _StrictMetricsEvaluator(schema, self._predicate, case_sensitive=self._case_sensitive).eval
         inclusive_metrics_evaluator = _InclusiveMetricsEvaluator(
             schema, self._predicate, case_sensitive=self._case_sensitive
@@ -501,10 +501,10 @@ class _DeleteFiles(_SnapshotProducer["_DeleteFiles"]):
 
         return existing_manifests, total_deleted_entries, partial_rewrites_needed
 
-    def _existing_manifests(self) -> List[ManifestFile]:
+    def _existing_manifests(self) -> list[ManifestFile]:
         return self._compute_deletes[0]
 
-    def _deleted_entries(self) -> List[ManifestEntry]:
+    def _deleted_entries(self) -> list[ManifestEntry]:
         return self._compute_deletes[1]
 
     @property
@@ -519,7 +519,7 @@ class _DeleteFiles(_SnapshotProducer["_DeleteFiles"]):
 
 
 class _FastAppendFiles(_SnapshotProducer["_FastAppendFiles"]):
-    def _existing_manifests(self) -> List[ManifestFile]:
+    def _existing_manifests(self) -> list[ManifestFile]:
         """To determine if there are any existing manifest files.
 
         A fast append will add another ManifestFile to the ManifestList.
@@ -539,7 +539,7 @@ class _FastAppendFiles(_SnapshotProducer["_FastAppendFiles"]):
 
         return existing_manifests
 
-    def _deleted_entries(self) -> List[ManifestEntry]:
+    def _deleted_entries(self) -> list[ManifestEntry]:
         """To determine if we need to record any deleted manifest entries.
 
         In case of an append, nothing is deleted.
@@ -559,7 +559,7 @@ class _MergeAppendFiles(_FastAppendFiles):
         io: FileIO,
         branch: str | None = MAIN_BRANCH,
         commit_uuid: uuid.UUID | None = None,
-        snapshot_properties: Dict[str, str] = EMPTY_DICT,
+        snapshot_properties: dict[str, str] = EMPTY_DICT,
     ) -> None:
         from pyiceberg.table import TableProperties
 
@@ -580,7 +580,7 @@ class _MergeAppendFiles(_FastAppendFiles):
             TableProperties.MANIFEST_MERGE_ENABLED_DEFAULT,
         )
 
-    def _process_manifests(self, manifests: List[ManifestFile]) -> List[ManifestFile]:
+    def _process_manifests(self, manifests: list[ManifestFile]) -> list[ManifestFile]:
         """To perform any post-processing on the manifests before writing them to the new snapshot.
 
         In _MergeAppendFiles, we merge manifests based on the target size and the minimum count to merge
@@ -605,7 +605,7 @@ class _OverwriteFiles(_SnapshotProducer["_OverwriteFiles"]):
     Data and delete files were added and removed in a logical overwrite operation.
     """
 
-    def _existing_manifests(self) -> List[ManifestFile]:
+    def _existing_manifests(self) -> list[ManifestFile]:
         """Determine if there are any existing manifest files."""
         existing_files = []
 
@@ -641,7 +641,7 @@ class _OverwriteFiles(_SnapshotProducer["_OverwriteFiles"]):
                         existing_files.append(writer.to_manifest_file())
         return existing_files
 
-    def _deleted_entries(self) -> List[ManifestEntry]:
+    def _deleted_entries(self) -> list[ManifestEntry]:
         """To determine if we need to record any deleted entries.
 
         With a full overwrite all the entries are considered deleted.
@@ -656,7 +656,7 @@ class _OverwriteFiles(_SnapshotProducer["_OverwriteFiles"]):
 
             executor = ExecutorFactory.get_or_create()
 
-            def _get_entries(manifest: ManifestFile) -> List[ManifestEntry]:
+            def _get_entries(manifest: ManifestFile) -> list[ManifestEntry]:
                 return [
                     ManifestEntry.from_args(
                         status=ManifestEntryStatus.DELETED,
@@ -679,14 +679,14 @@ class UpdateSnapshot:
     _transaction: Transaction
     _io: FileIO
     _branch: str | None
-    _snapshot_properties: Dict[str, str]
+    _snapshot_properties: dict[str, str]
 
     def __init__(
         self,
         transaction: Transaction,
         io: FileIO,
         branch: str | None = MAIN_BRANCH,
-        snapshot_properties: Dict[str, str] = EMPTY_DICT,
+        snapshot_properties: dict[str, str] = EMPTY_DICT,
     ) -> None:
         self._transaction = transaction
         self._io = io
@@ -747,13 +747,13 @@ class _ManifestMergeManager(Generic[U]):
         self._merge_enabled = merge_enabled
         self._snapshot_producer = snapshot_producer
 
-    def _group_by_spec(self, manifests: List[ManifestFile]) -> Dict[int, List[ManifestFile]]:
+    def _group_by_spec(self, manifests: list[ManifestFile]) -> dict[int, list[ManifestFile]]:
         groups = defaultdict(list)
         for manifest in manifests:
             groups[manifest.partition_spec_id].append(manifest)
         return groups
 
-    def _create_manifest(self, spec_id: int, manifest_bin: List[ManifestFile]) -> ManifestFile:
+    def _create_manifest(self, spec_id: int, manifest_bin: list[ManifestFile]) -> ManifestFile:
         with self._snapshot_producer.new_manifest_writer(spec=self._snapshot_producer.spec(spec_id)) as writer:
             for manifest in manifest_bin:
                 for entry in self._snapshot_producer.fetch_manifest_entry(manifest=manifest, discard_deleted=False):
@@ -769,11 +769,11 @@ class _ManifestMergeManager(Generic[U]):
 
         return writer.to_manifest_file()
 
-    def _merge_group(self, first_manifest: ManifestFile, spec_id: int, manifests: List[ManifestFile]) -> List[ManifestFile]:
+    def _merge_group(self, first_manifest: ManifestFile, spec_id: int, manifests: list[ManifestFile]) -> list[ManifestFile]:
         packer: ListPacker[ManifestFile] = ListPacker(target_weight=self._target_size_bytes, lookback=1, largest_bin_first=False)
-        bins: List[List[ManifestFile]] = packer.pack_end(manifests, lambda m: m.manifest_length)
+        bins: list[list[ManifestFile]] = packer.pack_end(manifests, lambda m: m.manifest_length)
 
-        def merge_bin(manifest_bin: List[ManifestFile]) -> List[ManifestFile]:
+        def merge_bin(manifest_bin: list[ManifestFile]) -> list[ManifestFile]:
             output_manifests = []
             if len(manifest_bin) == 1:
                 output_manifests.append(manifest_bin[0])
@@ -792,15 +792,15 @@ class _ManifestMergeManager(Generic[U]):
 
         # for consistent ordering, we need to maintain future order
         futures_index = {f: i for i, f in enumerate(futures)}
-        completed_futures: SortedList[Future[List[ManifestFile]]] = SortedList(iterable=[], key=lambda f: futures_index[f])
+        completed_futures: SortedList[Future[list[ManifestFile]]] = SortedList(iterable=[], key=lambda f: futures_index[f])
         for future in concurrent.futures.as_completed(futures):
             completed_futures.add(future)
 
-        bin_results: List[List[ManifestFile]] = [f.result() for f in completed_futures if f.result()]
+        bin_results: list[list[ManifestFile]] = [f.result() for f in completed_futures if f.result()]
 
         return [manifest for bin_result in bin_results for manifest in bin_result]
 
-    def merge_manifests(self, manifests: List[ManifestFile]) -> List[ManifestFile]:
+    def merge_manifests(self, manifests: list[ManifestFile]) -> list[ManifestFile]:
         if not self._merge_enabled or len(manifests) == 0:
             return manifests
 
@@ -830,8 +830,8 @@ class ManageSnapshots(UpdateTableMetadata["ManageSnapshots"]):
        ms.create_tag(snapshot_id1, "Tag_A").create_tag(snapshot_id2, "Tag_B")
     """
 
-    _updates: Tuple[TableUpdate, ...]
-    _requirements: Tuple[TableRequirement, ...]
+    _updates: tuple[TableUpdate, ...]
+    _requirements: tuple[TableRequirement, ...]
 
     def __init__(self, transaction: Transaction) -> None:
         super().__init__(transaction)
@@ -949,9 +949,9 @@ class ExpireSnapshots(UpdateTableMetadata["ExpireSnapshots"]):
     Pending changes are applied on commit.
     """
 
-    _updates: Tuple[TableUpdate, ...]
-    _requirements: Tuple[TableRequirement, ...]
-    _snapshot_ids_to_expire: Set[int]
+    _updates: tuple[TableUpdate, ...]
+    _requirements: tuple[TableRequirement, ...]
+    _snapshot_ids_to_expire: set[int]
 
     def __init__(self, transaction: Transaction) -> None:
         super().__init__(transaction)
@@ -976,7 +976,7 @@ class ExpireSnapshots(UpdateTableMetadata["ExpireSnapshots"]):
         self._updates += (update,)
         return self._updates, self._requirements
 
-    def _get_protected_snapshot_ids(self) -> Set[int]:
+    def _get_protected_snapshot_ids(self) -> set[int]:
         """
         Get the IDs of protected snapshots.
 
@@ -1012,7 +1012,7 @@ class ExpireSnapshots(UpdateTableMetadata["ExpireSnapshots"]):
 
         return self
 
-    def by_ids(self, snapshot_ids: List[int]) -> ExpireSnapshots:
+    def by_ids(self, snapshot_ids: list[int]) -> ExpireSnapshots:
         """
         Expire multiple snapshots by their IDs.
 

--- a/pyiceberg/table/update/sorting.py
+++ b/pyiceberg/table/update/sorting.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, List, Tuple
+from typing import TYPE_CHECKING, Any
 
 from pyiceberg.table.sorting import INITIAL_SORT_ORDER_ID, UNSORTED_SORT_ORDER, NullOrder, SortDirection, SortField, SortOrder
 from pyiceberg.table.update import (
@@ -38,11 +38,11 @@ class UpdateSortOrder(UpdateTableMetadata["UpdateSortOrder"]):
     _transaction: Transaction
     _last_assigned_order_id: int | None
     _case_sensitive: bool
-    _fields: List[SortField]
+    _fields: list[SortField]
 
     def __init__(self, transaction: Transaction, case_sensitive: bool = True) -> None:
         super().__init__(transaction)
-        self._fields: List[SortField] = []
+        self._fields: list[SortField] = []
         self._case_sensitive: bool = case_sensitive
         self._last_assigned_order_id: int | None = None
 
@@ -118,8 +118,8 @@ class UpdateSortOrder(UpdateTableMetadata["UpdateSortOrder"]):
     def _commit(self) -> UpdatesAndRequirements:
         """Apply the pending changes and commit."""
         new_sort_order = self._apply()
-        requirements: Tuple[TableRequirement, ...] = ()
-        updates: Tuple[TableUpdate, ...] = ()
+        requirements: tuple[TableRequirement, ...] = ()
+        updates: tuple[TableUpdate, ...] = ()
 
         if (
             self._transaction.table_metadata.default_sort_order_id != new_sort_order.order_id

--- a/pyiceberg/table/update/spec.py
+++ b/pyiceberg/table/update/spec.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List, Set, Tuple
+from typing import TYPE_CHECKING, Any
 
 from pyiceberg.expressions import (
     Reference,
@@ -48,15 +48,15 @@ if TYPE_CHECKING:
 
 class UpdateSpec(UpdateTableMetadata["UpdateSpec"]):
     _transaction: Transaction
-    _name_to_field: Dict[str, PartitionField] = {}
-    _name_to_added_field: Dict[str, PartitionField] = {}
-    _transform_to_field: Dict[Tuple[int, str], PartitionField] = {}
-    _transform_to_added_field: Dict[Tuple[int, str], PartitionField] = {}
-    _renames: Dict[str, str] = {}
-    _added_time_fields: Dict[int, PartitionField] = {}
+    _name_to_field: dict[str, PartitionField] = {}
+    _name_to_added_field: dict[str, PartitionField] = {}
+    _transform_to_field: dict[tuple[int, str], PartitionField] = {}
+    _transform_to_added_field: dict[tuple[int, str], PartitionField] = {}
+    _renames: dict[str, str] = {}
+    _added_time_fields: dict[int, PartitionField] = {}
     _case_sensitive: bool
-    _adds: List[PartitionField]
-    _deletes: Set[int]
+    _adds: list[PartitionField]
+    _deletes: set[int]
     _last_assigned_partition_id: int
 
     def __init__(self, transaction: Transaction, case_sensitive: bool = True) -> None:
@@ -157,8 +157,8 @@ class UpdateSpec(UpdateTableMetadata["UpdateSpec"]):
 
     def _commit(self) -> UpdatesAndRequirements:
         new_spec = self._apply()
-        updates: Tuple[TableUpdate, ...] = ()
-        requirements: Tuple[TableRequirement, ...] = ()
+        updates: tuple[TableUpdate, ...] = ()
+        requirements: tuple[TableRequirement, ...] = ()
 
         if self._transaction.table_metadata.default_spec_id != new_spec.spec_id:
             if new_spec.spec_id not in self._transaction.table_metadata.specs():
@@ -180,7 +180,7 @@ class UpdateSpec(UpdateTableMetadata["UpdateSpec"]):
 
     def _apply(self) -> PartitionSpec:
         def _check_and_add_partition_name(
-            schema: Schema, name: str, source_id: int, transform: Transform[Any, Any], partition_names: Set[str]
+            schema: Schema, name: str, source_id: int, transform: Transform[Any, Any], partition_names: set[str]
         ) -> None:
             from pyiceberg.partitioning import validate_partition_name
 
@@ -188,13 +188,13 @@ class UpdateSpec(UpdateTableMetadata["UpdateSpec"]):
             partition_names.add(name)
 
         def _add_new_field(
-            schema: Schema, source_id: int, field_id: int, name: str, transform: Transform[Any, Any], partition_names: Set[str]
+            schema: Schema, source_id: int, field_id: int, name: str, transform: Transform[Any, Any], partition_names: set[str]
         ) -> PartitionField:
             _check_and_add_partition_name(schema, name, source_id, transform, partition_names)
             return PartitionField(source_id, field_id, transform, name)
 
         partition_fields = []
-        partition_names: Set[str] = set()
+        partition_names: set[str] = set()
         for field in self._transaction.table_metadata.spec().fields:
             if field.field_id not in self._deletes:
                 renamed = self._renames.get(field.name)
@@ -267,7 +267,7 @@ class UpdateSpec(UpdateTableMetadata["UpdateSpec"]):
                 new_spec_id = spec.spec_id + 1
         return PartitionSpec(*partition_fields, spec_id=new_spec_id)
 
-    def _partition_field(self, transform_key: Tuple[int, Transform[Any, Any]], name: str | None) -> PartitionField:
+    def _partition_field(self, transform_key: tuple[int, Transform[Any, Any]], name: str | None) -> PartitionField:
         if self._transaction.table_metadata.format_version == 2:
             source_id, transform = transform_key
             historical_fields = []

--- a/pyiceberg/table/update/statistics.py
+++ b/pyiceberg/table/update/statistics.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING
 
 from pyiceberg.table.statistics import StatisticsFile
 from pyiceberg.table.update import (
@@ -47,7 +47,7 @@ class UpdateStatistics(UpdateTableMetadata["UpdateStatistics"]):
         update.remove_statistics(snapshot_id=2)
     """
 
-    _updates: Tuple[TableUpdate, ...] = ()
+    _updates: tuple[TableUpdate, ...] = ()
 
     def __init__(self, transaction: "Transaction") -> None:
         super().__init__(transaction)

--- a/pyiceberg/table/update/validate.py
+++ b/pyiceberg/table/update/validate.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Iterator, Set
+from typing import Iterator
 
 from pyiceberg.exceptions import ValidationException
 from pyiceberg.expressions import BooleanExpression
@@ -25,8 +25,8 @@ from pyiceberg.table import Table
 from pyiceberg.table.snapshots import Operation, Snapshot, ancestors_between
 from pyiceberg.typedef import Record
 
-VALIDATE_DATA_FILES_EXIST_OPERATIONS: Set[Operation] = {Operation.OVERWRITE, Operation.REPLACE, Operation.DELETE}
-VALIDATE_ADDED_DATA_FILES_OPERATIONS: Set[Operation] = {Operation.APPEND, Operation.OVERWRITE}
+VALIDATE_DATA_FILES_EXIST_OPERATIONS: set[Operation] = {Operation.OVERWRITE, Operation.REPLACE, Operation.DELETE}
+VALIDATE_ADDED_DATA_FILES_OPERATIONS: set[Operation] = {Operation.APPEND, Operation.OVERWRITE}
 
 
 def _validation_history(

--- a/pyiceberg/typedef.py
+++ b/pyiceberg/typedef.py
@@ -23,13 +23,9 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Dict,
     Generic,
-    List,
     Literal,
     Protocol,
-    Set,
-    Tuple,
     TypeVar,
     Union,
     runtime_checkable,
@@ -43,7 +39,7 @@ if TYPE_CHECKING:
     from pyiceberg.types import StructType
 
 
-class FrozenDict(Dict[Any, Any]):
+class FrozenDict(dict[Any, Any]):
     def __setitem__(self, instance: Any, value: Any) -> None:
         """Assign a value to a FrozenDict."""
         raise AttributeError("FrozenDict does not support assignment")
@@ -61,7 +57,7 @@ V = TypeVar("V")
 
 
 # from https://stackoverflow.com/questions/2912231/is-there-a-clever-way-to-pass-the-key-to-defaultdicts-default-factory
-class KeyDefaultDict(Dict[K, V]):
+class KeyDefaultDict(dict[K, V]):
     def __init__(self, default_factory: Callable[[K], V]):
         super().__init__()
         self.default_factory = default_factory
@@ -73,7 +69,7 @@ class KeyDefaultDict(Dict[K, V]):
         return val
 
 
-Identifier = Tuple[str, ...]
+Identifier = tuple[str, ...]
 """A tuple of strings representing a table identifier.
 
 Each string in the tuple represents a part of the table's unique path. For example,
@@ -85,11 +81,11 @@ Examples:
     >>> identifier: Identifier = ("namespace", "table_name")
 """
 
-Properties = Dict[str, Any]
+Properties = dict[str, Any]
 """A dictionary type for properties in PyIceberg."""
 
 
-RecursiveDict = Dict[str, Union[str, "RecursiveDict"]]
+RecursiveDict = dict[str, Union[str, "RecursiveDict"]]
 """A recursive dictionary type for nested structures in PyIceberg."""
 
 # Represents the literal value
@@ -126,7 +122,7 @@ class IcebergBaseModel(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True, frozen=True)
 
-    def _exclude_private_properties(self, exclude: Set[str] | None = None) -> Set[str]:
+    def _exclude_private_properties(self, exclude: set[str] | None = None) -> set[str]:
         # A small trick to exclude private properties. Properties are serialized by pydantic,
         # regardless if they start with an underscore.
         # This will look at the dict, and find the fields and exclude them
@@ -135,14 +131,14 @@ class IcebergBaseModel(BaseModel):
         )
 
     def model_dump(
-        self, exclude_none: bool = True, exclude: Set[str] | None = None, by_alias: bool = True, **kwargs: Any
-    ) -> Dict[str, Any]:
+        self, exclude_none: bool = True, exclude: set[str] | None = None, by_alias: bool = True, **kwargs: Any
+    ) -> dict[str, Any]:
         return super().model_dump(
             exclude_none=exclude_none, exclude=self._exclude_private_properties(exclude), by_alias=by_alias, **kwargs
         )
 
     def model_dump_json(
-        self, exclude_none: bool = True, exclude: Set[str] | None = None, by_alias: bool = True, **kwargs: Any
+        self, exclude_none: bool = True, exclude: set[str] | None = None, by_alias: bool = True, **kwargs: Any
     ) -> str:
         return super().model_dump_json(
             exclude_none=exclude_none, exclude=self._exclude_private_properties(exclude), by_alias=by_alias, **kwargs
@@ -172,7 +168,7 @@ class IcebergRootModel(RootModel[T], Generic[T]):
 
 class Record(StructProtocol):
     __slots__ = ("_data",)
-    _data: List[Any]
+    _data: list[Any]
 
     @classmethod
     def _bind(cls, struct: StructType, **arguments: Any) -> Self:

--- a/pyiceberg/types.py
+++ b/pyiceberg/types.py
@@ -38,9 +38,7 @@ from typing import (
     Annotated,
     Any,
     ClassVar,
-    Dict,
     Literal,
-    Tuple,
 )
 
 from pydantic import (
@@ -64,7 +62,7 @@ FIXED = "fixed"
 FIXED_PARSER = ParseNumberFromBrackets(FIXED)
 
 
-def transform_dict_value_to_str(dict: Dict[str, Any]) -> Dict[str, str]:
+def transform_dict_value_to_str(dict: dict[str, Any]) -> dict[str, str]:
     """Transform all values in the dictionary to string. Raise an error if any value is None."""
     for key, value in dict.items():
         if value is None:
@@ -72,7 +70,7 @@ def transform_dict_value_to_str(dict: Dict[str, Any]) -> Dict[str, str]:
     return {k: str(v).lower() if isinstance(v, bool) else str(v) for k, v in dict.items()}
 
 
-def _parse_decimal_type(decimal: Any) -> Tuple[int, int]:
+def _parse_decimal_type(decimal: Any) -> tuple[int, int]:
     if isinstance(decimal, str):
         matches = DECIMAL_REGEX.search(decimal)
         if matches:
@@ -250,7 +248,7 @@ class DecimalType(PrimitiveType):
         True
     """
 
-    root: Tuple[int, int]
+    root: tuple[int, int]
 
     def __init__(self, precision: int, scale: int) -> None:
         super().__init__(root=(precision, scale))
@@ -282,7 +280,7 @@ class DecimalType(PrimitiveType):
         """Return the hash of the tuple."""
         return hash(self.root)
 
-    def __getnewargs__(self) -> Tuple[int, int]:
+    def __getnewargs__(self) -> tuple[int, int]:
         """Pickle the DecimalType class."""
         return self.precision, self.scale
 
@@ -375,7 +373,7 @@ class NestedField(IcebergType):
         super().__init__(**data)
 
     @model_serializer()
-    def serialize_model(self) -> Dict[str, Any]:
+    def serialize_model(self) -> dict[str, Any]:
         from pyiceberg.conversions import to_json
 
         fields = {
@@ -415,7 +413,7 @@ class NestedField(IcebergType):
 
         return f"NestedField({', '.join(parts)})"
 
-    def __getnewargs__(self) -> Tuple[int, str, IcebergType, bool, str | None]:
+    def __getnewargs__(self) -> tuple[int, str, IcebergType, bool, str | None]:
         """Pickle the NestedField class."""
         return (self.field_id, self.name, self.field_type, self.required, self.doc)
 
@@ -436,7 +434,7 @@ class StructType(IcebergType):
     """
 
     type: Literal["struct"] = Field(default="struct")
-    fields: Tuple[NestedField, ...] = Field(default_factory=tuple)
+    fields: tuple[NestedField, ...] = Field(default_factory=tuple)
     _hash: int = PrivateAttr()
 
     def __init__(self, *fields: NestedField, **data: Any):
@@ -476,7 +474,7 @@ class StructType(IcebergType):
         """Return the length of an instance of the StructType class."""
         return len(self.fields)
 
-    def __getnewargs__(self) -> Tuple[NestedField, ...]:
+    def __getnewargs__(self) -> tuple[NestedField, ...]:
         """Pickle the StructType class."""
         return self.fields
 
@@ -526,7 +524,7 @@ class ListType(IcebergType):
         """Return the string representation of the ListType class."""
         return f"list<{self.element_type}>"
 
-    def __getnewargs__(self) -> Tuple[int, IcebergType, bool]:
+    def __getnewargs__(self) -> tuple[int, IcebergType, bool]:
         """Pickle the ListType class."""
         return (self.element_id, self.element_type, self.element_required)
 
@@ -594,7 +592,7 @@ class MapType(IcebergType):
         """Return the string representation of the MapType class."""
         return f"map<{self.key_type}, {self.value_type}>"
 
-    def __getnewargs__(self) -> Tuple[int, IcebergType, int, IcebergType, bool]:
+    def __getnewargs__(self) -> tuple[int, IcebergType, int, IcebergType, bool]:
         """Pickle the MapType class."""
         return (self.key_id, self.key_type, self.value_id, self.value_type, self.value_required)
 

--- a/pyiceberg/utils/bin_packing.py
+++ b/pyiceberg/utils/bin_packing.py
@@ -20,7 +20,6 @@ from typing import (
     Callable,
     Generic,
     Iterable,
-    List,
     TypeVar,
 )
 
@@ -31,7 +30,7 @@ class Bin(Generic[T]):
     def __init__(self, target_weight: int) -> None:
         self.bin_weight = 0
         self.target_weight = target_weight
-        self.items: List[T] = []
+        self.items: list[T] = []
 
     def weight(self) -> int:
         return self.bin_weight
@@ -45,7 +44,7 @@ class Bin(Generic[T]):
 
 
 class PackingIterator(Generic[T]):
-    bins: List[Bin[T]]
+    bins: list[Bin[T]]
 
     def __init__(
         self,
@@ -66,7 +65,7 @@ class PackingIterator(Generic[T]):
         """Return an iterator for the PackingIterator class."""
         return self
 
-    def __next__(self) -> List[T]:
+    def __next__(self) -> list[T]:
         """Return the next item when iterating over the PackingIterator class."""
         while True:
             try:
@@ -115,7 +114,7 @@ class ListPacker(Generic[T]):
         self._lookback = lookback
         self._largest_bin_first = largest_bin_first
 
-    def pack(self, items: List[T], weight_func: Callable[[T], int]) -> List[List[T]]:
+    def pack(self, items: list[T], weight_func: Callable[[T], int]) -> list[list[T]]:
         return list(
             PackingIterator(
                 items=items,
@@ -126,6 +125,6 @@ class ListPacker(Generic[T]):
             )
         )
 
-    def pack_end(self, items: List[T], weight_func: Callable[[T], int]) -> List[List[T]]:
+    def pack_end(self, items: list[T], weight_func: Callable[[T], int]) -> list[list[T]]:
         packed = self.pack(items=list(reversed(items)), weight_func=weight_func)
         return [list(reversed(bin_items)) for bin_items in reversed(packed)]

--- a/pyiceberg/utils/config.py
+++ b/pyiceberg/utils/config.py
@@ -16,7 +16,6 @@
 # under the License.
 import logging
 import os
-from typing import List
 
 import strictyaml
 
@@ -106,7 +105,7 @@ class Config:
             Amended configuration.
         """
 
-        def set_property(_config: RecursiveDict, path: List[str], config_value: str) -> None:
+        def set_property(_config: RecursiveDict, path: list[str], config_value: str) -> None:
             while len(path) > 0:
                 element = path.pop(0)
                 if len(path) == 0:
@@ -159,7 +158,7 @@ class Config:
                 return catalog_conf
         return None
 
-    def get_known_catalogs(self) -> List[str]:
+    def get_known_catalogs(self) -> list[str]:
         catalogs = self.config.get(CATALOG, {})
         if not isinstance(catalogs, dict):
             raise ValueError("Catalog configurations needs to be an object")

--- a/pyiceberg/utils/lazydict.py
+++ b/pyiceberg/utils/lazydict.py
@@ -16,7 +16,6 @@
 # under the License.
 
 from typing import (
-    Dict,
     Iterator,
     Mapping,
     Sequence,
@@ -41,9 +40,9 @@ class LazyDict(Mapping[K, V]):
     # that the developer has correctly used the class and that the contents are valid.
     def __init__(self, contents: Sequence[Sequence[K | V]]):
         self._contents = contents
-        self._dict: Dict[K, V] | None = None
+        self._dict: dict[K, V] | None = None
 
-    def _build_dict(self) -> Dict[K, V]:
+    def _build_dict(self) -> dict[K, V]:
         self._dict = {}
         for item in self._contents:
             self._dict.update(dict(zip(cast(Sequence[K], item[::2]), cast(Sequence[V], item[1::2]), strict=True)))
@@ -65,6 +64,6 @@ class LazyDict(Mapping[K, V]):
         source = self._dict or self._build_dict()
         return len(source)
 
-    def __dict__(self) -> Dict[K, V]:  # type: ignore
+    def __dict__(self) -> dict[K, V]:  # type: ignore
         """Convert the lazy dict in a dict."""
         return self._dict or self._build_dict()

--- a/pyiceberg/utils/properties.py
+++ b/pyiceberg/utils/properties.py
@@ -17,7 +17,6 @@
 
 from typing import (
     Any,
-    Dict,
 )
 
 from pyiceberg.typedef import Properties
@@ -27,7 +26,7 @@ HEADER_PREFIX = "header."
 
 
 def property_as_int(
-    properties: Dict[str, str],
+    properties: dict[str, str],
     property_name: str,
     default: int | None = None,
 ) -> int | None:
@@ -41,7 +40,7 @@ def property_as_int(
 
 
 def property_as_float(
-    properties: Dict[str, str],
+    properties: dict[str, str],
     property_name: str,
     default: float | None = None,
 ) -> float | None:
@@ -55,7 +54,7 @@ def property_as_float(
 
 
 def property_as_bool(
-    properties: Dict[str, str],
+    properties: dict[str, str],
     property_name: str,
     default: bool,
 ) -> bool:

--- a/pyiceberg/utils/schema_conversion.py
+++ b/pyiceberg/utils/schema_conversion.py
@@ -19,9 +19,6 @@
 import logging
 from typing import (
     Any,
-    Dict,
-    List,
-    Tuple,
 )
 
 from pyiceberg.schema import (
@@ -59,7 +56,7 @@ from pyiceberg.utils.decimal import decimal_required_bytes
 
 logger = logging.getLogger(__name__)
 
-PRIMITIVE_FIELD_TYPE_MAPPING: Dict[str, PrimitiveType] = {
+PRIMITIVE_FIELD_TYPE_MAPPING: dict[str, PrimitiveType] = {
     "boolean": BooleanType(),
     "bytes": BinaryType(),
     "double": DoubleType(),
@@ -71,7 +68,7 @@ PRIMITIVE_FIELD_TYPE_MAPPING: Dict[str, PrimitiveType] = {
     "null": UnknownType(),
 }
 
-LOGICAL_FIELD_TYPE_MAPPING: Dict[Tuple[str, str], PrimitiveType] = {
+LOGICAL_FIELD_TYPE_MAPPING: dict[tuple[str, str], PrimitiveType] = {
     ("date", "int"): DateType(),
     ("time-micros", "long"): TimeType(),
     ("timestamp-micros", "long"): TimestampType(),
@@ -83,7 +80,7 @@ AvroType = str | Any
 
 
 class AvroSchemaConversion:
-    def avro_to_iceberg(self, avro_schema: Dict[str, Any]) -> Schema:
+    def avro_to_iceberg(self, avro_schema: dict[str, Any]) -> Schema:
         """Convert an Apache Avro into an Apache Iceberg schema equivalent.
 
         This expects to have field id's to be encoded in the Avro schema:
@@ -132,7 +129,7 @@ class AvroSchemaConversion:
         """Convert an Iceberg schema into an Avro dictionary that can be serialized to JSON."""
         return visit(schema, ConvertSchemaToAvro(schema_name))
 
-    def _resolve_union(self, type_union: Dict[str, str] | List[str | Dict[str, str]] | str) -> Tuple[str | Dict[str, Any], bool]:
+    def _resolve_union(self, type_union: dict[str, str] | list[str | dict[str, str]] | str) -> tuple[str | dict[str, Any], bool]:
         """
         Convert Unions into their type and resolves if the field is required.
 
@@ -155,7 +152,7 @@ class AvroSchemaConversion:
         Raises:
             TypeError: In the case non-optional union types are encountered.
         """
-        avro_types: Dict[str, str] | List[Dict[str, str] | str]
+        avro_types: dict[str, str] | list[dict[str, str] | str]
         if isinstance(type_union, str):
             # It is a primitive and required
             return type_union, True
@@ -181,7 +178,7 @@ class AvroSchemaConversion:
         # Filter the null value and return the type
         return list(filter(lambda t: t != "null", avro_types))[0], False
 
-    def _convert_schema(self, avro_type: str | Dict[str, Any]) -> IcebergType:
+    def _convert_schema(self, avro_type: str | dict[str, Any]) -> IcebergType:
         """
         Resolve the Avro type.
 
@@ -219,7 +216,7 @@ class AvroSchemaConversion:
         else:
             raise TypeError(f"Type not recognized: {avro_type}")
 
-    def _convert_field(self, field: Dict[str, Any]) -> NestedField:
+    def _convert_field(self, field: dict[str, Any]) -> NestedField:
         """Convert an Avro field into an Iceberg equivalent field.
 
         Args:
@@ -241,7 +238,7 @@ class AvroSchemaConversion:
             doc=field.get("doc"),
         )
 
-    def _convert_record_type(self, record_type: Dict[str, Any]) -> StructType:
+    def _convert_record_type(self, record_type: dict[str, Any]) -> StructType:
         """
         Convert the fields from a record into an Iceberg struct.
 
@@ -295,7 +292,7 @@ class AvroSchemaConversion:
 
         return StructType(*[self._convert_field(field) for field in record_type["fields"]])
 
-    def _convert_array_type(self, array_type: Dict[str, Any]) -> ListType:
+    def _convert_array_type(self, array_type: dict[str, Any]) -> ListType:
         if "element-id" not in array_type:
             raise ValueError(f"Cannot convert array-type, missing element-id: {array_type}")
 
@@ -307,7 +304,7 @@ class AvroSchemaConversion:
             element_required=element_required,
         )
 
-    def _convert_map_type(self, map_type: Dict[str, Any]) -> MapType:
+    def _convert_map_type(self, map_type: dict[str, Any]) -> MapType:
         """Convert an avro map type into an Iceberg MapType.
 
         Args:
@@ -344,7 +341,7 @@ class AvroSchemaConversion:
             value_required=value_required,
         )
 
-    def _convert_logical_type(self, avro_logical_type: Dict[str, Any]) -> IcebergType:
+    def _convert_logical_type(self, avro_logical_type: dict[str, Any]) -> IcebergType:
         """Convert a schema with a logical type annotation into an IcebergType.
 
         For the decimal and map we need to fetch more keys from the dict, and for
@@ -385,7 +382,7 @@ class AvroSchemaConversion:
         else:
             raise ValueError(f"Unknown logical/physical type combination: {avro_logical_type}")
 
-    def _convert_logical_decimal_type(self, avro_type: Dict[str, Any]) -> DecimalType:
+    def _convert_logical_decimal_type(self, avro_type: dict[str, Any]) -> DecimalType:
         """Convert an avro type to an Iceberg DecimalType.
 
         Args:
@@ -412,7 +409,7 @@ class AvroSchemaConversion:
         """
         return DecimalType(precision=avro_type["precision"], scale=avro_type["scale"])
 
-    def _convert_logical_map_type(self, avro_type: Dict[str, Any]) -> MapType:
+    def _convert_logical_map_type(self, avro_type: dict[str, Any]) -> MapType:
         """Convert an avro map type to an Iceberg MapType.
 
         In the case where a map hasn't a key as a type you can use a logical map to still encode this in Avro.
@@ -464,7 +461,7 @@ class AvroSchemaConversion:
             value_required=value.required,
         )
 
-    def _convert_fixed_type(self, avro_type: Dict[str, Any]) -> FixedType:
+    def _convert_fixed_type(self, avro_type: dict[str, Any]) -> FixedType:
         """
         Convert Avro Type to the equivalent Iceberg fixed type.
 
@@ -519,7 +516,7 @@ class ConvertSchemaToAvro(SchemaVisitorPerPrimitiveType[AvroType]):
     def before_map_value(self, value: NestedField) -> None:
         self.last_map_value_field_id = value.field_id
 
-    def struct(self, struct: StructType, field_results: List[AvroType]) -> AvroType:
+    def struct(self, struct: StructType, field_results: list[AvroType]) -> AvroType:
         return {"type": "record", "fields": field_results}
 
     def field(self, field: NestedField, field_result: AvroType) -> AvroType:

--- a/pyiceberg/utils/singleton.py
+++ b/pyiceberg/utils/singleton.py
@@ -28,7 +28,7 @@ return it.
 More information on metaclasses: https://docs.python.org/3/reference/datamodel.html#metaclasses
 """
 
-from typing import Any, ClassVar, Dict
+from typing import Any, ClassVar
 
 
 def _convert_to_hashable_type(element: Any) -> Any:
@@ -40,7 +40,7 @@ def _convert_to_hashable_type(element: Any) -> Any:
 
 
 class Singleton:
-    _instances: ClassVar[Dict] = {}  # type: ignore
+    _instances: ClassVar[dict] = {}  # type: ignore
 
     def __new__(cls, *args, **kwargs):  # type: ignore
         key = (cls, tuple(args), _convert_to_hashable_type(kwargs))
@@ -48,7 +48,7 @@ class Singleton:
             cls._instances[key] = super().__new__(cls)
         return cls._instances[key]
 
-    def __deepcopy__(self, memo: Dict[int, Any]) -> Any:
+    def __deepcopy__(self, memo: dict[int, Any]) -> Any:
         """
         Prevent deep copy operations for singletons.
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -59,8 +59,7 @@ select = [
 ]
 ignore = [
     "E501",
-    "UP035",
-    "UP006"
+    "UP035"
 ]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.

--- a/tests/avro/test_decoder.py
+++ b/tests/avro/test_decoder.py
@@ -20,7 +20,7 @@ import itertools
 import struct
 from io import SEEK_SET
 from types import TracebackType
-from typing import Callable, Type
+from typing import Callable
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -129,7 +129,7 @@ class OneByteAtATimeInputStream(InputStream):
     def __enter__(self) -> OneByteAtATimeInputStream:
         return self
 
-    def __exit__(self, exctype: Type[BaseException] | None, excinst: BaseException | None, exctb: TracebackType | None) -> None:
+    def __exit__(self, exctype: type[BaseException] | None, excinst: BaseException | None, exctb: TracebackType | None) -> None:
         self.close()
 
 

--- a/tests/catalog/integration_test_dynamodb.py
+++ b/tests/catalog/integration_test_dynamodb.py
@@ -15,7 +15,7 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-from typing import Generator, List
+from typing import Generator
 
 import boto3
 import pytest
@@ -115,7 +115,7 @@ def test_load_table(test_catalog: Catalog, table_schema_nested: Schema, database
     assert table.metadata == loaded_table.metadata
 
 
-def test_list_tables(test_catalog: Catalog, table_schema_nested: Schema, database_name: str, table_list: List[str]) -> None:
+def test_list_tables(test_catalog: Catalog, table_schema_nested: Schema, database_name: str, table_list: list[str]) -> None:
     test_catalog.create_namespace(database_name)
     for table_name in table_list:
         test_catalog.create_table((database_name, table_name), table_schema_nested)
@@ -204,7 +204,7 @@ def test_create_namespace_with_comment_and_location(test_catalog: Catalog, datab
     assert properties["location"] == test_location
 
 
-def test_list_namespaces(test_catalog: Catalog, database_list: List[str]) -> None:
+def test_list_namespaces(test_catalog: Catalog, database_list: list[str]) -> None:
     for database_name in database_list:
         test_catalog.create_namespace(database_name)
     db_list = test_catalog.list_namespaces()

--- a/tests/catalog/integration_test_glue.py
+++ b/tests/catalog/integration_test_glue.py
@@ -16,7 +16,7 @@
 #  under the License.
 
 import time
-from typing import Any, Dict, Generator, List
+from typing import Any, Generator
 from uuid import uuid4
 
 import boto3
@@ -70,7 +70,7 @@ class AthenaQueryHelper:
         self._output_bucket = get_bucket_name()
         self._output_path = f"athena_results_{uuid4()}"
 
-    def get_query_results(self, query: str) -> List[Dict[str, Any]]:
+    def get_query_results(self, query: str) -> list[dict[str, Any]]:
         query_execution_id = self._athena_client.start_query_execution(
             QueryString=query, ResultConfiguration={"OutputLocation": f"s3://{self._output_bucket}/{self._output_path}"}
         )["QueryExecutionId"]
@@ -222,7 +222,7 @@ def test_load_table(test_catalog: Catalog, table_schema_nested: Schema, table_na
     assert MetastoreCatalog._parse_metadata_version(table.metadata_location) == 0
 
 
-def test_list_tables(test_catalog: Catalog, table_schema_nested: Schema, database_name: str, table_list: List[str]) -> None:
+def test_list_tables(test_catalog: Catalog, table_schema_nested: Schema, database_name: str, table_list: list[str]) -> None:
     test_catalog.create_namespace(database_name)
     for table_name in table_list:
         test_catalog.create_table((database_name, table_name), table_schema_nested)
@@ -312,7 +312,7 @@ def test_create_namespace_with_comment_and_location(test_catalog: Catalog, datab
     assert properties["location"] == test_location
 
 
-def test_list_namespaces(test_catalog: Catalog, database_list: List[str]) -> None:
+def test_list_namespaces(test_catalog: Catalog, database_list: list[str]) -> None:
     for database_name in database_list:
         test_catalog.create_namespace(database_name)
     db_list = test_catalog.list_namespaces()

--- a/tests/catalog/test_dynamodb.py
+++ b/tests/catalog/test_dynamodb.py
@@ -14,7 +14,6 @@
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-from typing import List
 from unittest import mock
 
 import boto3
@@ -393,7 +392,7 @@ def test_fail_on_rename_non_iceberg_table(
 
 @mock_aws
 def test_list_tables(
-    _bucket_initialize: None, moto_endpoint_url: str, table_schema_nested: Schema, database_name: str, table_list: List[str]
+    _bucket_initialize: None, moto_endpoint_url: str, table_schema_nested: Schema, database_name: str, table_list: list[str]
 ) -> None:
     test_catalog = DynamoDbCatalog("test_ddb_catalog", **{"warehouse": f"s3://{BUCKET_NAME}", "s3.endpoint": moto_endpoint_url})
     test_catalog.create_namespace(namespace=database_name)
@@ -405,7 +404,7 @@ def test_list_tables(
 
 
 @mock_aws
-def test_list_namespaces(_bucket_initialize: None, database_list: List[str]) -> None:
+def test_list_namespaces(_bucket_initialize: None, database_list: list[str]) -> None:
     test_catalog = DynamoDbCatalog("test_ddb_catalog")
     for database_name in database_list:
         test_catalog.create_namespace(namespace=database_name)

--- a/tests/catalog/test_glue.py
+++ b/tests/catalog/test_glue.py
@@ -14,7 +14,6 @@
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-from typing import List
 from unittest import mock
 
 import boto3
@@ -439,7 +438,7 @@ def test_list_tables(
     moto_endpoint_url: str,
     table_schema_nested: Schema,
     database_name: str,
-    table_list: List[str],
+    table_list: list[str],
 ) -> None:
     test_catalog = GlueCatalog("glue", **{"s3.endpoint": moto_endpoint_url, "warehouse": f"s3://{BUCKET_NAME}/"})
     test_catalog.create_namespace(namespace=database_name)
@@ -475,7 +474,7 @@ def test_list_tables(
 
 
 @mock_aws
-def test_list_namespaces(_bucket_initialize: None, moto_endpoint_url: str, database_list: List[str]) -> None:
+def test_list_namespaces(_bucket_initialize: None, moto_endpoint_url: str, database_list: list[str]) -> None:
     test_catalog = GlueCatalog("glue", **{"s3.endpoint": moto_endpoint_url})
     for database_name in database_list:
         test_catalog.create_namespace(namespace=database_name)

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -17,7 +17,7 @@
 # pylint: disable=redefined-outer-name,unused-argument
 import base64
 import os
-from typing import Any, Callable, Dict, cast
+from typing import Any, Callable, cast
 from unittest import mock
 
 import pytest
@@ -69,7 +69,7 @@ OAUTH_TEST_HEADERS = {
 
 
 @pytest.fixture
-def example_table_metadata_with_snapshot_v1_rest_json(example_table_metadata_with_snapshot_v1: Dict[str, Any]) -> Dict[str, Any]:
+def example_table_metadata_with_snapshot_v1_rest_json(example_table_metadata_with_snapshot_v1: dict[str, Any]) -> dict[str, Any]:
     return {
         "metadata-location": "s3://warehouse/database/table/metadata/00001-5f2f8166-244c-4eae-ac36-384ecdec81fc.gz.metadata.json",
         "metadata": example_table_metadata_with_snapshot_v1,
@@ -81,7 +81,7 @@ def example_table_metadata_with_snapshot_v1_rest_json(example_table_metadata_wit
 
 
 @pytest.fixture
-def example_table_metadata_with_no_location(example_table_metadata_with_snapshot_v1: Dict[str, Any]) -> Dict[str, Any]:
+def example_table_metadata_with_no_location(example_table_metadata_with_snapshot_v1: dict[str, Any]) -> dict[str, Any]:
     return {
         "metadata": example_table_metadata_with_snapshot_v1,
         "config": {
@@ -92,7 +92,7 @@ def example_table_metadata_with_no_location(example_table_metadata_with_snapshot
 
 
 @pytest.fixture
-def example_table_metadata_no_snapshot_v1_rest_json(example_table_metadata_no_snapshot_v1: Dict[str, Any]) -> Dict[str, Any]:
+def example_table_metadata_no_snapshot_v1_rest_json(example_table_metadata_no_snapshot_v1: dict[str, Any]) -> dict[str, Any]:
     return {
         "metadata-location": "s3://warehouse/database/table/metadata.json",
         "metadata": example_table_metadata_no_snapshot_v1,
@@ -837,7 +837,7 @@ def test_update_namespace_properties_404(rest_mock: Mocker) -> None:
     assert "Namespace does not exist" in str(e.value)
 
 
-def test_load_table_200(rest_mock: Mocker, example_table_metadata_with_snapshot_v1_rest_json: Dict[str, Any]) -> None:
+def test_load_table_200(rest_mock: Mocker, example_table_metadata_with_snapshot_v1_rest_json: dict[str, Any]) -> None:
     rest_mock.get(
         f"{TEST_URI}v1/namespaces/fokko/tables/table",
         json=example_table_metadata_with_snapshot_v1_rest_json,
@@ -859,7 +859,7 @@ def test_load_table_200(rest_mock: Mocker, example_table_metadata_with_snapshot_
 
 
 def test_load_table_200_loading_mode(
-    rest_mock: Mocker, example_table_metadata_with_snapshot_v1_rest_json: Dict[str, Any]
+    rest_mock: Mocker, example_table_metadata_with_snapshot_v1_rest_json: dict[str, Any]
 ) -> None:
     rest_mock.get(
         f"{TEST_URI}v1/namespaces/fokko/tables/table?snapshots=refs",
@@ -882,7 +882,7 @@ def test_load_table_200_loading_mode(
 
 
 def test_load_table_honor_access_delegation(
-    rest_mock: Mocker, example_table_metadata_with_snapshot_v1_rest_json: Dict[str, Any]
+    rest_mock: Mocker, example_table_metadata_with_snapshot_v1_rest_json: dict[str, Any]
 ) -> None:
     test_headers_with_remote_signing = {**TEST_HEADERS, "X-Iceberg-Access-Delegation": "remote-signing"}
     rest_mock.get(
@@ -914,7 +914,7 @@ def test_load_table_honor_access_delegation(
 
 
 def test_load_table_from_self_identifier_200(
-    rest_mock: Mocker, example_table_metadata_with_snapshot_v1_rest_json: Dict[str, Any]
+    rest_mock: Mocker, example_table_metadata_with_snapshot_v1_rest_json: dict[str, Any]
 ) -> None:
     rest_mock.get(
         f"{TEST_URI}v1/namespaces/pdames/tables/table",
@@ -1017,7 +1017,7 @@ def test_drop_table_404(rest_mock: Mocker) -> None:
 
 
 def test_create_table_200(
-    rest_mock: Mocker, table_schema_simple: Schema, example_table_metadata_no_snapshot_v1_rest_json: Dict[str, Any]
+    rest_mock: Mocker, table_schema_simple: Schema, example_table_metadata_no_snapshot_v1_rest_json: dict[str, Any]
 ) -> None:
     rest_mock.post(
         f"{TEST_URI}v1/namespaces/fokko/tables",
@@ -1047,7 +1047,7 @@ def test_create_table_200(
 
 
 def test_create_table_with_given_location_removes_trailing_slash_200(
-    rest_mock: Mocker, table_schema_simple: Schema, example_table_metadata_no_snapshot_v1_rest_json: Dict[str, Any]
+    rest_mock: Mocker, table_schema_simple: Schema, example_table_metadata_no_snapshot_v1_rest_json: dict[str, Any]
 ) -> None:
     rest_mock.post(
         f"{TEST_URI}v1/namespaces/fokko/tables",
@@ -1074,8 +1074,8 @@ def test_create_table_with_given_location_removes_trailing_slash_200(
 def test_create_staged_table_200(
     rest_mock: Mocker,
     table_schema_simple: Schema,
-    example_table_metadata_with_no_location: Dict[str, Any],
-    example_table_metadata_no_snapshot_v1_rest_json: Dict[str, Any],
+    example_table_metadata_with_no_location: dict[str, Any],
+    example_table_metadata_no_snapshot_v1_rest_json: dict[str, Any],
 ) -> None:
     rest_mock.post(
         f"{TEST_URI}v1/namespaces/fokko/tables",
@@ -1163,12 +1163,12 @@ def test_create_table_409(rest_mock: Mocker, table_schema_simple: Schema) -> Non
 
 
 def test_create_table_if_not_exists_200(
-    rest_mock: Mocker, table_schema_simple: Schema, example_table_metadata_no_snapshot_v1_rest_json: Dict[str, Any]
+    rest_mock: Mocker, table_schema_simple: Schema, example_table_metadata_no_snapshot_v1_rest_json: dict[str, Any]
 ) -> None:
-    def json_callback() -> Callable[[Any, Any], Dict[str, Any]]:
+    def json_callback() -> Callable[[Any, Any], dict[str, Any]]:
         call_count = 0
 
-        def callback(request: Any, context: Any) -> Dict[str, Any]:
+        def callback(request: Any, context: Any) -> dict[str, Any]:
             nonlocal call_count
             call_count += 1
 
@@ -1250,7 +1250,7 @@ def test_create_table_419(rest_mock: Mocker, table_schema_simple: Schema) -> Non
 
 
 def test_register_table_200(
-    rest_mock: Mocker, table_schema_simple: Schema, example_table_metadata_no_snapshot_v1_rest_json: Dict[str, Any]
+    rest_mock: Mocker, table_schema_simple: Schema, example_table_metadata_no_snapshot_v1_rest_json: dict[str, Any]
 ) -> None:
     rest_mock.post(
         f"{TEST_URI}v1/namespaces/default/register",
@@ -1318,7 +1318,7 @@ def test_delete_table_204(rest_mock: Mocker) -> None:
 
 
 def test_delete_table_from_self_identifier_204(
-    rest_mock: Mocker, example_table_metadata_with_snapshot_v1_rest_json: Dict[str, Any]
+    rest_mock: Mocker, example_table_metadata_with_snapshot_v1_rest_json: dict[str, Any]
 ) -> None:
     rest_mock.get(
         f"{TEST_URI}v1/namespaces/pdames/tables/table",
@@ -1337,7 +1337,7 @@ def test_delete_table_from_self_identifier_204(
     catalog.drop_table(table.name())
 
 
-def test_rename_table_200(rest_mock: Mocker, example_table_metadata_with_snapshot_v1_rest_json: Dict[str, Any]) -> None:
+def test_rename_table_200(rest_mock: Mocker, example_table_metadata_with_snapshot_v1_rest_json: dict[str, Any]) -> None:
     rest_mock.post(
         f"{TEST_URI}v1/tables/rename",
         json={
@@ -1374,7 +1374,7 @@ def test_rename_table_200(rest_mock: Mocker, example_table_metadata_with_snapsho
 
 
 def test_rename_table_from_self_identifier_200(
-    rest_mock: Mocker, example_table_metadata_with_snapshot_v1_rest_json: Dict[str, Any]
+    rest_mock: Mocker, example_table_metadata_with_snapshot_v1_rest_json: dict[str, Any]
 ) -> None:
     rest_mock.get(
         f"{TEST_URI}v1/namespaces/pdames/tables/source",
@@ -1795,7 +1795,7 @@ def test_catalog_from_parameters_empty_env(rest_mock: Mocker) -> None:
 
 
 def test_table_identifier_in_commit_table_request(
-    rest_mock: Mocker, table_schema_simple: Schema, example_table_metadata_v2: Dict[str, Any]
+    rest_mock: Mocker, table_schema_simple: Schema, example_table_metadata_v2: dict[str, Any]
 ) -> None:
     metadata_location = "s3://some_bucket/metadata.json"
     rest_mock.post(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,9 +38,7 @@ from tempfile import TemporaryDirectory
 from typing import (
     TYPE_CHECKING,
     Any,
-    Dict,
     Generator,
-    List,
 )
 
 import boto3
@@ -103,7 +101,7 @@ if TYPE_CHECKING:
     from pyiceberg.io.pyarrow import PyArrowFileIO
 
 
-def pytest_collection_modifyitems(items: List[pytest.Item]) -> None:
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     for item in items:
         if not any(item.iter_markers()):
             item.add_marker("unmarked")
@@ -546,7 +544,7 @@ def iceberg_schema_nested_no_ids() -> Schema:
 
 
 @pytest.fixture(scope="session")
-def all_avro_types() -> Dict[str, Any]:
+def all_avro_types() -> dict[str, Any]:
     return {
         "type": "record",
         "name": "all_avro_types",
@@ -650,7 +648,7 @@ EXAMPLE_TABLE_METADATA_V1 = {
 
 
 @pytest.fixture(scope="session")
-def example_table_metadata_v1() -> Dict[str, Any]:
+def example_table_metadata_v1() -> dict[str, Any]:
     return EXAMPLE_TABLE_METADATA_V1
 
 
@@ -724,7 +722,7 @@ EXAMPLE_TABLE_METADATA_WITH_SNAPSHOT_V1 = {
 
 
 @pytest.fixture
-def example_table_metadata_with_snapshot_v1() -> Dict[str, Any]:
+def example_table_metadata_with_snapshot_v1() -> dict[str, Any]:
     return EXAMPLE_TABLE_METADATA_WITH_SNAPSHOT_V1
 
 
@@ -777,18 +775,18 @@ EXAMPLE_TABLE_METADATA_NO_SNAPSHOT_V1 = {
 
 
 @pytest.fixture
-def example_table_metadata_no_snapshot_v1() -> Dict[str, Any]:
+def example_table_metadata_no_snapshot_v1() -> dict[str, Any]:
     return EXAMPLE_TABLE_METADATA_NO_SNAPSHOT_V1
 
 
 @pytest.fixture
-def example_table_metadata_v2_with_extensive_snapshots() -> Dict[str, Any]:
+def example_table_metadata_v2_with_extensive_snapshots() -> dict[str, Any]:
     def generate_snapshot(
         snapshot_id: int,
         parent_snapshot_id: int | None = None,
         timestamp_ms: int | None = None,
         sequence_number: int = 0,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         return {
             "snapshot-id": snapshot_id,
             "parent-snapshot-id": parent_snapshot_id,
@@ -1116,22 +1114,22 @@ TABLE_METADATA_V2_WITH_STATISTICS = {
 
 
 @pytest.fixture
-def example_table_metadata_v2() -> Dict[str, Any]:
+def example_table_metadata_v2() -> dict[str, Any]:
     return EXAMPLE_TABLE_METADATA_V2
 
 
 @pytest.fixture
-def table_metadata_v2_with_fixed_and_decimal_types() -> Dict[str, Any]:
+def table_metadata_v2_with_fixed_and_decimal_types() -> dict[str, Any]:
     return TABLE_METADATA_V2_WITH_FIXED_AND_DECIMAL_TYPES
 
 
 @pytest.fixture
-def table_metadata_v2_with_statistics() -> Dict[str, Any]:
+def table_metadata_v2_with_statistics() -> dict[str, Any]:
     return TABLE_METADATA_V2_WITH_STATISTICS
 
 
 @pytest.fixture
-def example_table_metadata_v3() -> Dict[str, Any]:
+def example_table_metadata_v3() -> dict[str, Any]:
     return EXAMPLE_TABLE_METADATA_V3
 
 
@@ -1487,7 +1485,7 @@ manifest_file_records_v2 = [
 
 
 @pytest.fixture(scope="session")
-def avro_schema_manifest_file_v1() -> Dict[str, Any]:
+def avro_schema_manifest_file_v1() -> dict[str, Any]:
     return {
         "type": "record",
         "name": "manifest_file",
@@ -1589,7 +1587,7 @@ def avro_schema_manifest_file_v1() -> Dict[str, Any]:
 
 
 @pytest.fixture(scope="session")
-def avro_schema_manifest_file_v2() -> Dict[str, Any]:
+def avro_schema_manifest_file_v2() -> dict[str, Any]:
     return {
         "type": "record",
         "name": "manifest_file",
@@ -1668,7 +1666,7 @@ def avro_schema_manifest_file_v2() -> Dict[str, Any]:
 
 
 @pytest.fixture(scope="session")
-def avro_schema_manifest_entry() -> Dict[str, Any]:
+def avro_schema_manifest_entry() -> dict[str, Any]:
     return {
         "type": "record",
         "name": "manifest_entry",
@@ -1898,7 +1896,7 @@ def test_partition_spec() -> Schema:
 
 @pytest.fixture(scope="session")
 def generated_manifest_entry_file(
-    avro_schema_manifest_entry: Dict[str, Any], test_schema: Schema, test_partition_spec: PartitionSpec
+    avro_schema_manifest_entry: dict[str, Any], test_schema: Schema, test_partition_spec: PartitionSpec
 ) -> Generator[str, None, None]:
     from fastavro import parse_schema, writer
 
@@ -1921,7 +1919,7 @@ def generated_manifest_entry_file(
 
 @pytest.fixture(scope="session")
 def generated_manifest_file_file_v1(
-    avro_schema_manifest_file_v1: Dict[str, Any], generated_manifest_entry_file: str
+    avro_schema_manifest_file_v1: dict[str, Any], generated_manifest_entry_file: str
 ) -> Generator[str, None, None]:
     from fastavro import parse_schema, writer
 
@@ -1939,7 +1937,7 @@ def generated_manifest_file_file_v1(
 
 @pytest.fixture(scope="session")
 def generated_manifest_file_file_v2(
-    avro_schema_manifest_file_v2: Dict[str, Any], generated_manifest_entry_file: str
+    avro_schema_manifest_file_v2: dict[str, Any], generated_manifest_entry_file: str
 ) -> Generator[str, None, None]:
     from fastavro import parse_schema, writer
 
@@ -2288,7 +2286,7 @@ def table_name() -> str:
 
 
 @pytest.fixture()
-def table_list(table_name: str) -> List[str]:
+def table_list(table_name: str) -> list[str]:
     return [f"{table_name}_{idx}" for idx in range(NUM_TABLES)]
 
 
@@ -2307,7 +2305,7 @@ def gcp_dataset_name() -> str:
 
 
 @pytest.fixture()
-def database_list(database_name: str) -> List[str]:
+def database_list(database_name: str) -> list[str]:
     return [f"{database_name}_{idx}" for idx in range(NUM_TABLES)]
 
 
@@ -2320,7 +2318,7 @@ def hierarchical_namespace_name() -> str:
 
 
 @pytest.fixture()
-def hierarchical_namespace_list(hierarchical_namespace_name: str) -> List[str]:
+def hierarchical_namespace_list(hierarchical_namespace_name: str) -> list[str]:
     return [f"{hierarchical_namespace_name}_{idx}" for idx in range(NUM_TABLES)]
 
 
@@ -2466,7 +2464,7 @@ def warehouse(tmp_path_factory: pytest.TempPathFactory) -> Path:
 
 
 @pytest.fixture
-def table_v1(example_table_metadata_v1: Dict[str, Any]) -> Table:
+def table_v1(example_table_metadata_v1: dict[str, Any]) -> Table:
     table_metadata = TableMetadataV1(**example_table_metadata_v1)
     return Table(
         identifier=("database", "table"),
@@ -2478,7 +2476,7 @@ def table_v1(example_table_metadata_v1: Dict[str, Any]) -> Table:
 
 
 @pytest.fixture
-def table_v2(example_table_metadata_v2: Dict[str, Any]) -> Table:
+def table_v2(example_table_metadata_v2: dict[str, Any]) -> Table:
     table_metadata = TableMetadataV2(**example_table_metadata_v2)
     return Table(
         identifier=("database", "table"),
@@ -2490,7 +2488,7 @@ def table_v2(example_table_metadata_v2: Dict[str, Any]) -> Table:
 
 
 @pytest.fixture
-def table_v3(example_table_metadata_v3: Dict[str, Any]) -> Table:
+def table_v3(example_table_metadata_v3: dict[str, Any]) -> Table:
     table_metadata = TableMetadataV3(**example_table_metadata_v3)
     return Table(
         identifier=("database", "table"),
@@ -2502,7 +2500,7 @@ def table_v3(example_table_metadata_v3: Dict[str, Any]) -> Table:
 
 
 @pytest.fixture
-def table_v2_orc(example_table_metadata_v2: Dict[str, Any]) -> Table:
+def table_v2_orc(example_table_metadata_v2: dict[str, Any]) -> Table:
     import copy
 
     metadata_dict = copy.deepcopy(example_table_metadata_v2)
@@ -2521,7 +2519,7 @@ def table_v2_orc(example_table_metadata_v2: Dict[str, Any]) -> Table:
 
 @pytest.fixture
 def table_v2_with_fixed_and_decimal_types(
-    table_metadata_v2_with_fixed_and_decimal_types: Dict[str, Any],
+    table_metadata_v2_with_fixed_and_decimal_types: dict[str, Any],
 ) -> Table:
     table_metadata = TableMetadataV2(
         **table_metadata_v2_with_fixed_and_decimal_types,
@@ -2536,7 +2534,7 @@ def table_v2_with_fixed_and_decimal_types(
 
 
 @pytest.fixture
-def table_v2_with_extensive_snapshots(example_table_metadata_v2_with_extensive_snapshots: Dict[str, Any]) -> Table:
+def table_v2_with_extensive_snapshots(example_table_metadata_v2_with_extensive_snapshots: dict[str, Any]) -> Table:
     table_metadata = TableMetadataV2(**example_table_metadata_v2_with_extensive_snapshots)
     return Table(
         identifier=("database", "table"),
@@ -2548,7 +2546,7 @@ def table_v2_with_extensive_snapshots(example_table_metadata_v2_with_extensive_s
 
 
 @pytest.fixture
-def table_v2_with_statistics(table_metadata_v2_with_statistics: Dict[str, Any]) -> Table:
+def table_v2_with_statistics(table_metadata_v2_with_statistics: dict[str, Any]) -> Table:
     table_metadata = TableMetadataV2(**table_metadata_v2_with_statistics)
     return Table(
         identifier=("database", "table"),

--- a/tests/expressions/test_literals.py
+++ b/tests/expressions/test_literals.py
@@ -21,9 +21,6 @@ import uuid
 from decimal import Decimal
 from typing import (
     Any,
-    List,
-    Set,
-    Type,
 )
 
 import pytest
@@ -95,14 +92,14 @@ def test_literal_from_nan_error() -> None:
         BinaryLiteral,
     ],
 )
-def test_literal_classes_with_none_type_error(literal_class: Type[PrimitiveType]) -> None:
+def test_literal_classes_with_none_type_error(literal_class: type[PrimitiveType]) -> None:
     with pytest.raises(TypeError) as e:
         literal_class(None)
     assert "Invalid literal value: None" in str(e.value)
 
 
 @pytest.mark.parametrize("literal_class", [FloatLiteral, DoubleLiteral])
-def test_literal_classes_with_nan_value_error(literal_class: Type[PrimitiveType]) -> None:
+def test_literal_classes_with_nan_value_error(literal_class: type[PrimitiveType]) -> None:
     with pytest.raises(ValueError) as e:
         literal_class(float("nan"))
     assert "Cannot create expression literal from NaN." in str(e.value)
@@ -824,7 +821,7 @@ def test_invalid_binary_conversions() -> None:
     )
 
 
-def assert_invalid_conversions(lit: Literal[Any], types: List[PrimitiveType]) -> None:
+def assert_invalid_conversions(lit: Literal[Any], types: list[PrimitiveType]) -> None:
     for type_var in types:
         with pytest.raises(TypeError):
             _ = lit.to(type_var)
@@ -958,4 +955,4 @@ assert_type(literal(123), Literal[int])
 assert_type(literal(123.4), Literal[float])
 assert_type(literal(bytes([0x01, 0x02, 0x03])), Literal[bytes])
 assert_type(literal(Decimal("19.25")), Literal[Decimal])
-assert_type({literal(1), literal(2), literal(3)}, Set[Literal[int]])
+assert_type({literal(1), literal(2), literal(3)}, set[Literal[int]])

--- a/tests/expressions/test_visitors.py
+++ b/tests/expressions/test_visitors.py
@@ -16,7 +16,7 @@
 # under the License.
 # pylint:disable=redefined-outer-name
 
-from typing import Any, List, Set
+from typing import Any
 
 import pytest
 
@@ -91,7 +91,7 @@ from pyiceberg.types import (
 )
 
 
-class ExampleVisitor(BooleanExpressionVisitor[List[str]]):
+class ExampleVisitor(BooleanExpressionVisitor[list[str]]):
     """A test implementation of a BooleanExpressionVisitor
 
     As this visitor visits each node, it appends an element to a `visit_history` list. This enables testing that a given expression is
@@ -99,119 +99,119 @@ class ExampleVisitor(BooleanExpressionVisitor[List[str]]):
     """
 
     def __init__(self) -> None:
-        self.visit_history: List[str] = []
+        self.visit_history: list[str] = []
 
-    def visit_true(self) -> List[str]:
+    def visit_true(self) -> list[str]:
         self.visit_history.append("TRUE")
         return self.visit_history
 
-    def visit_false(self) -> List[str]:
+    def visit_false(self) -> list[str]:
         self.visit_history.append("FALSE")
         return self.visit_history
 
-    def visit_not(self, child_result: List[str]) -> List[str]:
+    def visit_not(self, child_result: list[str]) -> list[str]:
         self.visit_history.append("NOT")
         return self.visit_history
 
-    def visit_and(self, left_result: List[str], right_result: List[str]) -> List[str]:
+    def visit_and(self, left_result: list[str], right_result: list[str]) -> list[str]:
         self.visit_history.append("AND")
         return self.visit_history
 
-    def visit_or(self, left_result: List[str], right_result: List[str]) -> List[str]:
+    def visit_or(self, left_result: list[str], right_result: list[str]) -> list[str]:
         self.visit_history.append("OR")
         return self.visit_history
 
-    def visit_unbound_predicate(self, predicate: UnboundPredicate[Any]) -> List[str]:
+    def visit_unbound_predicate(self, predicate: UnboundPredicate[Any]) -> list[str]:
         self.visit_history.append(str(predicate.__class__.__name__).upper())
         return self.visit_history
 
-    def visit_bound_predicate(self, predicate: BoundPredicate[Any]) -> List[str]:
+    def visit_bound_predicate(self, predicate: BoundPredicate[Any]) -> list[str]:
         self.visit_history.append(str(predicate.__class__.__name__).upper())
         return self.visit_history
 
 
-class FooBoundBooleanExpressionVisitor(BoundBooleanExpressionVisitor[List[str]]):
+class FooBoundBooleanExpressionVisitor(BoundBooleanExpressionVisitor[list[str]]):
     """A test implementation of a BoundBooleanExpressionVisitor
     As this visitor visits each node, it appends an element to a `visit_history` list. This enables testing that a given bound expression is
     visited in an expected order by the `visit` method.
     """
 
     def __init__(self) -> None:
-        self.visit_history: List[str] = []
+        self.visit_history: list[str] = []
 
-    def visit_in(self, term: BoundTerm[Any], literals: Set[Any]) -> List[str]:
+    def visit_in(self, term: BoundTerm[Any], literals: set[Any]) -> list[str]:
         self.visit_history.append("IN")
         return self.visit_history
 
-    def visit_not_in(self, term: BoundTerm[Any], literals: Set[Any]) -> List[str]:
+    def visit_not_in(self, term: BoundTerm[Any], literals: set[Any]) -> list[str]:
         self.visit_history.append("NOT_IN")
         return self.visit_history
 
-    def visit_is_nan(self, term: BoundTerm[Any]) -> List[str]:
+    def visit_is_nan(self, term: BoundTerm[Any]) -> list[str]:
         self.visit_history.append("IS_NAN")
         return self.visit_history
 
-    def visit_not_nan(self, term: BoundTerm[Any]) -> List[str]:
+    def visit_not_nan(self, term: BoundTerm[Any]) -> list[str]:
         self.visit_history.append("NOT_NAN")
         return self.visit_history
 
-    def visit_is_null(self, term: BoundTerm[Any]) -> List[str]:
+    def visit_is_null(self, term: BoundTerm[Any]) -> list[str]:
         self.visit_history.append("IS_NULL")
         return self.visit_history
 
-    def visit_not_null(self, term: BoundTerm[Any]) -> List[str]:
+    def visit_not_null(self, term: BoundTerm[Any]) -> list[str]:
         self.visit_history.append("NOT_NULL")
         return self.visit_history
 
-    def visit_equal(self, term: BoundTerm[Any], literal: Literal[Any]) -> List[str]:  # pylint: disable=redefined-outer-name
+    def visit_equal(self, term: BoundTerm[Any], literal: Literal[Any]) -> list[str]:  # pylint: disable=redefined-outer-name
         self.visit_history.append("EQUAL")
         return self.visit_history
 
-    def visit_not_equal(self, term: BoundTerm[Any], literal: Literal[Any]) -> List[str]:  # pylint: disable=redefined-outer-name
+    def visit_not_equal(self, term: BoundTerm[Any], literal: Literal[Any]) -> list[str]:  # pylint: disable=redefined-outer-name
         self.visit_history.append("NOT_EQUAL")
         return self.visit_history
 
-    def visit_greater_than_or_equal(self, term: BoundTerm[Any], literal: Literal[Any]) -> List[str]:  # pylint: disable=redefined-outer-name
+    def visit_greater_than_or_equal(self, term: BoundTerm[Any], literal: Literal[Any]) -> list[str]:  # pylint: disable=redefined-outer-name
         self.visit_history.append("GREATER_THAN_OR_EQUAL")
         return self.visit_history
 
-    def visit_greater_than(self, term: BoundTerm[Any], literal: Literal[Any]) -> List[str]:  # pylint: disable=redefined-outer-name
+    def visit_greater_than(self, term: BoundTerm[Any], literal: Literal[Any]) -> list[str]:  # pylint: disable=redefined-outer-name
         self.visit_history.append("GREATER_THAN")
         return self.visit_history
 
-    def visit_less_than(self, term: BoundTerm[Any], literal: Literal[Any]) -> List[str]:  # pylint: disable=redefined-outer-name
+    def visit_less_than(self, term: BoundTerm[Any], literal: Literal[Any]) -> list[str]:  # pylint: disable=redefined-outer-name
         self.visit_history.append("LESS_THAN")
         return self.visit_history
 
-    def visit_less_than_or_equal(self, term: BoundTerm[Any], literal: Literal[Any]) -> List[str]:  # pylint: disable=redefined-outer-name
+    def visit_less_than_or_equal(self, term: BoundTerm[Any], literal: Literal[Any]) -> list[str]:  # pylint: disable=redefined-outer-name
         self.visit_history.append("LESS_THAN_OR_EQUAL")
         return self.visit_history
 
-    def visit_true(self) -> List[str]:
+    def visit_true(self) -> list[str]:
         self.visit_history.append("TRUE")
         return self.visit_history
 
-    def visit_false(self) -> List[str]:
+    def visit_false(self) -> list[str]:
         self.visit_history.append("FALSE")
         return self.visit_history
 
-    def visit_not(self, child_result: List[str]) -> List[str]:
+    def visit_not(self, child_result: list[str]) -> list[str]:
         self.visit_history.append("NOT")
         return self.visit_history
 
-    def visit_and(self, left_result: List[str], right_result: List[str]) -> List[str]:
+    def visit_and(self, left_result: list[str], right_result: list[str]) -> list[str]:
         self.visit_history.append("AND")
         return self.visit_history
 
-    def visit_or(self, left_result: List[str], right_result: List[str]) -> List[str]:
+    def visit_or(self, left_result: list[str], right_result: list[str]) -> list[str]:
         self.visit_history.append("OR")
         return self.visit_history
 
-    def visit_starts_with(self, term: BoundTerm[Any], literal: Literal[Any]) -> List[str]:
+    def visit_starts_with(self, term: BoundTerm[Any], literal: Literal[Any]) -> list[str]:
         self.visit_history.append("STARTS_WITH")
         return self.visit_history
 
-    def visit_not_starts_with(self, term: BoundTerm[Any], literal: Literal[Any]) -> List[str]:
+    def visit_not_starts_with(self, term: BoundTerm[Any], literal: Literal[Any]) -> list[str]:
         self.visit_history.append("NOT_STARTS_WITH")
         return self.visit_history
 
@@ -1041,7 +1041,7 @@ def test_not_nan(schema: Schema, manifest: ManifestFile) -> None:
 
 
 def test_missing_stats(schema: Schema, manifest_no_stats: ManifestFile) -> None:
-    expressions: List[BooleanExpression] = [
+    expressions: list[BooleanExpression] = [
         LessThan(Reference("id"), 5),
         LessThanOrEqual(Reference("id"), 30),
         EqualTo(Reference("id"), 70),

--- a/tests/integration/test_catalog.py
+++ b/tests/integration/test_catalog.py
@@ -17,7 +17,7 @@
 
 import os
 from pathlib import Path, PosixPath
-from typing import Generator, List
+from typing import Generator
 
 import pytest
 
@@ -171,7 +171,7 @@ def test_load_table(test_catalog: Catalog, table_schema_nested: Schema, database
 
 @pytest.mark.integration
 @pytest.mark.parametrize("test_catalog", CATALOGS)
-def test_list_tables(test_catalog: Catalog, table_schema_nested: Schema, database_name: str, table_list: List[str]) -> None:
+def test_list_tables(test_catalog: Catalog, table_schema_nested: Schema, database_name: str, table_list: list[str]) -> None:
     test_catalog.create_namespace(database_name)
     for table_name in table_list:
         test_catalog.create_table((database_name, table_name), table_schema_nested)
@@ -443,7 +443,7 @@ def test_create_namespace_with_comment(test_catalog: Catalog, database_name: str
 
 @pytest.mark.integration
 @pytest.mark.parametrize("test_catalog", CATALOGS)
-def test_list_namespaces(test_catalog: Catalog, database_list: List[str]) -> None:
+def test_list_namespaces(test_catalog: Catalog, database_list: list[str]) -> None:
     for database_name in database_list:
         test_catalog.create_namespace(database_name)
     db_list = test_catalog.list_namespaces()

--- a/tests/integration/test_delete_count.py
+++ b/tests/integration/test_delete_count.py
@@ -17,7 +17,7 @@
 # pylint:disable=redefined-outer-name
 import random
 from datetime import datetime, timedelta
-from typing import Generator, List
+from typing import Generator
 
 import pyarrow as pa
 import pytest
@@ -34,7 +34,7 @@ from pyiceberg.transforms import HourTransform, IdentityTransform
 from pyiceberg.types import LongType, NestedField, StringType
 
 
-def run_spark_commands(spark: SparkSession, sqls: List[str]) -> None:
+def run_spark_commands(spark: SparkSession, sqls: list[str]) -> None:
     for sql in sqls:
         spark.sql(sql)
 

--- a/tests/integration/test_deletes.py
+++ b/tests/integration/test_deletes.py
@@ -16,7 +16,7 @@
 # under the License.
 # pylint:disable=redefined-outer-name
 from datetime import datetime
-from typing import Generator, List
+from typing import Generator
 
 import pyarrow as pa
 import pytest
@@ -34,7 +34,7 @@ from pyiceberg.transforms import IdentityTransform
 from pyiceberg.types import FloatType, IntegerType, LongType, NestedField, StringType, TimestampType
 
 
-def run_spark_commands(spark: SparkSession, sqls: List[str]) -> None:
+def run_spark_commands(spark: SparkSession, sqls: list[str]) -> None:
     for sql in sqls:
         spark.sql(sql)
 

--- a/tests/integration/test_partitioning_key.py
+++ b/tests/integration/test_partitioning_key.py
@@ -17,7 +17,7 @@
 # pylint:disable=redefined-outer-name
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
-from typing import Any, List
+from typing import Any
 
 import pytest
 from pyspark.sql import SparkSession
@@ -728,8 +728,8 @@ identifier = "default.test_table"
 def test_partition_key(
     session_catalog: Catalog,
     spark: SparkSession,
-    partition_fields: List[PartitionField],
-    partition_values: List[Any],
+    partition_fields: list[PartitionField],
+    partition_values: list[Any],
     expected_partition_record: Record,
     expected_hive_partition_path_slice: str,
     spark_create_table_sql_for_justification: str,

--- a/tests/integration/test_rest_manifest.py
+++ b/tests/integration/test_rest_manifest.py
@@ -20,7 +20,7 @@ import inspect
 from copy import copy
 from enum import Enum
 from tempfile import TemporaryDirectory
-from typing import Any, List
+from typing import Any
 
 import pytest
 from fastavro import reader
@@ -36,7 +36,7 @@ from pyiceberg.utils.lazydict import LazyDict
 
 # helper function to serialize our objects to dicts to enable
 # direct comparison with the dicts returned by fastavro
-def todict(obj: Any, spec_keys: List[str]) -> Any:
+def todict(obj: Any, spec_keys: list[str]) -> Any:
     if type(obj) is Record:
         return {key: obj[pos] for key, pos in zip(spec_keys, range(len(obj)), strict=True)}
     if isinstance(obj, dict) or isinstance(obj, LazyDict):

--- a/tests/integration/test_writes/test_partitioned_writes.py
+++ b/tests/integration/test_writes/test_partitioned_writes.py
@@ -18,7 +18,7 @@
 
 
 from datetime import date
-from typing import Any, Set
+from typing import Any
 
 import pyarrow as pa
 import pytest
@@ -1038,7 +1038,7 @@ def test_append_transform_partition_verify_partitions_count(
     arrow_table_date_timestamps: pa.Table,
     table_date_timestamps_schema: Schema,
     transform: Transform[Any, Any],
-    expected_partitions: Set[Any],
+    expected_partitions: set[Any],
     format_version: int,
 ) -> None:
     # Given

--- a/tests/integration/test_writes/test_writes.py
+++ b/tests/integration/test_writes/test_writes.py
@@ -24,7 +24,7 @@ import uuid
 from datetime import date, datetime, timedelta
 from decimal import Decimal
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 from urllib.parse import urlparse
 
 import fastavro
@@ -639,7 +639,7 @@ def test_write_parquet_compression_properties(
     session_catalog: Catalog,
     arrow_table_with_null: pa.Table,
     format_version: int,
-    properties: Dict[str, Any],
+    properties: dict[str, Any],
     expected_compression_name: str,
 ) -> None:
     identifier = "default.write_parquet_compression_properties"
@@ -674,8 +674,8 @@ def test_write_parquet_other_properties(
     spark: SparkSession,
     session_catalog: Catalog,
     arrow_table_with_null: pa.Table,
-    properties: Dict[str, Any],
-    expected_kwargs: Dict[str, Any],
+    properties: dict[str, Any],
+    expected_kwargs: dict[str, Any],
 ) -> None:
     identifier = "default.test_write_parquet_other_properties"
 
@@ -701,7 +701,7 @@ def test_write_parquet_unsupported_properties(
     spark: SparkSession,
     session_catalog: Catalog,
     arrow_table_with_null: pa.Table,
-    properties: Dict[str, str],
+    properties: dict[str, str],
 ) -> None:
     identifier = "default.write_parquet_unsupported_properties"
 

--- a/tests/integration/test_writes/utils.py
+++ b/tests/integration/test_writes/utils.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint:disable=redefined-outer-name
-from typing import List, Union
+from typing import Union
 
 import pyarrow as pa
 
@@ -63,7 +63,7 @@ def _create_table(
     session_catalog: Catalog,
     identifier: str,
     properties: Properties = EMPTY_DICT,
-    data: List[pa.Table] | None = None,
+    data: list[pa.Table] | None = None,
     partition_spec: PartitionSpec = UNPARTITIONED_PARTITION_SPEC,
     schema: Union[Schema, "pa.Schema"] = TABLE_SCHEMA,
 ) -> Table:

--- a/tests/io/test_fsspec.py
+++ b/tests/io/test_fsspec.py
@@ -20,7 +20,6 @@ import pickle
 import tempfile
 import threading
 import uuid
-from typing import List
 from unittest import mock
 
 import pytest
@@ -59,8 +58,8 @@ def test_fsspec_local_fs_can_create_path_without_parent_dir(fsspec_fileio: Fsspe
 
 def test_fsspec_get_fs_instance_per_thread_caching(fsspec_fileio: FsspecFileIO) -> None:
     """Test that filesystem instances are cached per-thread by `FsspecFileIO.get_fs`"""
-    fs_instances: List[AbstractFileSystem] = []
-    start_work_events: List[threading.Event] = [threading.Event() for _ in range(2)]
+    fs_instances: list[AbstractFileSystem] = []
+    start_work_events: list[threading.Event] = [threading.Event() for _ in range(2)]
 
     def get_fs(start_work_event: threading.Event) -> None:
         # Wait to be told to actually start getting the filesystem instances

--- a/tests/io/test_pyarrow.py
+++ b/tests/io/test_pyarrow.py
@@ -22,7 +22,7 @@ import uuid
 import warnings
 from datetime import date, datetime, timezone
 from pathlib import Path
-from typing import Any, List
+from typing import Any
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
@@ -1014,7 +1014,7 @@ def file_map(schema_map: Schema, tmpdir: str) -> str:
 
 
 def project(
-    schema: Schema, files: List[str], expr: BooleanExpression | None = None, table_schema: Schema | None = None
+    schema: Schema, files: list[str], expr: BooleanExpression | None = None, table_schema: Schema | None = None
 ) -> pa.Table:
     def _set_spec_id(datafile: DataFile) -> DataFile:
         datafile.spec_id = 0
@@ -2160,7 +2160,7 @@ def test_make_compatible_name() -> None:
         ([None, None, None], DateType(), None),
     ],
 )
-def test_stats_aggregator_update_min(vals: List[Any], primitive_type: PrimitiveType, expected_result: Any) -> None:
+def test_stats_aggregator_update_min(vals: list[Any], primitive_type: PrimitiveType, expected_result: Any) -> None:
     stats = StatsAggregator(primitive_type, _primitive_to_physical(primitive_type))
 
     for val in vals:
@@ -2180,7 +2180,7 @@ def test_stats_aggregator_update_min(vals: List[Any], primitive_type: PrimitiveT
         ([None, None, None], DateType(), None),
     ],
 )
-def test_stats_aggregator_update_max(vals: List[Any], primitive_type: PrimitiveType, expected_result: Any) -> None:
+def test_stats_aggregator_update_max(vals: list[Any], primitive_type: PrimitiveType, expected_result: Any) -> None:
     stats = StatsAggregator(primitive_type, _primitive_to_physical(primitive_type))
 
     for val in vals:

--- a/tests/io/test_pyarrow_stats.py
+++ b/tests/io/test_pyarrow_stats.py
@@ -30,9 +30,6 @@ from datetime import (
 from decimal import Decimal
 from typing import (
     Any,
-    Dict,
-    List,
-    Tuple,
 )
 
 import pyarrow as pa
@@ -81,8 +78,8 @@ class TestStruct:
 
 
 def construct_test_table(
-    write_statistics: bool | List[str] = True,
-) -> Tuple[pq.FileMetaData, TableMetadataV1 | TableMetadataV2]:
+    write_statistics: bool | list[str] = True,
+) -> tuple[pq.FileMetaData, TableMetadataV1 | TableMetadataV2]:
     table_metadata = {
         "format-version": 2,
         "location": "s3://bucket/test/location",
@@ -143,7 +140,7 @@ def construct_test_table(
 
     _list = [[1, 2, 3], [4, 5, 6], None, [7, 8, 9]]
 
-    _maps: List[Dict[int, int] | None] = [
+    _maps: list[dict[int, int] | None] = [
         {1: 2, 3: 4},
         None,
         {5: 6},
@@ -167,7 +164,7 @@ def construct_test_table(
         },
         schema=arrow_schema,
     )
-    metadata_collector: List[Any] = []
+    metadata_collector: list[Any] = []
 
     with pa.BufferOutputStream() as f:
         with pq.ParquetWriter(
@@ -422,7 +419,7 @@ def test_column_metrics_mode() -> None:
     assert 1 not in datafile.upper_bounds
 
 
-def construct_test_table_primitive_types() -> Tuple[pq.FileMetaData, TableMetadataV1 | TableMetadataV2]:
+def construct_test_table_primitive_types() -> tuple[pq.FileMetaData, TableMetadataV1 | TableMetadataV2]:
     table_metadata = {
         "format-version": 2,
         "location": "s3://bucket/test/location",
@@ -506,7 +503,7 @@ def construct_test_table_primitive_types() -> Tuple[pq.FileMetaData, TableMetada
         schema=arrow_schema,
     )
 
-    metadata_collector: List[Any] = []
+    metadata_collector: list[Any] = []
 
     with pa.BufferOutputStream() as f:
         with pq.ParquetWriter(f, table.schema, metadata_collector=metadata_collector, store_decimal_as_integer=True) as writer:
@@ -576,7 +573,7 @@ def test_metrics_primitive_types() -> None:
     assert not any(key in datafile.upper_bounds.keys() for key in [16, 17, 18])
 
 
-def construct_test_table_invalid_upper_bound() -> Tuple[pq.FileMetaData, TableMetadataV1 | TableMetadataV2]:
+def construct_test_table_invalid_upper_bound() -> tuple[pq.FileMetaData, TableMetadataV1 | TableMetadataV2]:
     table_metadata = {
         "format-version": 2,
         "location": "s3://bucket/test/location",
@@ -618,7 +615,7 @@ def construct_test_table_invalid_upper_bound() -> Tuple[pq.FileMetaData, TableMe
         schema=arrow_schema,
     )
 
-    metadata_collector: List[Any] = []
+    metadata_collector: list[Any] = []
 
     with pa.BufferOutputStream() as f:
         with pq.ParquetWriter(f, table.schema, metadata_collector=metadata_collector) as writer:

--- a/tests/table/test_expire_snapshots.py
+++ b/tests/table/test_expire_snapshots.py
@@ -16,7 +16,6 @@
 # under the License.
 import threading
 from datetime import datetime, timedelta
-from typing import Dict
 from unittest.mock import MagicMock, Mock
 from uuid import uuid4
 
@@ -253,7 +252,7 @@ def test_thread_safety_fix() -> None:
 
 def test_concurrent_operations() -> None:
     """Test concurrent operations with separate ExpireSnapshots instances."""
-    results: Dict[str, set[int]] = {"expire1_snapshots": set(), "expire2_snapshots": set()}
+    results: dict[str, set[int]] = {"expire1_snapshots": set(), "expire2_snapshots": set()}
 
     def worker1() -> None:
         expire1 = ExpireSnapshots(Mock())

--- a/tests/table/test_init.py
+++ b/tests/table/test_init.py
@@ -18,7 +18,7 @@
 import json
 import uuid
 from copy import copy
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 from pydantic import ValidationError
@@ -545,7 +545,7 @@ def test_update_column(table_v1: Table, table_v2: Table) -> None:
 
 
 def test_add_primitive_type_column(table_v2: Table) -> None:
-    primitive_type: Dict[str, PrimitiveType] = {
+    primitive_type: dict[str, PrimitiveType] = {
         "boolean": BooleanType(),
         "int": IntegerType(),
         "long": LongType(),
@@ -1221,7 +1221,7 @@ def test_correct_schema() -> None:
     assert "Snapshot not found: -1" in str(exc_info.value)
 
 
-def test_table_properties(example_table_metadata_v2: Dict[str, Any]) -> None:
+def test_table_properties(example_table_metadata_v2: dict[str, Any]) -> None:
     # metadata properties are all strings
     for k, v in example_table_metadata_v2["properties"].items():
         assert isinstance(k, str)
@@ -1239,7 +1239,7 @@ def test_table_properties(example_table_metadata_v2: Dict[str, Any]) -> None:
     assert isinstance(new_metadata.properties["property_name"], str)
 
 
-def test_table_properties_raise_for_none_value(example_table_metadata_v2: Dict[str, Any]) -> None:
+def test_table_properties_raise_for_none_value(example_table_metadata_v2: dict[str, Any]) -> None:
     property_with_none = {"property_name": None}
     example_table_metadata_v2 = {**example_table_metadata_v2, "properties": property_with_none}
     with pytest.raises(ValidationError) as exc_info:

--- a/tests/table/test_metadata.py
+++ b/tests/table/test_metadata.py
@@ -19,7 +19,7 @@
 import io
 import json
 from copy import copy
-from typing import Any, Dict
+from typing import Any
 from unittest.mock import MagicMock, patch
 from uuid import UUID
 
@@ -57,34 +57,34 @@ from pyiceberg.types import (
 )
 
 
-def test_from_dict_v1(example_table_metadata_v1: Dict[str, Any]) -> None:
+def test_from_dict_v1(example_table_metadata_v1: dict[str, Any]) -> None:
     """Test initialization of a TableMetadata instance from a dictionary"""
     TableMetadataUtil.parse_obj(example_table_metadata_v1)
 
 
-def test_from_dict_v1_parse_raw(example_table_metadata_v1: Dict[str, Any]) -> None:
+def test_from_dict_v1_parse_raw(example_table_metadata_v1: dict[str, Any]) -> None:
     """Test initialization of a TableMetadata instance from a str"""
     TableMetadataUtil.parse_raw(json.dumps(example_table_metadata_v1))
 
 
-def test_from_dict_v2(example_table_metadata_v2: Dict[str, Any]) -> None:
+def test_from_dict_v2(example_table_metadata_v2: dict[str, Any]) -> None:
     """Test initialization of a TableMetadata instance from a dictionary"""
     TableMetadataUtil.parse_obj(example_table_metadata_v2)
 
 
-def test_from_dict_v2_parse_raw(example_table_metadata_v2: Dict[str, Any]) -> None:
+def test_from_dict_v2_parse_raw(example_table_metadata_v2: dict[str, Any]) -> None:
     """Test initialization of a TableMetadata instance from a str"""
     TableMetadataUtil.parse_raw(json.dumps(example_table_metadata_v2))
 
 
-def test_from_byte_stream(example_table_metadata_v2: Dict[str, Any]) -> None:
+def test_from_byte_stream(example_table_metadata_v2: dict[str, Any]) -> None:
     """Test generating a TableMetadata instance from a file-like byte stream"""
     data = bytes(json.dumps(example_table_metadata_v2), encoding=UTF8)
     byte_stream = io.BytesIO(data)
     FromByteStream.table_metadata(byte_stream=byte_stream)
 
 
-def test_v2_metadata_parsing(example_table_metadata_v2: Dict[str, Any]) -> None:
+def test_v2_metadata_parsing(example_table_metadata_v2: dict[str, Any]) -> None:
     """Test retrieving values from a TableMetadata instance of version 2"""
     table_metadata = TableMetadataUtil.parse_obj(example_table_metadata_v2)
 
@@ -107,7 +107,7 @@ def test_v2_metadata_parsing(example_table_metadata_v2: Dict[str, Any]) -> None:
     assert table_metadata.default_sort_order_id == 3
 
 
-def test_v1_metadata_parsing_directly(example_table_metadata_v1: Dict[str, Any]) -> None:
+def test_v1_metadata_parsing_directly(example_table_metadata_v1: dict[str, Any]) -> None:
     """Test retrieving values from a TableMetadata instance of version 1"""
     table_metadata = TableMetadataV1(**example_table_metadata_v1)
 
@@ -138,14 +138,14 @@ def test_v1_metadata_parsing_directly(example_table_metadata_v1: Dict[str, Any])
     assert table_metadata.default_sort_order_id == 0
 
 
-def test_parsing_correct_types(example_table_metadata_v2: Dict[str, Any]) -> None:
+def test_parsing_correct_types(example_table_metadata_v2: dict[str, Any]) -> None:
     table_metadata = TableMetadataV2(**example_table_metadata_v2)
     assert isinstance(table_metadata.schemas[0], Schema)
     assert isinstance(table_metadata.schemas[0].fields[0], NestedField)
     assert isinstance(table_metadata.schemas[0].fields[0].field_type, LongType)
 
 
-def test_updating_metadata(example_table_metadata_v2: Dict[str, Any]) -> None:
+def test_updating_metadata(example_table_metadata_v2: dict[str, Any]) -> None:
     """Test creating a new TableMetadata instance that's an updated version of
     an existing TableMetadata instance"""
     table_metadata = TableMetadataV2(**example_table_metadata_v2)
@@ -170,20 +170,20 @@ def test_updating_metadata(example_table_metadata_v2: Dict[str, Any]) -> None:
     assert table_metadata.schemas[-1] == Schema(**new_schema)
 
 
-def test_serialize_v1(example_table_metadata_v1: Dict[str, Any]) -> None:
+def test_serialize_v1(example_table_metadata_v1: dict[str, Any]) -> None:
     table_metadata = TableMetadataV1(**example_table_metadata_v1)
     table_metadata_json = table_metadata.model_dump_json()
     expected = """{"location":"s3://bucket/test/location","table-uuid":"d20125c8-7284-442c-9aea-15fee620737c","last-updated-ms":1602638573874,"last-column-id":3,"schemas":[{"type":"struct","fields":[{"id":1,"name":"x","type":"long","required":true},{"id":2,"name":"y","type":"long","required":true,"doc":"comment"},{"id":3,"name":"z","type":"long","required":true}],"schema-id":0,"identifier-field-ids":[]}],"current-schema-id":0,"partition-specs":[{"spec-id":0,"fields":[{"source-id":1,"field-id":1000,"transform":"identity","name":"x"}]}],"default-spec-id":0,"last-partition-id":1000,"properties":{},"snapshots":[{"snapshot-id":1925,"timestamp-ms":1602638573822,"manifest-list":"s3://bucket/test/manifest-list"}],"snapshot-log":[],"metadata-log":[],"sort-orders":[{"order-id":0,"fields":[]}],"default-sort-order-id":0,"refs":{},"statistics":[],"partition-statistics":[],"format-version":1,"schema":{"type":"struct","fields":[{"id":1,"name":"x","type":"long","required":true},{"id":2,"name":"y","type":"long","required":true,"doc":"comment"},{"id":3,"name":"z","type":"long","required":true}],"schema-id":0,"identifier-field-ids":[]},"partition-spec":[{"name":"x","transform":"identity","source-id":1,"field-id":1000}]}"""
     assert table_metadata_json == expected
 
 
-def test_serialize_v2(example_table_metadata_v2: Dict[str, Any]) -> None:
+def test_serialize_v2(example_table_metadata_v2: dict[str, Any]) -> None:
     table_metadata = TableMetadataV2(**example_table_metadata_v2).model_dump_json()
     expected = """{"location":"s3://bucket/test/location","table-uuid":"9c12d441-03fe-4693-9a96-a0705ddf69c1","last-updated-ms":1602638573590,"last-column-id":3,"schemas":[{"type":"struct","fields":[{"id":1,"name":"x","type":"long","required":true}],"schema-id":0,"identifier-field-ids":[]},{"type":"struct","fields":[{"id":1,"name":"x","type":"long","required":true},{"id":2,"name":"y","type":"long","required":true,"doc":"comment"},{"id":3,"name":"z","type":"long","required":true}],"schema-id":1,"identifier-field-ids":[1,2]}],"current-schema-id":1,"partition-specs":[{"spec-id":0,"fields":[{"source-id":1,"field-id":1000,"transform":"identity","name":"x"}]}],"default-spec-id":0,"last-partition-id":1000,"properties":{"read.split.target.size":"134217728"},"current-snapshot-id":3055729675574597004,"snapshots":[{"snapshot-id":3051729675574597004,"sequence-number":0,"timestamp-ms":1515100955770,"manifest-list":"s3://a/b/1.avro","summary":{"operation":"append"}},{"snapshot-id":3055729675574597004,"parent-snapshot-id":3051729675574597004,"sequence-number":1,"timestamp-ms":1555100955770,"manifest-list":"s3://a/b/2.avro","summary":{"operation":"append"},"schema-id":1}],"snapshot-log":[{"snapshot-id":3051729675574597004,"timestamp-ms":1515100955770},{"snapshot-id":3055729675574597004,"timestamp-ms":1555100955770}],"metadata-log":[{"metadata-file":"s3://bucket/.../v1.json","timestamp-ms":1515100}],"sort-orders":[{"order-id":3,"fields":[{"source-id":2,"transform":"identity","direction":"asc","null-order":"nulls-first"},{"source-id":3,"transform":"bucket[4]","direction":"desc","null-order":"nulls-last"}]}],"default-sort-order-id":3,"refs":{"test":{"snapshot-id":3051729675574597004,"type":"tag","max-ref-age-ms":10000000},"main":{"snapshot-id":3055729675574597004,"type":"branch"}},"statistics":[],"partition-statistics":[],"format-version":2,"last-sequence-number":34}"""
     assert table_metadata == expected
 
 
-def test_serialize_v3(example_table_metadata_v3: Dict[str, Any]) -> None:
+def test_serialize_v3(example_table_metadata_v3: dict[str, Any]) -> None:
     # Writing will be part of https://github.com/apache/iceberg-python/issues/1551
 
     with pytest.raises(NotImplementedError) as exc_info:
@@ -192,7 +192,7 @@ def test_serialize_v3(example_table_metadata_v3: Dict[str, Any]) -> None:
     assert "Writing V3 is not yet supported, see: https://github.com/apache/iceberg-python/issues/1551" in str(exc_info.value)
 
 
-def test_migrate_v1_schemas(example_table_metadata_v1: Dict[str, Any]) -> None:
+def test_migrate_v1_schemas(example_table_metadata_v1: dict[str, Any]) -> None:
     table_metadata = TableMetadataV1(**example_table_metadata_v1)
 
     assert isinstance(table_metadata, TableMetadataV1)
@@ -200,7 +200,7 @@ def test_migrate_v1_schemas(example_table_metadata_v1: Dict[str, Any]) -> None:
     assert table_metadata.schemas[0] == table_metadata.schema_
 
 
-def test_migrate_v1_partition_specs(example_table_metadata_v1: Dict[str, Any]) -> None:
+def test_migrate_v1_partition_specs(example_table_metadata_v1: dict[str, Any]) -> None:
     # Copy the example, and add a spec
     table_metadata = TableMetadataV1(**example_table_metadata_v1)
     assert isinstance(table_metadata, TableMetadataV1)
@@ -281,7 +281,7 @@ def test_new_table_metadata_with_explicit_v1_format() -> None:
     assert actual.sort_orders == [expected_sort_order]
 
 
-def test_invalid_format_version(example_table_metadata_v1: Dict[str, Any]) -> None:
+def test_invalid_format_version(example_table_metadata_v1: dict[str, Any]) -> None:
     """Test the exception when trying to load an unknown version"""
 
     example_table_metadata_v22 = copy(example_table_metadata_v1)
@@ -449,7 +449,7 @@ def test_invalid_partition_spec() -> None:
     assert "default-spec-id 1 can't be found" in str(exc_info.value)
 
 
-def test_v1_writing_metadata(example_table_metadata_v1: Dict[str, Any]) -> None:
+def test_v1_writing_metadata(example_table_metadata_v1: dict[str, Any]) -> None:
     """
     https://iceberg.apache.org/spec/#version-2
 
@@ -464,7 +464,7 @@ def test_v1_writing_metadata(example_table_metadata_v1: Dict[str, Any]) -> None:
     assert "last-sequence-number" not in metadata_v1
 
 
-def test_v1_metadata_for_v2(example_table_metadata_v1: Dict[str, Any]) -> None:
+def test_v1_metadata_for_v2(example_table_metadata_v1: dict[str, Any]) -> None:
     """
     https://iceberg.apache.org/spec/#version-2
 
@@ -548,7 +548,7 @@ def test_v1_write_metadata_for_v2() -> None:
     assert "partition-spec" not in metadata_v2
 
 
-def test_v2_ref_creation(example_table_metadata_v2: Dict[str, Any]) -> None:
+def test_v2_ref_creation(example_table_metadata_v2: dict[str, Any]) -> None:
     table_metadata = TableMetadataV2(**example_table_metadata_v2)
     assert table_metadata.refs == {
         "main": SnapshotRef(

--- a/tests/table/test_puffin.py
+++ b/tests/table/test_puffin.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 from os import path
-from typing import List
 
 import pytest
 from pyroaring import BitMap
@@ -32,7 +31,7 @@ def _open_file(file: str) -> bytes:
 def test_map_empty() -> None:
     puffin = _open_file("64mapempty.bin")
 
-    expected: List[BitMap] = []
+    expected: list[BitMap] = []
     actual = _deserialize_bitmap(puffin)
 
     assert expected == actual

--- a/tests/table/test_sorting.py
+++ b/tests/table/test_sorting.py
@@ -16,7 +16,7 @@
 # under the License.
 # pylint:disable=redefined-outer-name,eval-used
 import json
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 
@@ -63,7 +63,7 @@ def test_deserialize_sort_order(sort_order: SortOrder) -> None:
     assert SortOrder.model_validate_json(payload) == sort_order
 
 
-def test_sorting_schema(example_table_metadata_v2: Dict[str, Any]) -> None:
+def test_sorting_schema(example_table_metadata_v2: dict[str, Any]) -> None:
     table_metadata = TableMetadataUtil.parse_raw(json.dumps(example_table_metadata_v2))
 
     assert table_metadata.sort_orders == [

--- a/tests/test_avro_sanitization.py
+++ b/tests/test_avro_sanitization.py
@@ -18,7 +18,7 @@
 
 
 import tempfile
-from typing import Any, Dict
+from typing import Any
 
 from fastavro import reader
 
@@ -72,7 +72,7 @@ def test_comprehensive_field_name_sanitization() -> None:
         schema = Schema(NestedField(field_id=1, name=original_name, field_type=StringType(), required=True))
 
         avro_schema: AvroType = AvroSchemaConversion().iceberg_to_avro(schema)
-        avro_dict: Dict[str, Any] = avro_schema
+        avro_dict: dict[str, Any] = avro_schema
 
         assert avro_dict["fields"][0]["name"] == expected_sanitized
 
@@ -126,7 +126,7 @@ def test_comprehensive_avro_compatibility() -> None:
             avro_reader = reader(fo)
 
             avro_schema: AvroType = avro_reader.writer_schema
-            avro_dict: Dict[str, Any] = avro_schema
+            avro_dict: dict[str, Any] = avro_schema
             field_names = [field["name"] for field in avro_dict["fields"]]
 
             # Expected sanitized names (matching Java implementation)
@@ -143,7 +143,7 @@ def test_comprehensive_avro_compatibility() -> None:
 
             # Verify iceberg-field-name properties
             for field in avro_dict["fields"]:
-                field_dict: Dict[str, Any] = field
+                field_dict: dict[str, Any] = field
                 if field_dict["name"] == "invalid_x2Efield":
                     assert "iceberg-field-name" in field_dict
                     assert field_dict["iceberg-field-name"] == "invalid.field"
@@ -201,7 +201,7 @@ def test_emoji_field_name_sanitization() -> None:
     )
 
     avro_schema: AvroType = AvroSchemaConversion().iceberg_to_avro(schema, schema_name="emoji_test")
-    avro_dict: Dict[str, Any] = avro_schema
+    avro_dict: dict[str, Any] = avro_schema
 
     field_names = [field["name"] for field in avro_dict["fields"]]
     expected_field_names = [
@@ -213,7 +213,7 @@ def test_emoji_field_name_sanitization() -> None:
     assert field_names == expected_field_names
 
     for field in avro_dict["fields"]:
-        field_dict: Dict[str, Any] = field
+        field_dict: dict[str, Any] = field
         if field_dict["name"] == "_x1F60E":
             assert field_dict["iceberg-field-name"] == "😎"
         elif field_dict["name"] == "_x1F60E_with_text":
@@ -240,13 +240,13 @@ def test_emoji_field_name_sanitization() -> None:
             avro_reader = reader(fo)
 
             avro_schema_reader: AvroType = avro_reader.writer_schema
-            avro_dict_reader: Dict[str, Any] = avro_schema_reader
+            avro_dict_reader: dict[str, Any] = avro_schema_reader
             field_names_reader = [field["name"] for field in avro_dict_reader["fields"]]
 
             assert field_names_reader == expected_field_names
 
             for field in avro_dict_reader["fields"]:
-                field_dict_reader: Dict[str, Any] = field
+                field_dict_reader: dict[str, Any] = field
                 if field_dict_reader["name"] == "_x1F60E":
                     assert field_dict_reader["iceberg-field-name"] == "😎"
                 elif field_dict_reader["name"] == "_x1F60E_with_text":

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -16,7 +16,7 @@
 # under the License.
 
 from textwrap import dedent
-from typing import Any, Dict, List
+from typing import Any
 
 import pyarrow as pa
 import pytest
@@ -409,8 +409,8 @@ def test_build_position_accessors(table_schema_nested: Schema) -> None:
 
 def test_build_position_accessors_with_struct(table_schema_nested: Schema) -> None:
     class TestStruct(StructProtocol):
-        def __init__(self, pos: Dict[int, Any] = EMPTY_DICT):
-            self._pos: Dict[int, Any] = pos
+        def __init__(self, pos: dict[int, Any] = EMPTY_DICT):
+            self._pos: dict[int, Any] = pos
 
         def __setitem__(self, pos: int, value: Any) -> None:
             pass
@@ -952,14 +952,14 @@ def test_unknown_type_promotion_to_non_primitive_raises_resolve_error() -> None:
 
 
 @pytest.fixture()
-def primitive_fields() -> List[NestedField]:
+def primitive_fields() -> list[NestedField]:
     return [
         NestedField(field_id=1, name=str(primitive_type), field_type=primitive_type, required=False)
         for primitive_type in TEST_PRIMITIVE_TYPES
     ]
 
 
-def test_add_top_level_primitives(primitive_fields: List[NestedField], table_v2: Table) -> None:
+def test_add_top_level_primitives(primitive_fields: list[NestedField], table_v2: Table) -> None:
     for primitive_field in primitive_fields:
         new_schema = Schema(primitive_field)
         applied = UpdateSchema(transaction=Transaction(table_v2), schema=Schema()).union_by_name(new_schema)._apply()
@@ -1025,7 +1025,7 @@ def test_add_nested_primitive(primitive_fields: NestedField, table_v2: Table) ->
         assert applied.as_struct() == new_schema.as_struct()
 
 
-def _primitive_fields(types: List[PrimitiveType], start_id: int = 0) -> List[NestedField]:
+def _primitive_fields(types: list[PrimitiveType], start_id: int = 0) -> list[NestedField]:
     fields = []
     for iceberg_type in types:
         fields.append(NestedField(field_id=start_id, name=str(iceberg_type), field_type=iceberg_type, required=False))

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -18,7 +18,7 @@
 import json
 import os
 import uuid
-from typing import Any, Dict, Tuple
+from typing import Any
 
 import pytest
 from pytest_mock import MockFixture
@@ -31,7 +31,7 @@ from pyiceberg.typedef import IcebergBaseModel
 
 
 def test_legacy_current_snapshot_id(
-    mocker: MockFixture, tmp_path_factory: pytest.TempPathFactory, example_table_metadata_no_snapshot_v1: Dict[str, Any]
+    mocker: MockFixture, tmp_path_factory: pytest.TempPathFactory, example_table_metadata_no_snapshot_v1: dict[str, Any]
 ) -> None:
     from pyiceberg.io.pyarrow import PyArrowFileIO
 
@@ -54,7 +54,7 @@ def test_legacy_current_snapshot_id(
 
 def test_null_serializer_field() -> None:
     class ExampleRequest(IcebergBaseModel):
-        requirements: Tuple[TableRequirement, ...]
+        requirements: tuple[TableRequirement, ...]
 
     request = ExampleRequest(requirements=(AssertRefSnapshotId(ref="main", snapshot_id=None),))
     dumped_json = request.model_dump_json()

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -16,7 +16,6 @@
 # under the License.
 # pylint: disable=W0123,W0613
 import pickle
-from typing import Type
 
 import pydantic_core
 import pytest
@@ -79,7 +78,7 @@ primitive_types = {
 
 
 @pytest.mark.parametrize("input_index, input_type", non_parameterized_types)
-def test_repr_primitive_types(input_index: int, input_type: Type[PrimitiveType]) -> None:
+def test_repr_primitive_types(input_index: int, input_type: type[PrimitiveType]) -> None:
     assert isinstance(eval(repr(input_type())), input_type)
     assert input_type == pickle.loads(pickle.dumps(input_type))
 
@@ -273,7 +272,7 @@ def test_nested_field_primitive_type_as_str() -> None:
 @pytest.mark.parametrize("input_index,input_type", non_parameterized_types)
 @pytest.mark.parametrize("check_index,check_type", non_parameterized_types)
 def test_non_parameterized_type_equality(
-    input_index: int, input_type: Type[PrimitiveType], check_index: int, check_type: Type[PrimitiveType]
+    input_index: int, input_type: type[PrimitiveType], check_index: int, check_type: type[PrimitiveType]
 ) -> None:
     if input_index == check_index:
         assert input_type() == check_type()

--- a/tests/utils/test_bin_packing.py
+++ b/tests/utils/test_bin_packing.py
@@ -16,7 +16,6 @@
 # under the License.
 
 import random
-from typing import List
 
 import pytest
 
@@ -38,11 +37,11 @@ INT_MAX = 2147483647
         ),  # sparse
     ],
 )
-def test_bin_packing(splits: List[int], lookback: int, split_size: int, open_cost: int) -> None:
+def test_bin_packing(splits: list[int], lookback: int, split_size: int, open_cost: int) -> None:
     def weight_func(x: int) -> int:
         return max(x, open_cost)
 
-    item_list_sums: List[int] = [sum(item) for item in PackingIterator(splits, split_size, lookback, weight_func)]
+    item_list_sums: list[int] = [sum(item) for item in PackingIterator(splits, split_size, lookback, weight_func)]
     assert all(split_size >= item_sum >= 0 for item_sum in item_list_sums)
 
 
@@ -80,7 +79,7 @@ def test_bin_packing(splits: List[int], lookback: int, split_size: int, open_cos
     ],
 )
 def test_bin_packing_lookback(
-    splits: List[int], target_weight: int, lookback: int, largest_bin_first: bool, expected_lists: List[List[int]]
+    splits: list[int], target_weight: int, lookback: int, largest_bin_first: bool, expected_lists: list[list[int]]
 ) -> None:
     def weight_func(x: int) -> int:
         return x
@@ -123,7 +122,7 @@ def test_bin_packing_lookback(
     ],
 )
 def test_reverse_bin_packing_lookback(
-    splits: List[int], target_weight: int, lookback: int, largest_bin_first: bool, expected_lists: List[List[int]]
+    splits: list[int], target_weight: int, lookback: int, largest_bin_first: bool, expected_lists: list[list[int]]
 ) -> None:
     packer: ListPacker[int] = ListPacker(target_weight, lookback, largest_bin_first)
     result = packer.pack_end(splits, lambda x: x)

--- a/tests/utils/test_concurrent.py
+++ b/tests/utils/test_concurrent.py
@@ -18,14 +18,14 @@
 import multiprocessing
 import os
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
-from typing import Dict, Generator
+from typing import Generator
 from unittest import mock
 
 import pytest
 
 from pyiceberg.utils.concurrent import ExecutorFactory
 
-EMPTY_ENV: Dict[str, str | None] = {}
+EMPTY_ENV: dict[str, str | None] = {}
 VALID_ENV = {"PYICEBERG_MAX_WORKERS": "5"}
 INVALID_ENV = {"PYICEBERG_MAX_WORKERS": "invalid"}
 

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import os
-from typing import Any, Dict
+from typing import Any
 from unittest import mock
 
 import pytest
@@ -148,7 +148,7 @@ def test_from_configuration_files_get_typed_value(tmp_path_factory: pytest.TempP
 def test_config_lookup_order(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path_factory: pytest.TempPathFactory,
-    config_setup: Dict[str, Any],
+    config_setup: dict[str, Any],
     expected_result: str | None,
 ) -> None:
     """

--- a/tests/utils/test_manifest.py
+++ b/tests/utils/test_manifest.py
@@ -16,7 +16,6 @@
 # under the License.
 # pylint: disable=redefined-outer-name,arguments-renamed,fixme
 from tempfile import TemporaryDirectory
-from typing import Dict
 from unittest.mock import patch
 
 import fastavro
@@ -51,7 +50,7 @@ def clear_global_manifests_cache() -> None:
     _manifest_cache.clear()
 
 
-def _verify_metadata_with_fastavro(avro_file: str, expected_metadata: Dict[str, str]) -> None:
+def _verify_metadata_with_fastavro(avro_file: str, expected_metadata: dict[str, str]) -> None:
     with open(avro_file, "rb") as f:
         reader = fastavro.reader(f)
         metadata = reader.metadata

--- a/tests/utils/test_schema_conversion.py
+++ b/tests/utils/test_schema_conversion.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=W0212
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 
@@ -40,7 +40,7 @@ from pyiceberg.types import (
 from pyiceberg.utils.schema_conversion import AvroSchemaConversion
 
 
-def test_avro_to_iceberg(avro_schema_manifest_file_v1: Dict[str, Any]) -> None:
+def test_avro_to_iceberg(avro_schema_manifest_file_v1: dict[str, Any]) -> None:
     iceberg_schema = AvroSchemaConversion().avro_to_iceberg(avro_schema_manifest_file_v1)
     expected_iceberg_schema = Schema(
         NestedField(
@@ -377,14 +377,14 @@ def test_logical_map_with_invalid_fields() -> None:
     assert "Invalid key-value pair schema:" in str(exc_info.value)
 
 
-def test_iceberg_to_avro_manifest_list(avro_schema_manifest_file_v1: Dict[str, Any]) -> None:
+def test_iceberg_to_avro_manifest_list(avro_schema_manifest_file_v1: dict[str, Any]) -> None:
     """Round trip the manifest list"""
     iceberg_schema = AvroSchemaConversion().avro_to_iceberg(avro_schema_manifest_file_v1)
     avro_result = AvroSchemaConversion().iceberg_to_avro(iceberg_schema, schema_name="manifest_file")
     assert avro_schema_manifest_file_v1 == avro_result
 
 
-def test_iceberg_to_avro_manifest(avro_schema_manifest_entry: Dict[str, Any]) -> None:
+def test_iceberg_to_avro_manifest(avro_schema_manifest_entry: dict[str, Any]) -> None:
     """Round trip the manifest itself"""
     iceberg_schema = AvroSchemaConversion().avro_to_iceberg(avro_schema_manifest_entry)
     avro_result = AvroSchemaConversion().iceberg_to_avro(iceberg_schema, schema_name="manifest_entry")


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->
Part of #2700 

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
This enables linter rule UP006.

Most of these changes revolve around using native-Python types instead of using typing imports.

This is a big one, sorry! It seems easier just to do this in a single PR (considering how mechanical this process is) as opposed to breaking it up.

## Are these changes tested?
`make lint` and `make test` should pass.

## Are there any user-facing changes?
None.

<!-- In the case of user-facing changes, please add the changelog label. -->
