### PR TITLE
Remove deprecated datafusion APIs

### DIFF
--- a/mkdocs/docs/api.md
+++ b/mkdocs/docs/api.md
@@ -1965,7 +1965,7 @@ iceberg_table.append(data)
 
 # Register the table with DataFusion
 ctx = SessionContext()
-ctx.register_table_provider("test", iceberg_table)
+ctx.register_table("test", iceberg_table)
 
 # Query the table using DataFusion SQL
 ctx.table("test").show()

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -1555,7 +1555,7 @@ class Table:
 
         To support DataFusion features such as push down filtering, this function will return a PyCapsule
         interface that conforms to the FFI Table Provider required by DataFusion. From an end user perspective
-        you should not need to call this function directly. Instead you can use ``register_table_provider`` in
+        you should not need to call this function directly. Instead you can use ``register_table`` in
         the DataFusion SessionContext.
 
         Returns:
@@ -1572,7 +1572,7 @@ class Table:
             iceberg_table = catalog.create_table("default.test", schema=data.schema)
             iceberg_table.append(data)
             ctx = SessionContext()
-            ctx.register_table_provider("test", iceberg_table)
+            ctx.register_table("test", iceberg_table)
             ctx.table("test").show()
             ```
             Results in

--- a/tests/table/test_datafusion.py
+++ b/tests/table/test_datafusion.py
@@ -49,7 +49,7 @@ def test_datafusion_register_pyiceberg_table(catalog: Catalog, arrow_table_with_
     iceberg_table.append(arrow_table_with_null)
 
     ctx = SessionContext()
-    ctx.register_table_provider("test", iceberg_table)
+    ctx.register_table("test", iceberg_table)
 
     datafusion_table = ctx.table("test")
     assert datafusion_table is not None


### PR DESCRIPTION
# Rationale for this change

`register_table_provider` has been deprecated: https://datafusion.apache.org/python/autoapi/datafusion/context/index.html#datafusion.context.SessionContext.register_table_provider

<img width="743" height="163" alt="image" src="https://github.com/user-attachments/assets/737da056-ce93-4618-a0a6-99dea36e8273" />

## Are these changes tested?

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
