### PR TITLE
add X-Client-Version header to rest client

### DIFF
--- a/pyiceberg/catalog/rest/__init__.py
+++ b/pyiceberg/catalog/rest/__init__.py
@@ -491,7 +491,7 @@ class RestCatalog(Catalog):
         session.headers.update(header_properties)
         session.headers["Content-type"] = "application/json"
         session.headers["User-Agent"] = f"PyIceberg/{__version__}"
-        session.headers["X-Client-Version"] = f"Apache PyIceberg {__version__}"
+        session.headers["X-Client-Version"] = f"PyIceberg {__version__}"
         session.headers.setdefault("X-Iceberg-Access-Delegation", ACCESS_DELEGATION_DEFAULT)
 
     def _create_table(

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -1924,8 +1924,8 @@ def test_auth_header(rest_mock: Mocker) -> None:
 
 def test_client_version_header(rest_mock: Mocker) -> None:
     catalog = RestCatalog("rest", uri=TEST_URI, warehouse="s3://some-bucket")
-    assert catalog._session.headers.get("X-Client-Version") == f"Apache PyIceberg {pyiceberg.__version__}"
-    assert rest_mock.last_request.headers["X-Client-Version"] == f"Apache PyIceberg {pyiceberg.__version__}"
+    assert catalog._session.headers.get("X-Client-Version") == f"PyIceberg {pyiceberg.__version__}"
+    assert rest_mock.last_request.headers["X-Client-Version"] == f"PyIceberg {pyiceberg.__version__}"
 
 
 class TestRestCatalogClose:


### PR DESCRIPTION
Closes #2373 

# Rationale for this change
Bringing parity to the headers in Python. 
The version is as per the [HttpClient in Java](https://github.com/apache/iceberg/blob/68e555b94f4706a2af41dcb561c84007230c0bc1/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java#L533-L534) and the version string is matching [IcebergBuild](https://github.com/apache/iceberg/blob/779af12312fcf70c1e6e52d610d64cf947fd0a4f/api/src/main/java/org/apache/iceberg/IcebergBuild.java#L67) but with `PyIceberg` instead of Iceberg.

Previously, this was worked on #2652 but since that has stalled, adding a fix to close our the issue. Thanks to @jaimeferj for his original PR.

## Are these changes tested?
- Added a test in `tests/catalog/test_rest.py` - `test_client_version_header`

## Are there any user-facing changes?
No
