### PR TITLE
chore: remove stale ciwheelbuild config for PyPy

### DIFF
--- a/.github/workflows/pypi-build-artifacts.yml
+++ b/.github/workflows/pypi-build-artifacts.yml
@@ -72,9 +72,6 @@ jobs:
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.10,<3.14"
           CIBW_BEFORE_TEST: "uv sync --directory {project} --only-group dev --no-install-project"
           CIBW_TEST_COMMAND: "uv run --directory {project} pytest tests/avro/test_decoder.py"
-          # Ignore tests for pypy since not all dependencies are compiled for it
-          # and would require a local rust build chain
-          CIBW_TEST_SKIP: "pp*"
           # Skip free-threaded (PEP 703) builds until we evaluate decoder_fast support
           CIBW_SKIP: "cp3*t-*"
 

--- a/.github/workflows/svn-build-artifacts.yml
+++ b/.github/workflows/svn-build-artifacts.yml
@@ -67,9 +67,6 @@ jobs:
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.10,<3.14"
           CIBW_BEFORE_TEST: "uv sync --directory {project} --only-group dev --no-install-project"
           CIBW_TEST_COMMAND: "uv run --directory {project} pytest tests/avro/test_decoder.py"
-          # Ignore tests for pypy since not all dependencies are compiled for it
-          # and would require a local rust build chain
-          CIBW_TEST_SKIP: "pp*"
           # Skip free-threaded (PEP 703) builds until we evaluate decoder_fast support
           CIBW_SKIP: "cp3*t-*"
 


### PR DESCRIPTION
# Rationale for this change

I noticed our nightly builds kept showing these annotations:

<img width="1126" height="371" alt="image" src="https://github.com/user-attachments/assets/c6b7cfba-cce3-44af-b822-8c4d6ee144ae" />

We haven't shipped a PyPy build since 0.9.1 (https://pypi.org/project/pyiceberg/0.9.1/#files), so this skip rule isn't doing anything anymore. Removed it to clean up the warnings.

PyPy wheels are no longer built by default following the cibuildwheel 3.0 release and it was bumped in #2099. If we want PyPy support back, we can re-add the builds instead of just skipping tests. 

## Are these changes tested?
Successful run on personal branch: https://github.com/geruh/iceberg-python/actions/runs/21427296271

<img width="1156" height="156" alt="image" src="https://github.com/user-attachments/assets/1f0671df-04f3-4f40-9e3b-a6343b120484" />




## Are there any user-facing changes?

No
