### PR TITLE
Write Deletion Vectors

### DIFF
--- a/pyiceberg/table/puffin.py
+++ b/pyiceberg/table/puffin.py
@@ -211,11 +211,11 @@ class PuffinWriter:
         self._blobs.append(
             PuffinBlobMetadata(
                 type="deletion-vector-v1",
-                fields=[2147483645], # Java INT_MAX - 2, reserved field id for deletion vectors
+                fields=[2147483645],  # Java INT_MAX - 2, reserved field id for deletion vectors
                 snapshot_id=-1,
                 sequence_number=-1,
-                offset=0, # TODO: Use DeleteFileIndex data
-                length=0, # TODO: Use DeleteFileIndex data
+                offset=0,  # TODO: Use DeleteFileIndex data
+                length=0,  # TODO: Use DeleteFileIndex data
                 properties=properties,
                 compression_codec=None,
             )
@@ -236,9 +236,7 @@ class PuffinWriter:
                 updated_blobs_metadata.append(PuffinBlobMetadata(**original_metadata_dict))
                 current_offset += len(blob_payload)
 
-            footer = Footer(
-                blobs=updated_blobs_metadata, properties={"created-by": self._created_by} if self._created_by else {}
-            )
+            footer = Footer(blobs=updated_blobs_metadata, properties={"created-by": self._created_by} if self._created_by else {})
             footer_payload_bytes = footer.model_dump_json(by_alias=True, exclude_none=True).encode("utf-8")
 
             # Final assembly

--- a/pyiceberg/table/puffin.py
+++ b/pyiceberg/table/puffin.py
@@ -17,7 +17,8 @@
 import io
 import math
 import zlib
-from typing import TYPE_CHECKING, Dict, Iterable, List, Literal, Optional
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import Field
 from pyroaring import BitMap, FrozenBitMap
@@ -65,9 +66,9 @@ def _deserialize_bitmap(pl: bytes) -> list[BitMap]:
     return bitmaps
 
 
-def _serialize_bitmaps(bitmaps: Dict[int, BitMap]) -> bytes:
+def _serialize_bitmaps(bitmaps: dict[int, BitMap]) -> bytes:
     """
-    Serializes a dictionary of bitmaps into a byte array.
+    Serialize a dictionary of bitmaps into a byte array.
 
     The format is:
     - 8 bytes: number of bitmaps (little-endian)
@@ -149,8 +150,8 @@ class PuffinFile:
 
 
 class PuffinWriter:
-    _blobs: List[PuffinBlobMetadata]
-    _blob_payloads: List[bytes]
+    _blobs: list[PuffinBlobMetadata]
+    _blob_payloads: list[bytes]
 
     def __init__(self) -> None:
         self._blobs = []
@@ -162,7 +163,7 @@ class PuffinWriter:
         referenced_data_file: str,
     ) -> None:
         # 1. Create bitmaps from positions
-        bitmaps: Dict[int, BitMap] = {}
+        bitmaps: dict[int, BitMap] = {}
         cardinality = 0
         for pos in positions:
             cardinality += 1
@@ -219,7 +220,7 @@ class PuffinWriter:
             for blob_payload in self._blob_payloads:
                 payload_buffer.write(blob_payload)
 
-            updated_blobs_metadata: List[PuffinBlobMetadata] = []
+            updated_blobs_metadata: list[PuffinBlobMetadata] = []
             current_offset = 4  # Start after file magic (4 bytes)
             for i, blob_payload in enumerate(self._blob_payloads):
                 original_metadata_dict = self._blobs[i].model_dump(by_alias=True, exclude_none=True)

--- a/pyiceberg/table/puffin.py
+++ b/pyiceberg/table/puffin.py
@@ -219,14 +219,16 @@ class PuffinWriter:
             for blob_payload in self._blob_payloads:
                 payload_buffer.write(blob_payload)
 
-            # Set offsets and lengths in metadata
-            current_offset = 4  # Start after file magic
+            updated_blobs_metadata: List[PuffinBlobMetadata] = []
+            current_offset = 4  # Start after file magic (4 bytes)
             for i, blob_payload in enumerate(self._blob_payloads):
-                self._blobs[i].offset = current_offset
-                self._blobs[i].length = len(blob_payload)
+                original_metadata_dict = self._blobs[i].model_dump(by_alias=True, exclude_none=True)
+                original_metadata_dict["offset"] = current_offset
+                original_metadata_dict["length"] = len(blob_payload)
+                updated_blobs_metadata.append(PuffinBlobMetadata(**original_metadata_dict))
                 current_offset += len(blob_payload)
 
-            footer = Footer(blobs=self._blobs)
+            footer = Footer(blobs=updated_blobs_metadata)
             footer_payload_bytes = footer.model_dump_json(by_alias=True, exclude_none=True).encode("utf-8")
 
             # Final assembly

--- a/tests/integration/test_puffin_spark_interop.py
+++ b/tests/integration/test_puffin_spark_interop.py
@@ -87,7 +87,7 @@ def test_read_spark_written_puffin_dv(spark: SparkSession, session_catalog: Rest
     dv_dict = puffin.to_vector()
     assert len(dv_dict) == 1, "Expected one data file's deletions"
 
-    for data_file_path, chunked_array in dv_dict.items():
+    for _data_file_path, chunked_array in dv_dict.items():
         positions = chunked_array.to_pylist()
         assert len(positions) == 4, f"Expected 4 deleted positions, got {len(positions)}"
         assert sorted(positions) == [9, 19, 29, 39], f"Unexpected positions: {positions}"

--- a/tests/integration/test_puffin_spark_interop.py
+++ b/tests/integration/test_puffin_spark_interop.py
@@ -1,0 +1,93 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import pytest
+from pyspark.sql import SparkSession
+
+from pyiceberg.catalog.rest import RestCatalog
+from pyiceberg.manifest import ManifestContent
+from pyiceberg.table.puffin import PuffinFile
+
+
+def run_spark_commands(spark: SparkSession, sqls: list[str]) -> None:
+    for sql in sqls:
+        spark.sql(sql)
+
+
+@pytest.mark.integration
+def test_read_spark_written_puffin_dv(spark: SparkSession, session_catalog: RestCatalog) -> None:
+    """Verify pyiceberg can read Puffin DVs written by Spark."""
+    identifier = "default.spark_puffin_format_test"
+
+    run_spark_commands(spark, [f"DROP TABLE IF EXISTS {identifier}"])
+    run_spark_commands(
+        spark,
+        [
+            f"""
+            CREATE TABLE {identifier} (id BIGINT)
+            USING iceberg
+            TBLPROPERTIES (
+                'format-version' = '3',
+                'write.delete.mode' = 'merge-on-read'
+            )
+            """,
+        ],
+    )
+
+    df = spark.range(1, 51)
+    df.coalesce(1).writeTo(identifier).append()
+
+    files_before = spark.sql(f"SELECT * FROM {identifier}.files").collect()
+    assert len(files_before) == 1, f"Expected 1 file, got {len(files_before)}"
+
+    run_spark_commands(spark, [f"DELETE FROM {identifier} WHERE id IN (10, 20, 30, 40)"])
+
+    table = session_catalog.load_table(identifier)
+    current_snapshot = table.current_snapshot()
+    assert current_snapshot is not None
+
+    manifests = current_snapshot.manifests(table.io)
+    delete_manifests = [m for m in manifests if m.content == ManifestContent.DELETES]
+    assert len(delete_manifests) > 0, "Expected delete manifest with DVs"
+
+    delete_manifest = delete_manifests[0]
+    entries = list(delete_manifest.fetch_manifest_entry(table.io))
+    assert len(entries) > 0, "Expected at least one delete file entry"
+
+    delete_entry = entries[0]
+    puffin_path = delete_entry.data_file.file_path
+    assert puffin_path.endswith(".puffin"), f"Expected Puffin file, got: {puffin_path}"
+
+    input_file = table.io.new_input(puffin_path)
+    with input_file.open() as f:
+        puffin_bytes = f.read()
+
+    puffin = PuffinFile(puffin_bytes)
+
+    assert len(puffin.footer.blobs) == 1, "Expected exactly one blob"
+
+    blob = puffin.footer.blobs[0]
+    assert blob.type == "deletion-vector-v1"
+    assert "referenced-data-file" in blob.properties
+    assert blob.properties["cardinality"] == "4"
+
+    dv_dict = puffin.to_vector()
+    assert len(dv_dict) == 1, "Expected one data file's deletions"
+
+    for data_file_path, chunked_array in dv_dict.items():
+        positions = chunked_array.to_pylist()
+        assert len(positions) == 4, f"Expected 4 deleted positions, got {len(positions)}"
+        assert sorted(positions) == [9, 19, 29, 39], f"Unexpected positions: {positions}"

--- a/tests/table/test_puffin.py
+++ b/tests/table/test_puffin.py
@@ -99,7 +99,7 @@ def test_puffin_round_trip() -> None:
     read_vectors = reader.to_vector()
 
     assert file_path in read_vectors
-    assert read_vectors[file_path].to_pylist() == sorted(list(set(deletions)))
+    assert read_vectors[file_path].to_pylist() == sorted(set(deletions))
 
 
 def test_write_and_read_puffin_file() -> None:

--- a/tests/table/test_puffin.py
+++ b/tests/table/test_puffin.py
@@ -19,7 +19,7 @@ from os import path
 import pytest
 from pyroaring import BitMap
 
-from pyiceberg.table.puffin import _deserialize_bitmap, PuffinFile, PuffinWriter
+from pyiceberg.table.puffin import _deserialize_bitmap, PuffinFile, PuffinWriter, PROPERTY_REFERENCED_DATA_FILE
 
 
 def _open_file(file: str) -> bytes:
@@ -94,11 +94,11 @@ def test_puffin_round_trip():
     assert len(reader.footer.blobs) == 2
     
     blob1_meta = reader.footer.blobs[0]
-    assert blob1_meta.properties[PuffinFile.PROPERTY_REFERENCED_DATA_FILE] == file1_path
+    assert blob1_meta.properties[PROPERTY_REFERENCED_DATA_FILE] == file1_path
     assert blob1_meta.properties["cardinality"] == str(len(deletions1))
 
     blob2_meta = reader.footer.blobs[1]
-    assert blob2_meta.properties[PuffinFile.PROPERTY_REFERENCED_DATA_FILE] == file2_path
+    assert blob2_meta.properties[PROPERTY_REFERENCED_DATA_FILE] == file2_path
     assert blob2_meta.properties["cardinality"] == str(len(deletions2))
 
     # Assert the content of deletion vectors

--- a/tests/table/test_puffin.py
+++ b/tests/table/test_puffin.py
@@ -19,7 +19,7 @@ from os import path
 import pytest
 from pyroaring import BitMap
 
-from pyiceberg.table.puffin import _deserialize_bitmap, PuffinFile, PuffinWriter, PROPERTY_REFERENCED_DATA_FILE
+from pyiceberg.table.puffin import PROPERTY_REFERENCED_DATA_FILE, PuffinFile, PuffinWriter, _deserialize_bitmap
 
 
 def _open_file(file: str) -> bytes:
@@ -73,10 +73,10 @@ def test_map_high_vals() -> None:
         _ = _deserialize_bitmap(puffin)
 
 
-def test_puffin_round_trip():
+def test_puffin_round_trip() -> None:
     # Define some deletion positions for multiple files
     deletions1 = [10, 20, 30]
-    deletions2 = [5, (1 << 32) + 1] # Test with a high-bit position
+    deletions2 = [5, (1 << 32) + 1]  # Test with a high-bit position
 
     file1_path = "path/to/data1.parquet"
     file2_path = "path/to/data2.parquet"
@@ -92,7 +92,7 @@ def test_puffin_round_trip():
 
     # Assert footer metadata
     assert len(reader.footer.blobs) == 2
-    
+
     blob1_meta = reader.footer.blobs[0]
     assert blob1_meta.properties[PROPERTY_REFERENCED_DATA_FILE] == file1_path
     assert blob1_meta.properties["cardinality"] == str(len(deletions1))
@@ -103,7 +103,7 @@ def test_puffin_round_trip():
 
     # Assert the content of deletion vectors
     read_vectors = reader.to_vector()
-    
+
     assert file1_path in read_vectors
     assert file2_path in read_vectors
 
@@ -111,7 +111,7 @@ def test_puffin_round_trip():
     assert read_vectors[file2_path].to_pylist() == sorted(deletions2)
 
 
-def test_write_and_read_puffin_file():
+def test_write_and_read_puffin_file() -> None:
     writer = PuffinWriter()
     writer.add(positions=[1, 2, 3], referenced_data_file="file1.parquet")
     writer.add(positions=[4, 5, 6], referenced_data_file="file2.parquet")
@@ -139,7 +139,7 @@ def test_write_and_read_puffin_file():
     assert vectors["file2.parquet"].to_pylist() == [4, 5, 6]
 
 
-def test_puffin_file_with_no_blobs():
+def test_puffin_file_with_no_blobs() -> None:
     writer = PuffinWriter()
     puffin_bytes = writer.finish()
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
Part of #2261

# Rationale for this change
This adds a PuffinWriter for writing deletion vectors.

Right now, it's just the writer class + some round trip tests (where we read + write the same file) to sanity check that the PuffinWriter works as expected. Writing Puffin files is very complex, so I wanted to make sure we all agreed on the writing semantics before using this elsewhere.

Let me know your thoughts on this (or if it's too granular)

## Are these changes tested?
Unit tests included

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
