### PR TITLE
Fix: make test-coverage to properly enable coverage for all test suites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,8 +133,9 @@ test-gcs: ## Run tests marked with @pytest.mark.gcs
 	sh ./dev/run-gcs-server.sh
 	$(TEST_RUNNER) pytest tests/ -m gcs $(PYTEST_ARGS)
 
-test-coverage: COVERAGE=1
-test-coverage: test test-integration test-s3 test-adls test-gcs coverage-report ## Run all tests with coverage and report
+test-coverage: ## Run all tests with coverage and report
+	$(MAKE) COVERAGE=1 test test-integration test-s3 test-adls test-gcs
+	$(MAKE) coverage-report
 
 coverage-report: ## Combine and report coverage
 	uv run $(PYTHON_ARG) coverage combine


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
The `test-coverage` target was failing with "No data to combine" because the `COVERAGE=1` variable wasn't being propagated to prerequisite test targets. 

Make's target-specific variable syntax (`test-coverage: COVERAGE=1`) only sets the variable for that specific target, not for its prerequisites when they execute as separate Make invocations.

Found this out when verifying release, which is the only place we run `make test-coverage`. CI runs `make coverage-report`

## Are these changes tested?
Ran `make test-coverage` before and after

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
