### PR TITLE
Add support for aarch64

### DIFF
--- a/.github/workflows/pypi-build-artifacts.yml
+++ b/.github/workflows/pypi-build-artifacts.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-15-intel, macos-latest ]
+        os: [ ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-15-intel, macos-latest ]
 
     steps:
       - uses: actions/checkout@v6
@@ -59,7 +59,7 @@ jobs:
       # the repository, otherwise the tests will fail
       - name: Compile source distribution
         run: uv build --sdist
-        if: startsWith(matrix.os, 'ubuntu')
+        if: matrix.os == 'ubuntu-latest'
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.3.1
@@ -77,7 +77,7 @@ jobs:
 
 
       - name: Add source distribution
-        if: startsWith(matrix.os, 'ubuntu')
+        if: matrix.os == 'ubuntu-latest'
         run: ls -lah dist/* && cp dist/* wheelhouse/
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/svn-build-artifacts.yml
+++ b/.github/workflows/svn-build-artifacts.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-15-intel, macos-latest ]
+        os: [ ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-15-intel, macos-latest ]
 
     steps:
       - uses: actions/checkout@v6
@@ -54,7 +54,7 @@ jobs:
       # the repository, otherwise the tests will fail
       - name: Compile source distribution
         run: uv build --sdist
-        if: startsWith(matrix.os, 'ubuntu')
+        if: matrix.os == 'ubuntu-latest'
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.3.1
@@ -71,7 +71,7 @@ jobs:
           CIBW_SKIP: "cp3*t-*"
 
       - name: Add source distribution
-        if: startsWith(matrix.os, 'ubuntu')
+        if: matrix.os == 'ubuntu-latest'
         run: ls -lah dist/* && cp dist/* wheelhouse/
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
Closes #2970

# Rationale for this change
This should allow us to build aarch64 wheels on Linux. We have to use QEMU since GitHub doesn't have arm64 Linux runners (just Mac). 

## Are these changes tested?
Testing CI is awful! We shouldn't merge this in until after 0.11 and then see what happens.

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
