### PR TITLE
Fix `check-md-link` and allow manual trigger

### DIFF
--- a/.github/workflows/check-md-link.yml
+++ b/.github/workflows/check-md-link.yml
@@ -37,4 +37,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: tcort/github-action-markdown-link-check@v1
+    - uses: tcort/github-action-markdown-link-check@f3d33029dca1c4a24b87e2df648f9f4604ef6533


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
Closes #2705

This PR fixes `check-md-link` by pinning it to the [specific hash allowed in apache/infrastructure-actions](https://github.com/apache/infrastructure-actions/blob/ac09a0970d14dc1043a3787a95835c6efa07dd9c/actions.yml#L752-L753) and also allow manual trigger

## Are these changes tested?

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
