### PR TITLE
feat: Add RESTscan Planning Endpoints and config

### DIFF
--- a/pyiceberg/catalog/rest/__init__.py
+++ b/pyiceberg/catalog/rest/__init__.py
@@ -133,6 +133,7 @@ SNAPSHOT_LOADING_MODE = "snapshot-loading-mode"
 AUTH = "auth"
 CUSTOM = "custom"
 REST_SCAN_PLANNING_ENABLED = "rest-scan-planning-enabled"
+REST_SCAN_PLANNING_ENABLED_DEFAULT = False
 
 NAMESPACE_SEPARATOR = b"\x1f".decode(UTF8)
 
@@ -272,13 +273,13 @@ class RestCatalog(Catalog):
 
         return session
 
-    def is_scan_planning_enabled(self) -> bool:
-        """Check if server-side scan planning is enabled.
+    def is_rest_scan_planning_enabled(self) -> bool:
+        """Check if rest server-side scan planning is enabled.
 
         Returns:
             True if enabled, False otherwise.
         """
-        return property_as_bool(self.properties, REST_SCAN_PLANNING_ENABLED, False)
+        return property_as_bool(self.properties, REST_SCAN_PLANNING_ENABLED, REST_SCAN_PLANNING_ENABLED_DEFAULT)
 
     def _create_legacy_oauth2_auth_manager(self, session: Session) -> AuthManager:
         """Create the LegacyOAuth2AuthManager by fetching required properties.

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -1994,7 +1994,7 @@ class TestRestCatalogClose:
         assert catalog is not None and hasattr(catalog, "_session")
         assert len(catalog._session.adapters) == self.EXPECTED_ADAPTERS_SIGV4
 
-    def test_scan_planning_disabled_by_default(self, rest_mock: Mocker) -> None:
+    def test_rest_scan_planning_disabled_by_default(self, rest_mock: Mocker) -> None:
         rest_mock.get(
             f"{TEST_URI}v1/config",
             json={"defaults": {}, "overrides": {}},
@@ -2002,9 +2002,9 @@ class TestRestCatalogClose:
         )
         catalog = RestCatalog("rest", uri=TEST_URI, token=TEST_TOKEN)
 
-        assert catalog.is_scan_planning_enabled() is False
+        assert catalog.is_rest_scan_planning_enabled() is False
 
-    def test_scan_planning_enabled_by_property(self, rest_mock: Mocker) -> None:
+    def test_rest_scan_planning_enabled_by_property(self, rest_mock: Mocker) -> None:
         rest_mock.get(
             f"{TEST_URI}v1/config",
             json={"defaults": {}, "overrides": {}},
@@ -2017,9 +2017,9 @@ class TestRestCatalogClose:
             **{"rest-scan-planning-enabled": "true"},
         )
 
-        assert catalog.is_scan_planning_enabled() is True
+        assert catalog.is_rest_scan_planning_enabled() is True
 
-    def test_scan_planning_explicitly_disabled(self, rest_mock: Mocker) -> None:
+    def test_rest_scan_planning_explicitly_disabled(self, rest_mock: Mocker) -> None:
         rest_mock.get(
             f"{TEST_URI}v1/config",
             json={"defaults": {}, "overrides": {}},
@@ -2029,12 +2029,12 @@ class TestRestCatalogClose:
             "rest",
             uri=TEST_URI,
             token=TEST_TOKEN,
-            **{"rest.scan-planning.enabled": "false"},
+            **{"rest-scan-planning-enabled": "false"},
         )
 
-        assert catalog.is_scan_planning_enabled() is False
+        assert catalog.is_rest_scan_planning_enabled() is False
 
-    def test_scan_planning_enabled_from_server_config(self, rest_mock: Mocker) -> None:
+    def test_rest_scan_planning_enabled_from_server_config(self, rest_mock: Mocker) -> None:
         rest_mock.get(
             f"{TEST_URI}v1/config",
             json={"defaults": {"rest-scan-planning-enabled": "true"}, "overrides": {}},
@@ -2042,4 +2042,4 @@ class TestRestCatalogClose:
         )
         catalog = RestCatalog("rest", uri=TEST_URI, token=TEST_TOKEN)
 
-        assert catalog.is_scan_planning_enabled() is True
+        assert catalog.is_rest_scan_planning_enabled() is True


### PR DESCRIPTION
related to #2775 

# Rationale for this change
This PR adds some of the rest scanning endpoints needed for the synchronous scan planning And the configuration property used to determine scan planning support. 

Aligning with the java implementation in https://github.com/apache/iceberg/pull/13400.

## Usage

```
catalog = RestCatalog(
 "the-best-rest-catalog", uri="http://127.0.0.1:8181", **{"rest.scan-planning.enabled": "true"},
)
```
Ideally we only would want to use rest scan planning if the catalog is **_capable_**. I remember there was a PR open for this at one point but can't seem to find it.

## Are these changes tested?

## Are there any user-facing changes?

new property to configure scanning 