### PR TITLE
feat: Make AND expression JSON serializable

### DIFF
--- a/pyiceberg/expressions/__init__.py
+++ b/pyiceberg/expressions/__init__.py
@@ -261,9 +261,6 @@ class And(IcebergBaseModel, BooleanExpression):
             return left
         else:
             obj = super().__new__(cls)
-            obj.__pydantic_fields_set__ = set()
-            obj.left = left
-            obj.right = right
             return obj
 
     def __eq__(self, other: Any) -> bool:
@@ -272,7 +269,7 @@ class And(IcebergBaseModel, BooleanExpression):
 
     def __str__(self) -> str:
         """Return the string representation of the And class."""
-        return f"{str(self.__class__.__name__)}(left={repr(self.left)}, right={repr(self.right)})"
+        return f"And(left={str(self.left)}, right={str(self.right)})"
 
     def __repr__(self) -> str:
         """Return the string representation of the And class."""

--- a/tests/expressions/test_expressions.py
+++ b/tests/expressions/test_expressions.py
@@ -725,6 +725,15 @@ def test_and() -> None:
         null & "abc"
 
 
+def test_and_serialization() -> None:
+    expr = And(EqualTo("x", 1), GreaterThan("y", 2))
+
+    assert (
+        expr.model_dump_json()
+        == '{"type":"and","left":{"term":"x","type":"eq","value":1},"right":{"term":"y","type":"gt","value":2}}'
+    )
+
+
 def test_or() -> None:
     null = IsNull(Reference("a"))
     nan = IsNaN(Reference("b"))

--- a/tests/table/test_partitioning.py
+++ b/tests/table/test_partitioning.py
@@ -21,7 +21,6 @@ from uuid import UUID
 
 import pytest
 
-from pyiceberg.expressions import And, EqualTo
 from pyiceberg.partitioning import UNPARTITIONED_PARTITION_SPEC, PartitionField, PartitionSpec
 from pyiceberg.schema import Schema
 from pyiceberg.transforms import (
@@ -123,13 +122,6 @@ def test_serialize_partition_spec() -> None:
     assert (
         partitioned.model_dump_json()
         == """{"spec-id":3,"fields":[{"source-id":1,"field-id":1000,"transform":"truncate[19]","name":"str_truncate"},{"source-id":2,"field-id":1001,"transform":"bucket[25]","name":"int_bucket"}]}"""
-    )
-
-
-def test_serialize_and_expression() -> None:
-    expr = And(EqualTo("foo", 1), EqualTo("bar", 2))
-    assert expr.model_dump_json(by_alias=True) == (
-        '{"type":"and","left":{"type":"equal_to","term":"foo","literal":1},"right":{"type":"equal_to","term":"bar","literal":2}}'
     )
 
 


### PR DESCRIPTION
Related to: #2518, #2775 

# Rationale for this change

This work was done by @Aniketsy, I just opened this to get the tests passing, and we can merge for scan planning. 

But, this PR allows `And` expressions to be deserialized from JSON through Pydantic. 

This PR aligns the `And` expression with the `Or`/`Not` pattern by adding `IcebergBaseModel` as an inherited class. This gets teh And expression into a proven serializable state, preparing it for the full expression tree [de]serializability work in #2783.

## Are these changes tested?

Yes added a test and ensure that they align with EpressionParser in Iceberg Java

## Are there any user-facing changes?

No this is just serialization

cc: @kevinjqliu @Fokko 