### PR TITLE
Fix live reload for `make docs-serve`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ docs-install: ## Install docs dependencies (included in default groups)
 	uv sync $(PYTHON_ARG) --group docs
 
 docs-serve: ## Serve local docs preview (hot reload)
-	uv run $(PYTHON_ARG) mkdocs serve -f mkdocs/mkdocs.yml
+	uv run $(PYTHON_ARG) mkdocs serve -f mkdocs/mkdocs.yml --livereload
 
 docs-build: ## Build the static documentation site
 	uv run $(PYTHON_ARG) mkdocs build -f mkdocs/mkdocs.yml --strict


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
`make docs-serve` use to live reload on change. This PR fixes the underlying issue, thanks to https://github.com/mkdocs/mkdocs/issues/4032#issuecomment-3591002290
From the same thread, it looks like the underlying issue the `click>8.2.1` which we're using (#2762). click 8.3.2 should fix the issue, https://github.com/mkdocs/mkdocs/issues/4032#issuecomment-3644653585
but it doesnt hurt to always explicitly call `--livereload`

## Are these changes tested?

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
