### PR TITLE
fix: Remove unused fields from FileScanTask

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -1786,22 +1786,16 @@ class FileScanTask(ScanTask):
 
     file: DataFile
     delete_files: set[DataFile]
-    start: int
-    length: int
     residual: BooleanExpression
 
     def __init__(
         self,
         data_file: DataFile,
         delete_files: set[DataFile] | None = None,
-        start: int | None = None,
-        length: int | None = None,
         residual: BooleanExpression = ALWAYS_TRUE,
     ) -> None:
         self.file = data_file
         self.delete_files = delete_files or set()
-        self.start = start or 0
-        self.length = length or data_file.file_size_in_bytes
         self.residual = residual
 
 


### PR DESCRIPTION
Closes #2776

# Rationale for this change

This PR removes the unused `start` and `length` fields from the `FileScanTask`. While working on the models for rest scanning in #2775 we noticed that these fields were initialized but never accessed or used anywhere in the code base.

## Are these changes tested?
```
> make test
...
3023 passed, 1392 deselected in 30.39s
```

## Are there any user-facing changes?
no
