### PR TITLE
fix: include uv.lock in release tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -26,6 +26,7 @@ recursive-include tests *
 
 # Include development files
 include Makefile
+include uv.lock
 recursive-include dev *
 
 # Exclude build artifacts


### PR DESCRIPTION
# Rationale for this change
Include uv.lock in sdist so dependency resolution matches the release branch.

## Are these changes tested?
Yes

```
> cd /tmp/test-install2/pyiceberg-0.11.0 && uv pip list | grep -i "pytz\|pandas"
pandas                        2.3.3
pytz                          2025.2

> make test
tests/utils/test_singleton.py::test_singleton PASSED                     [ 99%]
tests/utils/test_singleton.py::test_singleton_transform PASSED           [ 99%]
tests/utils/test_truncate.py::test_upper_bound_string_truncation PASSED  [ 99%]
tests/utils/test_truncate.py::test_upper_bound_binary_truncation PASSED  [100%]
=============== 3505 passed, 1481 deselected in 68.44s (0:01:08) ===============
```

## Are there any user-facing changes?
No
