### PR TITLE
chore: remove redundant flynt pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,14 +63,6 @@ repos:
           ]
         additional_dependencies:
           - tomli==2.0.1
-  - repo: https://github.com/ikamensh/flynt
-    rev: 1.0.6
-    hooks:
-      - id: flynt
-        args:
-          # --line-length is set to a high value to deal with very long lines
-          - --line-length
-          - '99999'
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
     hooks:


### PR DESCRIPTION
# Rationale for this change

While working on the `ty` integration, I've been auditing the pre-commit hooks. This PR removes the `flynt` pre-commit hook since it;s redundant with ruff's `UP031` and `UP032` rules which are already enabled via the `UP` selector in  our `ruff.toml`.

`flynt` converts `.format()` and `%` style string formatting to f-strings. Ruff's pyupgrade rules do the same:
- **UP031**: `printf-string-formatting`: [converts `%` formatting](https://docs.astral.sh/ruff/rules/printf-string-formatting/)
- **UP032**: `f-string`: [converts `.format()` calls
](https://docs.astral.sh/ruff/rules/f-string/)

and both produce identical results

## Are these changes tested?

`make lint`

Manual tests:

Code: `"Hello, {}".format(name)` 
 - flynt: `f"Hello, {name}"` 
 - ruff: `f"Hello, {name}"` 

## Are there any user-facing changes?

No
