### PR TITLE
dont need pyiceberg-core in some optional deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,19 +58,16 @@ pyarrow = [
     "pyiceberg-core>=0.5.1,<0.8.0",
 ]
 pandas = [
-    "pyarrow>=17.0.0",
-    "pyiceberg-core>=0.5.1,<0.8.0",
     "pandas>=1.0.0,<3.0.0",
+    "pyarrow>=17.0.0",
 ]
 duckdb = [
-    "pyarrow>=17.0.0",
-    "pyiceberg-core>=0.5.1,<0.8.0",
     "duckdb>=0.5.0,<2.0.0",
+    "pyarrow>=17.0.0",
 ]
 ray = [
-    "pyarrow>=17.0.0",
-    "pyiceberg-core>=0.5.1,<0.8.0",
     "ray>=2.10.0,<=2.44.0",
+    "pyarrow>=17.0.0",
     "pandas>=1.0.0,<3.0.0",
 ]
 bodo = ["bodo>=2025.7.4"]


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
Follow up to #2601 
`pandas`/`duckdb`/`ray` do not need `pyiceberg-core` 

This matches the previous pyproject.toml:
https://github.com/apache/iceberg-python/pull/2601/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L133-L157

## Are these changes tested?

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
