### PR TITLE
Adding a sort order validation test

### DIFF
--- a/tests/integration/test_rest_catalog.py
+++ b/tests/integration/test_rest_catalog.py
@@ -66,9 +66,9 @@ def test_create_namespace_if_already_existing(catalog: RestCatalog) -> None:
 @pytest.mark.integration
 @pytest.mark.parametrize("catalog", [pytest.lazy_fixture("session_catalog")])
 def test_create_table_invalid_sort_order(catalog: RestCatalog) -> None:
+    from pyiceberg.catalog.rest import Endpoints
     from pyiceberg.schema import Schema
     from pyiceberg.types import LongType, NestedField
-    from pyiceberg.catalog.rest import Endpoints
 
     namespace = "default"
     table_name = "test_invalid_sort_order"


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
This test shows the error that iceberg-rest-fixture is throwing for a Sort Order that references a field that doesn't exist.

## Are these changes tested?

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
