### PR TITLE
Define Explicit Public API Surface for Avro modules

### DIFF
--- a/pyiceberg/avro/__init__.py
+++ b/pyiceberg/avro/__init__.py
@@ -21,3 +21,8 @@ STRUCT_FLOAT = struct.Struct("<f")  # little-endian float
 STRUCT_DOUBLE = struct.Struct("<d")  # little-endian double
 STRUCT_INT32 = struct.Struct("<i")
 STRUCT_INT64 = struct.Struct("<q")
+
+# Imported after struct constants to avoid circular imports in encoder/decoder.
+from pyiceberg.avro.file import AvroFile, AvroFileHeader, AvroOutputFile  # noqa: E402
+
+__all__ = ["AvroFile", "AvroFileHeader", "AvroOutputFile"]

--- a/pyiceberg/avro/codecs/__init__.py
+++ b/pyiceberg/avro/codecs/__init__.py
@@ -50,3 +50,10 @@ KNOWN_CODECS: dict[AvroCompressionCodec, type[Codec] | None] = {
 
 # Map to convert the naming from Iceberg to Avro
 CODEC_MAPPING_ICEBERG_TO_AVRO: dict[str, str] = {"gzip": "deflate", "zstd": "zstandard"}
+
+__all__ = [
+    "AvroCompressionCodec",
+    "AVRO_CODEC_KEY",
+    "CODEC_MAPPING_ICEBERG_TO_AVRO",
+    "KNOWN_CODECS",
+]

--- a/pyiceberg/avro/decoder.py
+++ b/pyiceberg/avro/decoder.py
@@ -17,13 +17,13 @@
 import io
 from abc import ABC, abstractmethod
 from io import SEEK_CUR
-from typing import (
-    cast,
-)
+from typing import cast
 
 from pyiceberg.avro import STRUCT_DOUBLE, STRUCT_FLOAT
 from pyiceberg.io import InputStream
 from pyiceberg.typedef import UTF8
+
+__all__: list[str] = []
 
 
 class BinaryDecoder(ABC):

--- a/pyiceberg/avro/decoder_fast.pyi
+++ b/pyiceberg/avro/decoder_fast.pyi
@@ -17,6 +17,8 @@
 
 from pyiceberg.avro.decoder import BinaryDecoder
 
+__all__: list[str] = []
+
 class CythonBinaryDecoder(BinaryDecoder):
     def __init__(self, input_contents: bytes) -> None:
         pass

--- a/pyiceberg/avro/decoder_fast.pyx
+++ b/pyiceberg/avro/decoder_fast.pyx
@@ -23,6 +23,8 @@ from libc.stdint cimport uint64_t, int64_t
 
 import array
 
+__all__ = []
+
 
 cdef extern from "decoder_basic.c":
   void decode_zigzag_ints(const unsigned char **buffer, const uint64_t count, uint64_t *result);

--- a/pyiceberg/avro/encoder.py
+++ b/pyiceberg/avro/encoder.py
@@ -21,6 +21,8 @@ from pyiceberg.avro import STRUCT_DOUBLE, STRUCT_FLOAT
 from pyiceberg.io import OutputStream
 from pyiceberg.typedef import UTF8
 
+__all__: list[str] = []
+
 
 class BinaryEncoder:
     """Encodes Python physical types into bytes."""

--- a/pyiceberg/avro/file.py
+++ b/pyiceberg/avro/file.py
@@ -50,6 +50,8 @@ from pyiceberg.types import (
 )
 from pyiceberg.utils.schema_conversion import AvroSchemaConversion
 
+__all__: list[str] = []
+
 VERSION = 1
 MAGIC = bytes(b"Obj" + bytearray([VERSION]))
 MAGIC_SIZE = len(MAGIC)

--- a/pyiceberg/avro/reader.py
+++ b/pyiceberg/avro/reader.py
@@ -44,6 +44,8 @@ from pyiceberg.utils.decimal import bytes_to_decimal, decimal_required_bytes
 from pyiceberg.utils.lazydict import LazyDict
 from pyiceberg.utils.singleton import Singleton
 
+__all__: list[str] = []
+
 
 def _skip_map_array(decoder: BinaryDecoder, skip_entry: Callable[[], None]) -> None:
     """Skips over an array or map.

--- a/pyiceberg/avro/resolver.py
+++ b/pyiceberg/avro/resolver.py
@@ -107,6 +107,8 @@ from pyiceberg.types import (
     UUIDType,
 )
 
+__all__: list[str] = []
+
 STRUCT_ROOT = -1
 
 

--- a/pyiceberg/avro/writer.py
+++ b/pyiceberg/avro/writer.py
@@ -36,6 +36,8 @@ from pyiceberg.typedef import Record
 from pyiceberg.utils.decimal import decimal_required_bytes, decimal_to_bytes
 from pyiceberg.utils.singleton import Singleton
 
+__all__: list[str] = []
+
 
 @dataclass(frozen=True)
 class Writer(Singleton):


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

Reduce unintentionally exposed public surface. Related issue: https://github.com/apache/iceberg-python/issues/1099

## Are these changes tested?

## Are there any user-facing changes?

Yes - and intentionally so. The number of public APIs exposed through the avro modules will be reduced significantly.

A quick search through [Daft](https://github.com/search?q=repo%3AEventual-Inc%2FDaft%20%22pyiceberg.avro%22&type=code) and [DuckDB](https://github.com/search?q=repo%3Aduckdb%2Fduckdb%20%22pyiceberg.avro%22&type=code) showed no direct usage of `pyiceberg.avro` module and its child modules in their non-test code.

TODO:
- [ ] I'll generate the stats of public API numbers before and after this change and add it to this PR
- [ ] Changelog


<!-- In the case of user-facing changes, please add the changelog label. -->
