### PR TITLE
fix: Allow writing data with missing optional map fields

### DIFF
--- a/pyiceberg/schema.py
+++ b/pyiceberg/schema.py
@@ -1783,7 +1783,11 @@ class _SchemaCompatibilityVisitor(PreOrderSchemaVisitor[bool]):
         return all(results)
 
     def field(self, field: NestedField, field_result: Callable[[], bool]) -> bool:
-        return self._is_field_compatible(field) and field_result()
+        # Skip child validation for missing optional fields (#2797)
+        is_compatible = self._is_field_compatible(field)
+        if field.field_id not in self.provided_schema._lazy_id_to_field:
+            return is_compatible
+        return is_compatible and field_result()
 
     def list(self, list_type: ListType, element_result: Callable[[], bool]) -> bool:
         return self._is_field_compatible(list_type.element_field) and element_result()


### PR DESCRIPTION
## Summary
- Fixes #2684: Writing to a table with an optional map field fails when the data is missing that field
- Modified `_SchemaCompatibilityVisitor.field()` to skip child validation when optional parent is missing
- Added 5 unit tests for schema compatibility with optional nested fields

## Root Cause
When writing data to a table with an optional map field, the schema compatibility check incorrectly failed if the data was missing that field. This happened because the validator descended into the map's internal key field (which is always `required=True` per Iceberg spec) even when the parent map field was optional and missing.

## The Fix
Modified `_SchemaCompatibilityVisitor.field()` in `pyiceberg/schema.py` to check if the field exists in the provided schema before descending into children. If an optional parent field is missing, we skip child validation entirely.

## Test plan
- [x] All 328 schema tests pass
- [x] Lint passes (`make lint`)
- [x] New tests cover:
  - Optional map field missing (should pass) - main fix
  - Required map field missing (should fail)
  - Optional list field missing (should pass)
  - Optional struct field missing (should pass)
  - Optional map field present (should pass)