### PR TITLE
fix: Add Cython build step to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,12 +70,9 @@ setup-venv: ## Create virtual environment
 	uv venv $(PYTHON_ARG)
 
 install-dependencies: setup-venv ## Install all dependencies including extras
-	uv sync $(PYTHON_ARG) --all-extras
+	uv sync $(PYTHON_ARG) --all-extras --reinstall
 
-install: install-uv install-dependencies build-ext ## Install uv and dependencies
-
-build-ext: ## Build Cython extensions
-	uv run $(PYTHON_ARG) python setup.py build_ext --inplace
+install: install-uv install-dependencies ## Install uv and dependencies
 
 # ===============
 # Code Validation


### PR DESCRIPTION
# Rationale for this change

Currently, uv sync is building the Cython extensions on first install. After running `make clean` (which deletes .so files), subsequent uv sync does not rebuild them, causing:

```
  ModuleNotFoundError: No module named 'pyiceberg.avro.decoder_fast'
```

This seems to be related to some known uv behavior: https://github.com/astral-sh/uv/issues/12399. The `--reinstall` flag forces uv to rebuild the package and its extensions.

> Note: CI works because it always starts fresh. Local dev breaks after make clean.

## Are these changes tested?

`make clean && make test`

## Are there any user-facing changes?

new make target
