### PR TITLE
infra: auto update docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ test-integration: test-integration-setup test-integration-exec test-integration-
 test-integration-setup: ## Start Docker services for integration tests
 	docker compose -f dev/docker-compose-integration.yml kill
 	docker compose -f dev/docker-compose-integration.yml rm -f
-	docker compose -f dev/docker-compose-integration.yml up -d --wait
+	docker compose -f dev/docker-compose-integration.yml up -d --build --wait
 	uv run $(PYTHON_ARG) python dev/provision.py
 
 test-integration-exec: ## Run integration tests (excluding provision)


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
Add the `--build` flag to `docker compose up`. This will trigger docker to rebuild if the docker-compose file or the Dockerfile is changed. 

This is useful when we need to change the `ICEBERG_VERSION` in [dev/spark/Dockerfile](https://github.com/apache/iceberg-python/blob/dea80784a5f9d6936a605c7ccb0f3f8d4ba30d9d/dev/spark/Dockerfile#L21). 
Previously, `make integration` will not pick up the new `ICEBERG_VERSION` change. It will only be picked up by rebuilding the image explicitly with `make test-integration-rebuild`.
With this PR, the `ICEBERG_VERSION` will be picked up automatically. The new Iceberg jar will be downloaded and the rest of the docker artifacts will be cached. 

## Are these changes tested?
Yes, locally using `ICEBERG_VERSION=1.10.1`

## Are there any user-facing changes?
No
<!-- In the case of user-facing changes, please add the changelog label. -->
