### PR TITLE
fix: skip pre-commit hook install with running during release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,8 +72,8 @@ setup-venv: ## Create virtual environment
 install-dependencies: setup-venv ## Install all dependencies including extras
 	uv sync $(PYTHON_ARG) --all-extras --reinstall
 
-install-hooks: ## Install pre-commit hooks
-	uv run $(PYTHON_ARG) prek install
+install-hooks: ## Install pre-commit hooks (skipped outside git repo, e.g. release tarballs)
+	@if [ -d .git ]; then uv run $(PYTHON_ARG) prek install; fi
 
 install: install-uv install-dependencies install-hooks ## Install uv, dependencies, and pre-commit hooks
 


### PR DESCRIPTION
# Rationale for this change
`make install` fails on release tarballs because `install-hooks` requires a .git directory. So this pr modifies install so we only run prek install when .git exists, otherwise succeed.

Found during 0.11.0 RC1 release verification.

## Are these changes tested?
Yes

## Are there any user-facing changes?
No
