### PR TITLE
fix: add mac intel wheel builds

### DIFF
--- a/.github/workflows/pypi-build-artifacts.yml
+++ b/.github/workflows/pypi-build-artifacts.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-latest, windows-latest, macos-15-intel, macos-latest ]
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/svn-build-artifacts.yml
+++ b/.github/workflows/svn-build-artifacts.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-latest, windows-latest, macos-15-intel, macos-latest ]
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
# Rationale for this change

Currently, our build matrix uses `macos-latest`, which is now Apple Silicon only. Intel Mac users don't get pre-built wheels—they have to build from source, which needs a compiler and takes a lot longer to install.

I went ahead and added macos-15-intel to the matrix for x86_64 wheels. GitHub has these [Intel runners available](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)

## Are these changes tested?

Tested on a personal fork and pypi test env:

Fork nightly run:
PyPI test: https://test.pypi.org/project/pyiceberg-geruh/0.10.0.dev20260128061235/#files

Arm and 64 plats available:
<img width="235" height="94" alt="image" src="https://github.com/user-attachments/assets/bd9611af-e08c-4e40-8117-ab00acd89e92" />


## Are there any user-facing changes?
no

