### PR TITLE
Fixing nightly build failure

### DIFF
--- a/.github/workflows/pypi-build-artifacts.yml
+++ b/.github/workflows/pypi-build-artifacts.yml
@@ -70,7 +70,7 @@ jobs:
           # Ignore 32 bit architectures
           CIBW_ARCHS: "auto64"
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.10,<3.14"
-          CIBW_TEST_REQUIRES: "pytest==7.4.2 moto==5.0.1"
+          CIBW_TEST_REQUIRES: "pytest==7.4.2 moto==5.0.1 pytest-lazy-fixture==0.6.3 sqlalchemy>=2.0.18,<3"
           CIBW_TEST_COMMAND: "pytest {project}/tests/avro/test_decoder.py"
           # Ignore tests for pypy since not all dependencies are compiled for it
           # and would require a local rust build chain

--- a/.github/workflows/svn-build-artifacts.yml
+++ b/.github/workflows/svn-build-artifacts.yml
@@ -65,7 +65,7 @@ jobs:
           # Ignore 32 bit architectures
           CIBW_ARCHS: "auto64"
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.10,<3.14"
-          CIBW_TEST_REQUIRES: "pytest==7.4.2 moto==5.0.1"
+          CIBW_TEST_REQUIRES: "pytest==7.4.2 moto==5.0.1 pytest-lazy-fixture==0.6.3 sqlalchemy>=2.0.18,<3"
           CIBW_TEST_COMMAND: "pytest {project}/tests/avro/test_decoder.py"
           # Ignore tests for pypy since not all dependencies are compiled for it
           # and would require a local rust build chain


### PR DESCRIPTION
Closes #2911 

# Rationale for this change
PR #2906 added imports to `tests/conftest.py` that require `pytest-lazy-fixture` and `sqlalchemy`. The nightly build's wheel test uses a minimal environment that doesn't include these dependencies, causing `tests/avro/test_decoder.py` to fail when loading `conftest.py`.

## Are these changes tested?
Yes. Reproduced locally by creating a minimal venv with only the original test dependencies, reproduced the failure, then verified the fix resolves it. 

## Are there any user-facing changes?
No
