### PR TITLE
Remove Pandas 3 Version Restriction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ duckdb = [
 ray = [
     "ray>=2.10.0,<3.0.0",
     "pyarrow>=17.0.0",
-    "pandas>=1.0.0,<3.0.0",
+    "pandas>=1.0.0",
 ]
 bodo = ["bodo>=2025.7.4"]
 daft = ["daft>=0.5.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -4512,7 +4512,7 @@ requires-dist = [
     { name = "kerberos", marker = "extra == 'hive-kerberos'", specifier = ">=1.3.1,<2" },
     { name = "mmh3", specifier = ">=4.0.0,<6.0.0" },
     { name = "pandas", marker = "extra == 'pandas'", specifier = ">=1.0.0" },
-    { name = "pandas", marker = "extra == 'ray'", specifier = ">=1.0.0,<3.0.0" },
+    { name = "pandas", marker = "extra == 'ray'", specifier = ">=1.0.0" },
     { name = "polars", marker = "extra == 'polars'", specifier = ">=1.21.0,<2" },
     { name = "psycopg2-binary", marker = "extra == 'sql-postgres'", specifier = ">=2.9.6" },
     { name = "pyarrow", marker = "extra == 'duckdb'", specifier = ">=17.0.0" },


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

Closes #2939.

# Rationale for this change

Pandas 3 is released but can't be used with PyIceberg due to the "<3.0.0" version restriction of PyIceberg. This removes the version restriction which doesn't seem necessary.

## Are these changes tested?

N/A.

## Are there any user-facing changes?

No.

<!-- In the case of user-facing changes, please add the changelog label. -->
