### PR TITLE
fix: nanos_to_hours returning incorrect hour values

### DIFF
--- a/pyiceberg/utils/datetime.py
+++ b/pyiceberg/utils/datetime.py
@@ -273,7 +273,7 @@ def nanos_to_time(nanos: int) -> time:
 
 def nanos_to_hours(nanos: int) -> int:
     """Convert a timestamp in nanoseconds to hours from 1970-01-01T00:00."""
-    return nanos // 3_600_000_000_0000
+    return nanos // 3_600_000_000_000
 
 
 def nanos_to_micros(nanos: int) -> int:

--- a/tests/utils/test_datetime.py
+++ b/tests/utils/test_datetime.py
@@ -23,6 +23,7 @@ from pyiceberg.utils.datetime import (
     datetime_to_millis,
     datetime_to_nanos,
     millis_to_datetime,
+    nanos_to_hours,
     nanos_to_micros,
     time_str_to_nanos,
     time_to_nanos,
@@ -132,3 +133,14 @@ def test_timestamptz_to_nanos(timestamp: str, nanos: int) -> None:
 @pytest.mark.parametrize("nanos, micros", [(1510871468000001001, 1510871468000001), (-1510871468000001001, -1510871468000002)])
 def test_nanos_to_micros(nanos: int, micros: int) -> None:
     assert micros == nanos_to_micros(nanos)
+
+
+@pytest.mark.parametrize(
+    "nanos, hours",
+    [
+        (1510871468000001001, 419686),
+        (-1510871468000001001, -419687),
+    ],
+)
+def test_nanos_to_hours(nanos: int, hours: int) -> None:
+    assert hours == nanos_to_hours(nanos)


### PR DESCRIPTION
# Rationale for this change
This PR removes an extra 0 from the nanos_to_hours conversion method which resulted in incorrect partitioning. Found this while testing out the V3 `TimestampNanoType` and partitioning. 

## Are these changes tested?
Yes, I added some tests from the java side to ensure we align.

- https://github.com/apache/iceberg/blob/9b573c7b46950a41d614c4240752f255282d8c1f/api/src/test/java/org/apache/iceberg/util/TestDateTimeUtil.java#L70

## Are there any user-facing changes?
No
