### PR TITLE
chore: replace debug-statements hook with ruff T100

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,6 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
-      - id: debug-statements
       - id: check-yaml
       - id: check-ast
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/ruff.toml
+++ b/ruff.toml
@@ -56,6 +56,7 @@ select = [
     "C4", # flake8-comprehensions
     "I", # isort
     "UP", # pyupgrade
+    "T100", # flake8-debugger
 ]
 ignore = []
 


### PR DESCRIPTION
# Rationale for this change

Like #2953, doing a dive into the linted dependencies we can replace the `debug-statements` pre-commit hook with ruff's [`T100` rule flake8-debugger](https://docs.astral.sh/ruff/rules/debugger/).

This will lighten the linters needed when working on cb. 

T100 catches more modern debuggers (`debugpy`, `ptvsd`, `IPython.embed`). It seems like there are rare debuggers it misses but aren't used like `bpdb`.

## Are these changes tested?

`make lint`

```
> ruff check --select T100 pyiceberg/ tests/
All checks passed!
```

## Are there any user-facing changes?
No
