### PR TITLE
Upgrade to RAT 0.17

### DIFF
--- a/dev/.rat-excludes
+++ b/dev/.rat-excludes
@@ -1,8 +1,8 @@
-.github/*
-.rat-excludes
-build
-.git
-.gitignore
+.github/**
+dev/.rat-excludes
 uv.lock
-mkdocs/*
-notebooks/*
+.ruff_cache/**
+.pytest_cache/**
+.mypy_cache/**
+mkdocs/**
+notebooks/**

--- a/dev/check-license
+++ b/dev/check-license
@@ -58,7 +58,7 @@ else
     declare java_cmd=java
 fi
 
-export RAT_VERSION=0.16.1
+export RAT_VERSION=0.17
 export rat_jar="$FWDIR"/lib/apache-rat-${RAT_VERSION}.jar
 mkdir -p "$FWDIR"/lib
 
@@ -67,20 +67,12 @@ mkdir -p "$FWDIR"/lib
     exit 1
 }
 
-mkdir -p build
-$java_cmd -jar "$rat_jar" --scan-hidden-directories -E "$FWDIR"/dev/.rat-excludes -d "$FWDIR" > build/rat-results.txt
+$java_cmd -jar "$rat_jar" \
+  --input-exclude-file "$FWDIR"/dev/.rat-excludes \
+  --input-exclude-std GIT IDEA MAC \
+  --input-include-std HIDDEN_DIR \
+  --output-style missing-headers \
+  --log-level ERROR \
+  -- "$FWDIR" || exit 1
 
-if [ $? -ne 0 ]; then
-   echo "RAT exited abnormally"
-   exit 1
-fi
-
-ERRORS="$(cat build/rat-results.txt | grep -e "??")"
-
-if test ! -z "$ERRORS"; then
-    echo "Could not find Apache license headers in the following files:"
-    echo "$ERRORS"
-    exit 1
-else
-    echo -e "RAT checks passed."
-fi
+echo "RAT checks passed."


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
(Copy over RAT upgrade changes from java, #15145, #15174, #15194)
Upgrades RAT to version 0.17, which has new regex for [exclusion expression](https://creadur.apache.org/rat/apache-rat-core/exclusion_expression.html) 

* Using `--input-exclude-file` because `-E,--exclude-file` is deprecated
* Using `--input-include-std HIDDEN_DIR` because `--scan-hidden-directories` is deprecated
* Using the new [`--output-style missing-headers` option](https://creadur.apache.org/rat/apache-rat/index.html) for output styling

Add usage of the new collections for ignore file patterns https://creadur.apache.org/rat/apache-rat/standard_collections.html
- `GIT` matches `**/.git/**`, `**/.gitignore`
- `IDEA` matches `**/*.iws`, `**/*.iml`, `**/*.ipr`, `**/.idea/**`
- `MAC` matches `**/.DS_Store`

## Are these changes tested?
yes locally and ci

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
