### PR TITLE
chore: Use `SnapshotRefType` Enum instead of hard-coded strings

### DIFF
--- a/pyiceberg/table/update/snapshot.py
+++ b/pyiceberg/table/update/snapshot.py
@@ -880,7 +880,7 @@ class ManageSnapshots(UpdateTableMetadata["ManageSnapshots"]):
         update, requirement = self._transaction._set_ref_snapshot(
             snapshot_id=snapshot_id,
             ref_name=tag_name,
-            type="tag",
+            type=SnapshotRefType.TAG,
             max_ref_age_ms=max_ref_age_ms,
         )
         self._updates += update
@@ -921,7 +921,7 @@ class ManageSnapshots(UpdateTableMetadata["ManageSnapshots"]):
         update, requirement = self._transaction._set_ref_snapshot(
             snapshot_id=snapshot_id,
             ref_name=branch_name,
-            type="branch",
+            type=SnapshotRefType.BRANCH,
             max_ref_age_ms=max_ref_age_ms,
             max_snapshot_age_ms=max_snapshot_age_ms,
             min_snapshots_to_keep=min_snapshots_to_keep,


### PR DESCRIPTION
# Rationale for this change
Use the enum instead of hard-coded strings!

Everywhere else that `"branch"` and `"tag"` are used seems to be in tests so I think fine to leave those alone

## Are these changes tested?
No functional changes

## Are there any user-facing changes?
No