### PR TITLE
infra: add the missing `setup-uv` step

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -78,6 +78,8 @@ jobs:
     - uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python }}
+    - name: Install UV
+      uses: astral-sh/setup-uv@v7
     - name: Install system dependencies
       run: sudo apt-get update && sudo apt-get install -y libkrb5-dev # for kerberos
     - name: Install


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
This is the only place where `astral-sh/setup-uv` step is missing in github actions. 

Since `uv` is not setup for this github action, the Makefile script will fallback to using `curl` to install `uv`, which can cause errors in run
For example, https://github.com/kevinjqliu/iceberg-python/actions/runs/20143215308/job/57816383548?pr=30#logs
```
Run make install
uv not found. Installing...
curl: (22) The requested URL returned error: 504
uv venv 
make: uv: No such file or directory
make: *** [Makefile:70: setup-venv] Error 127
Error: Process completed with exit code 2.
```

## Are these changes tested?

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
