### PR TITLE
docs: Update pyiceberg CLI help docs

### DIFF
--- a/mkdocs/docs/cli.md
+++ b/mkdocs/docs/cli.md
@@ -33,24 +33,28 @@ You can pass the path to the Catalog using the `--uri` and `--credential` argume
 Usage: pyiceberg [OPTIONS] COMMAND [ARGS]...
 
 Options:
---catalog TEXT
---verbose BOOLEAN
---output [text|json]
---ugi TEXT
---uri TEXT
---credential TEXT
---help                Show this message and exit.
+  --catalog TEXT
+  --verbose BOOLEAN
+  --output [text|json]
+  --ugi TEXT
+  --uri TEXT
+  --credential TEXT
+  --help                Show this message and exit.
 
 Commands:
-describe    Describes a namespace or table
-drop        Operations to drop a namespace or table
-list        Lists tables or namespaces
-location    Returns the location of the table
-properties  Properties on tables/namespaces
-rename      Renames a table
-schema      Gets the schema of the table
-spec        Returns the partition spec of the table
-uuid        Returns the UUID of the table
+  create      Operation to create a namespace.
+  describe    Describe a namespace or a table.
+  drop        Operations to drop a namespace or table.
+  files       List all the files of the table.
+  list        List tables or namespaces.
+  list-refs   List all the refs in the provided table.
+  location    Return the location of the table.
+  properties  Properties on tables/namespaces.
+  rename      Rename a table.
+  schema      Get the schema of the table.
+  spec        Return the partition spec of the table.
+  uuid        Return the UUID of the table.
+  version     Print pyiceberg version.
 ```
 
 This example assumes that you have a default catalog set. If you want to load another catalog, for example, the rest example above. Then you need to set `--catalog rest`.


### PR DESCRIPTION
Hi folks, big fan of Iceberg! I noticed a tiny change in the cli docs. Correcting it here.

<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

Fix docs.

## Are these changes tested?

No tests against docs.

## Are there any user-facing changes?

Should now reflect in https://py.iceberg.apache.org/cli/#python-cli

<!-- In the case of user-facing changes, please add the changelog label. -->
