### PR TITLE
infra: use new `del_branch_on_merge` in .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -42,7 +42,9 @@ github:
         required_approving_review_count: 1
 
       required_linear_history: true
-  del_branch_on_merge: true
+  pull_requests:
+    # auto-delete head branches after being merged
+    del_branch_on_merge: true
   features:
     wiki: true
     issues: true


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
Previous use of `del_branch_on_merge` 
```
github:
  del_branch_on_merge: true
```
is deprecated, https://github.com/apache/infrastructure-asfyaml?tab=readme-ov-file#delete-branch-on-merge

New way is to 
```
github:
  pull_requests:
    del_branch_on_merge: true
```
https://github.com/apache/infrastructure-asfyaml?tab=readme-ov-file#pull_requests

## Are these changes tested?

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
