### PR TITLE
Make manifest cache size configurable

### DIFF
--- a/mkdocs/docs/configuration.md
+++ b/mkdocs/docs/configuration.md
@@ -48,6 +48,21 @@ The environment variable picked up by Iceberg starts with `PYICEBERG_` and then 
 
 For example, `PYICEBERG_CATALOG__DEFAULT__S3__ACCESS_KEY_ID`, sets `s3.access-key-id` on the `default` catalog.
 
+## Manifest Caching
+
+PyIceberg caches `ManifestFile` objects locally and uses an LRU policy to bound the cache size. By default, up to `128`
+manifest entries are retained.
+
+You can change the cache size with the `PYICEBERG_MANIFEST_CACHE_SIZE` environment variable:
+
+```sh
+export PYICEBERG_MANIFEST_CACHE_SIZE=256
+```
+
+The memory used by this cache depends on the size and number of distinct manifests your workload touches. Lower the value
+if you want a tighter memory bound, or call `clear_manifest_cache()` to proactively release cached manifest metadata in
+long-lived processes. Setting `PYICEBERG_MANIFEST_CACHE_SIZE` to `0` disables manifest caching entirely.
+
 ## Tables
 
 Iceberg tables support table properties to configure table behavior.

--- a/mkdocs/docs/configuration.md
+++ b/mkdocs/docs/configuration.md
@@ -59,6 +59,8 @@ You can tune the `manifest-cache-size` configuration in `.pyiceberg.yaml`:
 manifest-cache-size: 256
 ```
 
+Permitted values: Any `int` between `0` and `math.inf`.
+
 You can also set it with the `PYICEBERG_MANIFEST_CACHE_SIZE` environment variable:
 
 ```sh

--- a/mkdocs/docs/configuration.md
+++ b/mkdocs/docs/configuration.md
@@ -53,7 +53,13 @@ For example, `PYICEBERG_CATALOG__DEFAULT__S3__ACCESS_KEY_ID`, sets `s3.access-ke
 PyIceberg caches `ManifestFile` objects locally and uses an LRU policy to bound the cache size. By default, up to `128`
 manifest entries are retained.
 
-You can change the cache size with the `PYICEBERG_MANIFEST_CACHE_SIZE` environment variable:
+You can tune the `manifest-cache-size` configuration in `.pyiceberg.yaml`:
+
+```yaml
+manifest-cache-size: 256
+```
+
+You can also set it with the `PYICEBERG_MANIFEST_CACHE_SIZE` environment variable:
 
 ```sh
 export PYICEBERG_MANIFEST_CACHE_SIZE=256
@@ -61,7 +67,7 @@ export PYICEBERG_MANIFEST_CACHE_SIZE=256
 
 The memory used by this cache depends on the size and number of distinct manifests your workload touches. Lower the value
 if you want a tighter memory bound, or call `clear_manifest_cache()` to proactively release cached manifest metadata in
-long-lived processes. Setting `PYICEBERG_MANIFEST_CACHE_SIZE` to `0` disables manifest caching entirely.
+long-lived processes. Setting `manifest-cache-size` or `PYICEBERG_MANIFEST_CACHE_SIZE` to `0` disables manifest caching entirely.
 
 ## Tables
 

--- a/mkdocs/docs/configuration.md
+++ b/mkdocs/docs/configuration.md
@@ -51,7 +51,7 @@ For example, `PYICEBERG_CATALOG__DEFAULT__S3__ACCESS_KEY_ID`, sets `s3.access-ke
 ## Manifest Caching
 
 PyIceberg caches `ManifestFile` objects locally and uses an LRU policy to bound the cache size. By default, up to `128`
-manifest entries are retained.
+distinct manifest files are retained.
 
 You can tune the `manifest-cache-size` configuration in `.pyiceberg.yaml`:
 
@@ -59,7 +59,7 @@ You can tune the `manifest-cache-size` configuration in `.pyiceberg.yaml`:
 manifest-cache-size: 256
 ```
 
-Permitted values: Any `int` between `0` and `math.inf`.
+Permitted values: any non-negative integer. Set the value to `0` to disable manifest caching entirely.
 
 You can also set it with the `PYICEBERG_MANIFEST_CACHE_SIZE` environment variable:
 
@@ -69,7 +69,7 @@ export PYICEBERG_MANIFEST_CACHE_SIZE=256
 
 The memory used by this cache depends on the size and number of distinct manifests your workload touches. Lower the value
 if you want a tighter memory bound, or call `clear_manifest_cache()` to proactively release cached manifest metadata in
-long-lived processes. Setting `manifest-cache-size` or `PYICEBERG_MANIFEST_CACHE_SIZE` to `0` disables manifest caching entirely.
+long-lived processes.
 
 ## Tables
 

--- a/pyiceberg/manifest.py
+++ b/pyiceberg/manifest.py
@@ -892,14 +892,28 @@ class ManifestFile(Record):
         return hash(self.manifest_path)
 
 
+# Global cache for ManifestFile objects, keyed by manifest_path.
+# This deduplicates ManifestFile objects across manifest lists, which commonly
+# share manifests after append operations.
 _DEFAULT_MANIFEST_CACHE_SIZE = 128
-_manifest_cache_size = Config().get_int("manifest-cache-size") or _DEFAULT_MANIFEST_CACHE_SIZE
+_configured_manifest_cache_size = Config().get_int("manifest-cache-size")
+_manifest_cache_size = (
+    _configured_manifest_cache_size if _configured_manifest_cache_size is not None else _DEFAULT_MANIFEST_CACHE_SIZE
+)
+
+# Lock for thread-safe cache access.
 _manifest_cache_lock = threading.RLock()
-_manifest_cache: LRUCache[str, ManifestFile] = LRUCache(maxsize=_manifest_cache_size)
+_manifest_cache: LRUCache[str, ManifestFile] | dict[str, ManifestFile] = (
+    LRUCache(maxsize=_manifest_cache_size) if _manifest_cache_size > 0 else {}
+)
 
 
 def clear_manifest_cache() -> None:
-    """Clear the manifest cache."""
+    """Clear cached ManifestFile objects.
+
+    This is primarily useful in long-lived or memory-sensitive processes that
+    want to release cached manifest metadata between bursts of table reads.
+    """
     with _manifest_cache_lock:
         _manifest_cache.clear()
 
@@ -930,6 +944,9 @@ def _manifests(io: FileIO, manifest_list: str) -> tuple[ManifestFile, ...]:
     """
     file = io.new_input(manifest_list)
     manifest_files = list(read_manifest_list(file))
+
+    if _manifest_cache_size == 0:
+        return tuple(manifest_files)
 
     result = []
     with _manifest_cache_lock:

--- a/pyiceberg/manifest.py
+++ b/pyiceberg/manifest.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import math
 import threading
 from abc import ABC, abstractmethod
-from collections.abc import Iterator
+from collections.abc import Iterator, MutableMapping
 from copy import copy
 from enum import Enum
 from types import TracebackType
@@ -898,14 +898,12 @@ class ManifestFile(Record):
 _DEFAULT_MANIFEST_CACHE_SIZE = 128
 _configured_manifest_cache_size = Config().get_int("manifest-cache-size")
 _manifest_cache_size = (
-    _configured_manifest_cache_size if _configured_manifest_cache_size is not None else _DEFAULT_MANIFEST_CACHE_SIZE
+    max(_configured_manifest_cache_size, 0) if _configured_manifest_cache_size is not None else _DEFAULT_MANIFEST_CACHE_SIZE
 )
 
-# Lock for thread-safe cache access.
+# Lock for thread-safe cache access
 _manifest_cache_lock = threading.RLock()
-_manifest_cache: LRUCache[str, ManifestFile] | dict[str, ManifestFile] = (
-    LRUCache(maxsize=_manifest_cache_size) if _manifest_cache_size > 0 else {}
-)
+_manifest_cache: MutableMapping[str, ManifestFile] = LRUCache(maxsize=_manifest_cache_size) if _manifest_cache_size > 0 else {}
 
 
 def clear_manifest_cache() -> None:

--- a/pyiceberg/manifest.py
+++ b/pyiceberg/manifest.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import math
 import threading
 from abc import ABC, abstractmethod
-from collections.abc import Iterator, MutableMapping
+from collections.abc import Iterator
 from copy import copy
 from enum import Enum
 from types import TracebackType
@@ -892,18 +892,57 @@ class ManifestFile(Record):
         return hash(self.manifest_path)
 
 
-# Global cache for ManifestFile objects, keyed by manifest_path.
-# This deduplicates ManifestFile objects across manifest lists, which commonly
-# share manifests after append operations.
-_DEFAULT_MANIFEST_CACHE_SIZE = 128
-_configured_manifest_cache_size = Config().get_int("manifest-cache-size")
-_manifest_cache_size = (
-    max(_configured_manifest_cache_size, 0) if _configured_manifest_cache_size is not None else _DEFAULT_MANIFEST_CACHE_SIZE
-)
+class _ManifestCache:
+    """Process-wide ManifestFile cache keyed by manifest_path.
 
-# Lock for thread-safe cache access
-_manifest_cache_lock = threading.RLock()
-_manifest_cache: MutableMapping[str, ManifestFile] = LRUCache(maxsize=_manifest_cache_size) if _manifest_cache_size > 0 else {}
+    Consecutive snapshots often reference the same manifests after append
+    operations, so reusing ManifestFile instances avoids retaining duplicate
+    objects.
+    """
+
+    DEFAULT_SIZE = 128
+
+    _cache: LRUCache[str, ManifestFile] | None
+
+    def __init__(self) -> None:
+        self.maxsize = self._load_configured_size()
+        self._cache = LRUCache(maxsize=self.maxsize) if self.maxsize > 0 else None
+        self._lock = threading.RLock()
+
+    @classmethod
+    def _load_configured_size(cls) -> int:
+        configured_size = Config().get_int("manifest-cache-size")
+        if configured_size is None:
+            return cls.DEFAULT_SIZE
+        if configured_size < 0:
+            raise ValueError(
+                f"manifest-cache-size should be a non-negative integer or left unset. Current value: {configured_size}"
+            )
+        return configured_size
+
+    def clear(self) -> None:
+        with self._lock:
+            if self._cache is not None:
+                self._cache.clear()
+
+    def get_or_cache(self, manifest_file: ManifestFile) -> ManifestFile:
+        if self._cache is None:
+            return manifest_file
+
+        with self._lock:
+            manifest_path = manifest_file.manifest_path
+            if manifest_path in self._cache:
+                return self._cache[manifest_path]
+
+            self._cache[manifest_path] = manifest_file
+            return manifest_file
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._cache) if self._cache is not None else 0
+
+
+_manifest_cache = _ManifestCache()
 
 
 def clear_manifest_cache() -> None:
@@ -912,12 +951,11 @@ def clear_manifest_cache() -> None:
     This is primarily useful in long-lived or memory-sensitive processes that
     want to release cached manifest metadata between bursts of table reads.
     """
-    with _manifest_cache_lock:
-        _manifest_cache.clear()
+    _manifest_cache.clear()
 
 
 def _manifests(io: FileIO, manifest_list: str) -> tuple[ManifestFile, ...]:
-    """Read manifests from a manifest list, deduplicating ManifestFile objects via cache.
+    """Read manifests from a manifest list, reusing cached ManifestFile objects.
 
     Caches individual ManifestFile objects by manifest_path. This is memory-efficient
     because consecutive manifest lists typically share most of their manifests:
@@ -943,20 +981,7 @@ def _manifests(io: FileIO, manifest_list: str) -> tuple[ManifestFile, ...]:
     file = io.new_input(manifest_list)
     manifest_files = list(read_manifest_list(file))
 
-    if _manifest_cache_size == 0:
-        return tuple(manifest_files)
-
-    result = []
-    with _manifest_cache_lock:
-        for manifest_file in manifest_files:
-            manifest_path = manifest_file.manifest_path
-            if manifest_path in _manifest_cache:
-                result.append(_manifest_cache[manifest_path])
-            else:
-                _manifest_cache[manifest_path] = manifest_file
-                result.append(manifest_file)
-
-    return tuple(result)
+    return tuple(_manifest_cache.get_or_cache(manifest_file) for manifest_file in manifest_files)
 
 
 def read_manifest_list(input_file: InputFile) -> Iterator[ManifestFile]:

--- a/tests/benchmark/test_memory_benchmark.py
+++ b/tests/benchmark/test_memory_benchmark.py
@@ -33,7 +33,7 @@ import pyarrow as pa
 import pytest
 
 from pyiceberg.catalog.memory import InMemoryCatalog
-from pyiceberg.manifest import _manifest_cache
+from pyiceberg.manifest import _get_manifest_cache, clear_manifest_cache
 
 
 def generate_test_dataframe() -> pa.Table:
@@ -64,7 +64,7 @@ def memory_catalog(tmp_path_factory: pytest.TempPathFactory) -> InMemoryCatalog:
 @pytest.fixture(autouse=True)
 def clear_caches() -> None:
     """Clear caches before each test."""
-    _manifest_cache.clear()
+    clear_manifest_cache()
     gc.collect()
 
 
@@ -95,7 +95,8 @@ def test_manifest_cache_memory_growth(memory_catalog: InMemoryCatalog) -> None:
         # Sample memory at intervals
         if (i + 1) % 10 == 0:
             current, _ = tracemalloc.get_traced_memory()
-            cache_size = len(_manifest_cache)
+            cache = _get_manifest_cache()
+            cache_size = len(cache) if cache is not None else 0
 
             memory_samples.append((i + 1, current, cache_size))
             print(f"  Iteration {i + 1}: Memory={current / 1024:.1f} KB, Cache entries={cache_size}")
@@ -150,13 +151,14 @@ def test_memory_after_gc_with_cache_cleared(memory_catalog: InMemoryCatalog) -> 
 
     gc.collect()
     before_clear_memory, _ = tracemalloc.get_traced_memory()
-    cache_size_before = len(_manifest_cache)
+    cache = _get_manifest_cache()
+    cache_size_before = len(cache) if cache is not None else 0
     print(f"  Memory before clear: {before_clear_memory / 1024:.1f} KB")
     print(f"  Cache size: {cache_size_before}")
 
     # Phase 2: Clear cache and GC
     print("\nPhase 2: Clearing cache and running GC...")
-    _manifest_cache.clear()
+    clear_manifest_cache()
     gc.collect()
     gc.collect()  # Multiple GC passes for thorough cleanup
 
@@ -191,7 +193,9 @@ def test_manifest_cache_deduplication_efficiency() -> None:
         FileFormat,
         ManifestEntry,
         ManifestEntryStatus,
+        _get_manifest_cache,
         _manifests,
+        clear_manifest_cache,
         write_manifest,
         write_manifest_list,
     )
@@ -245,7 +249,7 @@ def test_manifest_cache_deduplication_efficiency() -> None:
         num_lists = 10
         print(f"Creating {num_lists} manifest lists with overlapping manifests...")
 
-        _manifest_cache.clear()
+        clear_manifest_cache()
 
         for i in range(num_lists):
             list_path = f"{tmp_dir}/manifest-list_{i}.avro"
@@ -265,7 +269,8 @@ def test_manifest_cache_deduplication_efficiency() -> None:
             _manifests(io, list_path)
 
         # Analyze cache efficiency
-        cache_entries = len(_manifest_cache)
+        cache = _get_manifest_cache()
+        cache_entries = len(cache) if cache is not None else 0
         # List i contains manifests 0..i, so only the first num_lists manifests are actually used
         manifests_actually_used = num_lists
 

--- a/tests/benchmark/test_memory_benchmark.py
+++ b/tests/benchmark/test_memory_benchmark.py
@@ -96,8 +96,7 @@ def test_manifest_cache_memory_growth(memory_catalog: InMemoryCatalog) -> None:
         # Sample memory at intervals
         if (i + 1) % 10 == 0:
             current, _ = tracemalloc.get_traced_memory()
-            cache = manifest_module._manifest_cache
-            cache_size = len(cache) if cache is not None else 0
+            cache_size = len(manifest_module._manifest_cache)
 
             memory_samples.append((i + 1, current, cache_size))
             print(f"  Iteration {i + 1}: Memory={current / 1024:.1f} KB, Cache entries={cache_size}")
@@ -152,8 +151,7 @@ def test_memory_after_gc_with_cache_cleared(memory_catalog: InMemoryCatalog) -> 
 
     gc.collect()
     before_clear_memory, _ = tracemalloc.get_traced_memory()
-    cache = manifest_module._manifest_cache
-    cache_size_before = len(cache) if cache is not None else 0
+    cache_size_before = len(manifest_module._manifest_cache)
     print(f"  Memory before clear: {before_clear_memory / 1024:.1f} KB")
     print(f"  Cache size: {cache_size_before}")
 
@@ -269,8 +267,7 @@ def test_manifest_cache_deduplication_efficiency() -> None:
             _manifests(io, list_path)
 
         # Analyze cache efficiency
-        cache = manifest_module._manifest_cache
-        cache_entries = len(cache) if cache is not None else 0
+        cache_entries = len(manifest_module._manifest_cache)
         # List i contains manifests 0..i, so only the first num_lists manifests are actually used
         manifests_actually_used = num_lists
 

--- a/tests/benchmark/test_memory_benchmark.py
+++ b/tests/benchmark/test_memory_benchmark.py
@@ -73,8 +73,8 @@ def clear_caches() -> None:
 def test_manifest_cache_memory_growth(memory_catalog: InMemoryCatalog) -> None:
     """Benchmark memory growth of manifest cache during repeated appends.
 
-    This test reproduces the issue from GitHub #2325 where each append creates
-    a new manifest list entry in the cache, causing memory to grow.
+    This test reproduces the issue from GitHub #2325 where the old cache stored
+    each manifest list result, causing memory to grow.
 
     With the old caching strategy (tuple per manifest list), memory grew as O(N²).
     With the new strategy (individual ManifestFile objects), memory grows as O(N).

--- a/tests/utils/test_manifest.py
+++ b/tests/utils/test_manifest.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=redefined-outer-name,arguments-renamed,fixme
+import importlib
 from tempfile import TemporaryDirectory
 
 import fastavro
@@ -1039,3 +1040,65 @@ def test_clear_manifest_cache() -> None:
         cache_after = manifest_module._manifest_cache
         assert cache_after is not None, "Cache should still be enabled after clear"
         assert len(cache_after) == 0, "Cache should be empty after clear"
+
+
+def test_manifest_cache_can_be_disabled_with_zero_size(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that setting manifest-cache-size to 0 disables caching."""
+    monkeypatch.setenv("PYICEBERG_MANIFEST_CACHE_SIZE", "0")
+    importlib.reload(manifest_module)
+
+    try:
+        assert manifest_module._manifest_cache_size == 0
+        assert len(manifest_module._manifest_cache) == 0
+
+        io = PyArrowFileIO()
+
+        with TemporaryDirectory() as tmp_dir:
+            schema = Schema(NestedField(field_id=1, name="id", field_type=IntegerType(), required=True))
+            spec = UNPARTITIONED_PARTITION_SPEC
+
+            manifest_path = f"{tmp_dir}/manifest.avro"
+            with manifest_module.write_manifest(
+                format_version=2,
+                spec=spec,
+                schema=schema,
+                output_file=io.new_output(manifest_path),
+                snapshot_id=1,
+                avro_compression="zstandard",
+            ) as writer:
+                data_file = manifest_module.DataFile.from_args(
+                    content=manifest_module.DataFileContent.DATA,
+                    file_path=f"{tmp_dir}/data.parquet",
+                    file_format=manifest_module.FileFormat.PARQUET,
+                    partition=Record(),
+                    record_count=100,
+                    file_size_in_bytes=1000,
+                )
+                writer.add_entry(
+                    manifest_module.ManifestEntry.from_args(
+                        status=manifest_module.ManifestEntryStatus.ADDED,
+                        snapshot_id=1,
+                        data_file=data_file,
+                    )
+                )
+            manifest_file = writer.to_manifest_file()
+
+            list_path = f"{tmp_dir}/manifest-list.avro"
+            with manifest_module.write_manifest_list(
+                format_version=2,
+                output_file=io.new_output(list_path),
+                snapshot_id=1,
+                parent_snapshot_id=None,
+                sequence_number=1,
+                avro_compression="zstandard",
+            ) as list_writer:
+                list_writer.add_manifests([manifest_file])
+
+            manifests_first_call = manifest_module._manifests(io, list_path)
+            manifests_second_call = manifest_module._manifests(io, list_path)
+
+            assert len(manifest_module._manifest_cache) == 0
+            assert manifests_first_call[0] is not manifests_second_call[0]
+    finally:
+        monkeypatch.delenv("PYICEBERG_MANIFEST_CACHE_SIZE", raising=False)
+        importlib.reload(manifest_module)

--- a/tests/utils/test_manifest.py
+++ b/tests/utils/test_manifest.py
@@ -16,7 +16,9 @@
 # under the License.
 # pylint: disable=redefined-outer-name,arguments-renamed,fixme
 import importlib
+from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Any
 
 import fastavro
 import pytest
@@ -978,52 +980,56 @@ def test_inherit_from_manifest_snapshot_id() -> None:
     assert result.snapshot_id == 3051729675574597004
     assert result.sequence_number == 1
     assert result.file_sequence_number == 1
+def _create_test_manifest_list(module: Any, io: PyArrowFileIO, tmp_dir: str, name: str, snapshot_id: int) -> str:
+    schema = Schema(NestedField(field_id=1, name="id", field_type=IntegerType(), required=True))
+    spec = UNPARTITIONED_PARTITION_SPEC
+
+    manifest_path = f"{tmp_dir}/manifest-{name}.avro"
+    with module.write_manifest(
+        format_version=2,
+        spec=spec,
+        schema=schema,
+        output_file=io.new_output(manifest_path),
+        snapshot_id=snapshot_id,
+        avro_compression="zstandard",
+    ) as writer:
+        data_file = module.DataFile.from_args(
+            content=module.DataFileContent.DATA,
+            file_path=f"{tmp_dir}/data-{name}.parquet",
+            file_format=module.FileFormat.PARQUET,
+            partition=Record(),
+            record_count=100,
+            file_size_in_bytes=1000,
+        )
+        writer.add_entry(
+            module.ManifestEntry.from_args(
+                status=module.ManifestEntryStatus.ADDED,
+                snapshot_id=snapshot_id,
+                data_file=data_file,
+            )
+        )
+    manifest_file = writer.to_manifest_file()
+
+    list_path = f"{tmp_dir}/manifest-list-{name}.avro"
+    with module.write_manifest_list(
+        format_version=2,
+        output_file=io.new_output(list_path),
+        snapshot_id=snapshot_id,
+        parent_snapshot_id=snapshot_id - 1 if snapshot_id > 1 else None,
+        sequence_number=snapshot_id,
+        avro_compression="zstandard",
+    ) as list_writer:
+        list_writer.add_manifests([manifest_file])
+
+    return list_path
+
+
 def test_clear_manifest_cache() -> None:
     """Test that clear_manifest_cache() clears cache entries while keeping cache enabled."""
     io = PyArrowFileIO()
 
     with TemporaryDirectory() as tmp_dir:
-        schema = Schema(NestedField(field_id=1, name="id", field_type=IntegerType(), required=True))
-        spec = UNPARTITIONED_PARTITION_SPEC
-
-        # Create a manifest file
-        manifest_path = f"{tmp_dir}/manifest.avro"
-        with write_manifest(
-            format_version=2,
-            spec=spec,
-            schema=schema,
-            output_file=io.new_output(manifest_path),
-            snapshot_id=1,
-            avro_compression="zstandard",
-        ) as writer:
-            data_file = DataFile.from_args(
-                content=DataFileContent.DATA,
-                file_path=f"{tmp_dir}/data.parquet",
-                file_format=FileFormat.PARQUET,
-                partition=Record(),
-                record_count=100,
-                file_size_in_bytes=1000,
-            )
-            writer.add_entry(
-                ManifestEntry.from_args(
-                    status=ManifestEntryStatus.ADDED,
-                    snapshot_id=1,
-                    data_file=data_file,
-                )
-            )
-        manifest_file = writer.to_manifest_file()
-
-        # Create a manifest list
-        list_path = f"{tmp_dir}/manifest-list.avro"
-        with write_manifest_list(
-            format_version=2,
-            output_file=io.new_output(list_path),
-            snapshot_id=1,
-            parent_snapshot_id=None,
-            sequence_number=1,
-            avro_compression="zstandard",
-        ) as list_writer:
-            list_writer.add_manifests([manifest_file])
+        list_path = _create_test_manifest_list(manifest_module, io, tmp_dir, name="clear", snapshot_id=1)
 
         # Populate the cache
         _manifests(io, list_path)
@@ -1042,9 +1048,10 @@ def test_clear_manifest_cache() -> None:
         assert len(cache_after) == 0, "Cache should be empty after clear"
 
 
-def test_manifest_cache_can_be_disabled_with_zero_size(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test that setting manifest-cache-size to 0 disables caching."""
-    monkeypatch.setenv("PYICEBERG_MANIFEST_CACHE_SIZE", "0")
+@pytest.mark.parametrize("cache_size", ["0", "-1"])
+def test_manifest_cache_can_be_disabled_with_non_positive_size(monkeypatch: pytest.MonkeyPatch, cache_size: str) -> None:
+    """Test that non-positive manifest-cache-size values disable caching."""
+    monkeypatch.setenv("PYICEBERG_MANIFEST_CACHE_SIZE", cache_size)
     importlib.reload(manifest_module)
 
     try:
@@ -1054,51 +1061,83 @@ def test_manifest_cache_can_be_disabled_with_zero_size(monkeypatch: pytest.Monke
         io = PyArrowFileIO()
 
         with TemporaryDirectory() as tmp_dir:
-            schema = Schema(NestedField(field_id=1, name="id", field_type=IntegerType(), required=True))
-            spec = UNPARTITIONED_PARTITION_SPEC
-
-            manifest_path = f"{tmp_dir}/manifest.avro"
-            with manifest_module.write_manifest(
-                format_version=2,
-                spec=spec,
-                schema=schema,
-                output_file=io.new_output(manifest_path),
-                snapshot_id=1,
-                avro_compression="zstandard",
-            ) as writer:
-                data_file = manifest_module.DataFile.from_args(
-                    content=manifest_module.DataFileContent.DATA,
-                    file_path=f"{tmp_dir}/data.parquet",
-                    file_format=manifest_module.FileFormat.PARQUET,
-                    partition=Record(),
-                    record_count=100,
-                    file_size_in_bytes=1000,
-                )
-                writer.add_entry(
-                    manifest_module.ManifestEntry.from_args(
-                        status=manifest_module.ManifestEntryStatus.ADDED,
-                        snapshot_id=1,
-                        data_file=data_file,
-                    )
-                )
-            manifest_file = writer.to_manifest_file()
-
-            list_path = f"{tmp_dir}/manifest-list.avro"
-            with manifest_module.write_manifest_list(
-                format_version=2,
-                output_file=io.new_output(list_path),
-                snapshot_id=1,
-                parent_snapshot_id=None,
-                sequence_number=1,
-                avro_compression="zstandard",
-            ) as list_writer:
-                list_writer.add_manifests([manifest_file])
+            list_path = _create_test_manifest_list(manifest_module, io, tmp_dir, name="disabled", snapshot_id=1)
 
             manifests_first_call = manifest_module._manifests(io, list_path)
             manifests_second_call = manifest_module._manifests(io, list_path)
 
             assert len(manifest_module._manifest_cache) == 0
             assert manifests_first_call[0] is not manifests_second_call[0]
+    finally:
+        monkeypatch.delenv("PYICEBERG_MANIFEST_CACHE_SIZE", raising=False)
+        importlib.reload(manifest_module)
+
+
+def test_manifest_cache_respects_positive_env_size(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that a positive manifest-cache-size enables a bounded cache."""
+    monkeypatch.setenv("PYICEBERG_MANIFEST_CACHE_SIZE", "1")
+    importlib.reload(manifest_module)
+
+    try:
+        assert manifest_module._manifest_cache_size == 1
+
+        io = PyArrowFileIO()
+
+        with TemporaryDirectory() as tmp_dir:
+            first_list_path = _create_test_manifest_list(manifest_module, io, tmp_dir, name="first", snapshot_id=1)
+            second_list_path = _create_test_manifest_list(manifest_module, io, tmp_dir, name="second", snapshot_id=2)
+
+            manifests_first_call = manifest_module._manifests(io, first_list_path)
+            manifests_second_call = manifest_module._manifests(io, first_list_path)
+
+            assert manifests_first_call[0] is manifests_second_call[0]
+            assert len(manifest_module._manifest_cache) == 1
+
+            manifest_module._manifests(io, second_list_path)
+
+            assert len(manifest_module._manifest_cache) == 1
+    finally:
+        monkeypatch.delenv("PYICEBERG_MANIFEST_CACHE_SIZE", raising=False)
+        importlib.reload(manifest_module)
+
+
+def test_manifest_cache_reads_size_from_configuration_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Test that manifest-cache-size can be loaded from .pyiceberg.yaml."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / ".pyiceberg.yaml").write_text("manifest-cache-size: 2\n", encoding="utf-8")
+
+    monkeypatch.delenv("PYICEBERG_MANIFEST_CACHE_SIZE", raising=False)
+    monkeypatch.setenv("PYICEBERG_HOME", str(config_dir))
+    importlib.reload(manifest_module)
+
+    try:
+        assert manifest_module._manifest_cache_size == 2
+
+        io = PyArrowFileIO()
+
+        with TemporaryDirectory() as tmp_dir:
+            first_list_path = _create_test_manifest_list(manifest_module, io, tmp_dir, name="first", snapshot_id=1)
+            second_list_path = _create_test_manifest_list(manifest_module, io, tmp_dir, name="second", snapshot_id=2)
+            third_list_path = _create_test_manifest_list(manifest_module, io, tmp_dir, name="third", snapshot_id=3)
+
+            manifest_module._manifests(io, first_list_path)
+            manifest_module._manifests(io, second_list_path)
+            manifest_module._manifests(io, third_list_path)
+
+            assert len(manifest_module._manifest_cache) == 2
+    finally:
+        monkeypatch.delenv("PYICEBERG_HOME", raising=False)
+        importlib.reload(manifest_module)
+
+
+def test_invalid_manifest_cache_size_raises_value_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that invalid manifest-cache-size values raise a helpful error."""
+    monkeypatch.setenv("PYICEBERG_MANIFEST_CACHE_SIZE", "not-an-int")
+
+    try:
+        with pytest.raises(ValueError, match="manifest-cache-size should be an integer or left unset"):
+            importlib.reload(manifest_module)
     finally:
         monkeypatch.delenv("PYICEBERG_MANIFEST_CACHE_SIZE", raising=False)
         importlib.reload(manifest_module)

--- a/tests/utils/test_manifest.py
+++ b/tests/utils/test_manifest.py
@@ -16,7 +16,6 @@
 # under the License.
 # pylint: disable=redefined-outer-name,arguments-renamed,fixme
 from tempfile import TemporaryDirectory
-from unittest import mock
 
 import fastavro
 import pytest
@@ -52,8 +51,6 @@ from pyiceberg.types import IntegerType, NestedField
 
 @pytest.fixture(autouse=True)
 def reset_global_manifests_cache() -> None:
-    with manifest_module._manifest_cache_lock:
-        manifest_module._manifest_cache = manifest_module._init_manifest_cache()
     clear_manifest_cache()
 
 
@@ -1042,45 +1039,3 @@ def test_clear_manifest_cache() -> None:
         cache_after = manifest_module._manifest_cache
         assert cache_after is not None, "Cache should still be enabled after clear"
         assert len(cache_after) == 0, "Cache should be empty after clear"
-
-
-@pytest.mark.parametrize(
-    "env_vars,expected_enabled,expected_size",
-    [
-        ({}, True, 128),  # defaults
-        ({"PYICEBERG_MANIFEST_CACHE_SIZE": "64"}, True, 64),
-        ({"PYICEBERG_MANIFEST_CACHE_SIZE": "256"}, True, 256),
-        ({"PYICEBERG_MANIFEST_CACHE_SIZE": "0"}, False, 0),  # size=0 disables cache
-    ],
-)
-def test_manifest_cache_config_valid_values(env_vars: dict[str, str], expected_enabled: bool, expected_size: int) -> None:
-    """Test that valid config values are applied correctly."""
-    import os
-
-    with mock.patch.dict(os.environ, env_vars, clear=False):
-        with manifest_module._manifest_cache_lock:
-            manifest_module._manifest_cache = manifest_module._init_manifest_cache()
-        cache = manifest_module._manifest_cache
-
-        if expected_enabled:
-            assert cache is not None, "Cache should be enabled"
-            assert cache.maxsize == expected_size, f"Cache size should be {expected_size}"
-        else:
-            assert cache is None, "Cache should be disabled"
-
-
-@pytest.mark.parametrize(
-    "env_vars,expected_error_substring",
-    [
-        ({"PYICEBERG_MANIFEST_CACHE_SIZE": "abc"}, "manifest-cache-size should be an integer"),
-        ({"PYICEBERG_MANIFEST_CACHE_SIZE": "-5"}, "manifest-cache-size must be >= 0"),
-    ],
-)
-def test_manifest_cache_config_invalid_values(env_vars: dict[str, str], expected_error_substring: str) -> None:
-    """Test that invalid config values raise ValueError with appropriate message."""
-    import os
-
-    with mock.patch.dict(os.environ, env_vars, clear=False):
-        with pytest.raises(ValueError, match=expected_error_substring):
-            with manifest_module._manifest_cache_lock:
-                manifest_module._manifest_cache = manifest_module._init_manifest_cache()

--- a/tests/utils/test_manifest.py
+++ b/tests/utils/test_manifest.py
@@ -16,10 +16,12 @@
 # under the License.
 # pylint: disable=redefined-outer-name,arguments-renamed,fixme
 from tempfile import TemporaryDirectory
+from unittest import mock
 
 import fastavro
 import pytest
 
+import pyiceberg.manifest as manifest_module
 from pyiceberg.avro.codecs import AvroCompressionCodec
 from pyiceberg.io import load_file_io
 from pyiceberg.io.pyarrow import PyArrowFileIO
@@ -34,7 +36,9 @@ from pyiceberg.manifest import (
     PartitionFieldSummary,
     _inherit_from_manifest,
     _manifest_cache,
+    _get_manifest_cache,
     _manifests,
+    clear_manifest_cache,
     read_manifest_list,
     write_manifest,
     write_manifest_list,
@@ -47,9 +51,10 @@ from pyiceberg.types import IntegerType, NestedField
 
 
 @pytest.fixture(autouse=True)
-def clear_global_manifests_cache() -> None:
-    # Clear the global cache before each test
-    _manifest_cache.clear()
+def reset_global_manifests_cache() -> None:
+    # Reset cache state before each test so config is re-read
+    manifest_module._manifest_cache_manager._cache = None
+    manifest_module._manifest_cache_manager._initialized = False
 
 
 def _verify_metadata_with_fastavro(avro_file: str, expected_metadata: dict[str, str]) -> None:
@@ -805,9 +810,9 @@ def test_manifest_cache_deduplicates_manifest_files() -> None:
 
         # Verify cache size - should only have 3 unique ManifestFile objects
         # instead of 1 + 2 + 3 = 6 objects as with the old approach
-        assert len(_manifest_cache) == 3, (
-            f"Cache should contain exactly 3 unique ManifestFile objects, but has {len(_manifest_cache)}"
-        )
+        cache = _get_manifest_cache()
+        assert cache is not None, "Manifest cache should be enabled for this test"
+        assert len(cache) == 3, f"Cache should contain exactly 3 unique ManifestFile objects, but has {len(cache)}"
 
 
 def test_manifest_cache_efficiency_with_many_overlapping_lists() -> None:
@@ -880,9 +885,11 @@ def test_manifest_cache_efficiency_with_many_overlapping_lists() -> None:
         # With the new approach, we should have exactly N objects
 
         # Verify cache has exactly N unique entries
-        assert len(_manifest_cache) == num_manifests, (
+        cache = _get_manifest_cache()
+        assert cache is not None, "Manifest cache should be enabled for this test"
+        assert len(cache) == num_manifests, (
             f"Cache should contain exactly {num_manifests} ManifestFile objects, "
-            f"but has {len(_manifest_cache)}. "
+            f"but has {len(cache)}. "
             f"Old approach would have {num_manifests * (num_manifests + 1) // 2} objects."
         )
 
@@ -973,3 +980,115 @@ def test_inherit_from_manifest_snapshot_id() -> None:
     assert result.snapshot_id == 3051729675574597004
     assert result.sequence_number == 1
     assert result.file_sequence_number == 1
+def test_clear_manifest_cache() -> None:
+    """Test that clear_manifest_cache() clears cache entries while keeping cache enabled."""
+    io = PyArrowFileIO()
+
+    with TemporaryDirectory() as tmp_dir:
+        schema = Schema(NestedField(field_id=1, name="id", field_type=IntegerType(), required=True))
+        spec = UNPARTITIONED_PARTITION_SPEC
+
+        # Create a manifest file
+        manifest_path = f"{tmp_dir}/manifest.avro"
+        with write_manifest(
+            format_version=2,
+            spec=spec,
+            schema=schema,
+            output_file=io.new_output(manifest_path),
+            snapshot_id=1,
+            avro_compression="zstandard",
+        ) as writer:
+            data_file = DataFile.from_args(
+                content=DataFileContent.DATA,
+                file_path=f"{tmp_dir}/data.parquet",
+                file_format=FileFormat.PARQUET,
+                partition=Record(),
+                record_count=100,
+                file_size_in_bytes=1000,
+            )
+            writer.add_entry(
+                ManifestEntry.from_args(
+                    status=ManifestEntryStatus.ADDED,
+                    snapshot_id=1,
+                    data_file=data_file,
+                )
+            )
+        manifest_file = writer.to_manifest_file()
+
+        # Create a manifest list
+        list_path = f"{tmp_dir}/manifest-list.avro"
+        with write_manifest_list(
+            format_version=2,
+            output_file=io.new_output(list_path),
+            snapshot_id=1,
+            parent_snapshot_id=None,
+            sequence_number=1,
+            avro_compression="zstandard",
+        ) as list_writer:
+            list_writer.add_manifests([manifest_file])
+
+        # Populate the cache
+        _manifests(io, list_path)
+
+        # Verify cache has entries
+        cache = _get_manifest_cache()
+        assert cache is not None, "Cache should be enabled"
+        assert len(cache) > 0, "Cache should have entries after reading manifests"
+
+        # Clear the cache
+        clear_manifest_cache()
+
+        # Verify cache is empty but still enabled
+        cache_after = _get_manifest_cache()
+        assert cache_after is not None, "Cache should still be enabled after clear"
+        assert len(cache_after) == 0, "Cache should be empty after clear"
+
+
+@pytest.mark.parametrize(
+    "env_vars,expected_enabled,expected_size",
+    [
+        ({}, True, 128),  # defaults
+        ({"PYICEBERG_MANIFEST__CACHE__ENABLED": "true"}, True, 128),
+        ({"PYICEBERG_MANIFEST__CACHE__ENABLED": "false"}, False, 128),
+        ({"PYICEBERG_MANIFEST__CACHE__SIZE": "64"}, True, 64),
+        ({"PYICEBERG_MANIFEST__CACHE__SIZE": "256"}, True, 256),
+        ({"PYICEBERG_MANIFEST__CACHE__ENABLED": "false", "PYICEBERG_MANIFEST__CACHE__SIZE": "64"}, False, 64),
+    ],
+)
+def test_manifest_cache_config_valid_values(env_vars: dict[str, str], expected_enabled: bool, expected_size: int) -> None:
+    """Test that valid config values are applied correctly."""
+    import os
+
+    with mock.patch.dict(os.environ, env_vars, clear=False):
+        # Reset cache state so config is re-read
+        manifest_module._manifest_cache_manager._cache = None
+        manifest_module._manifest_cache_manager._initialized = False
+        cache = _get_manifest_cache()
+
+        if expected_enabled:
+            assert cache is not None, "Cache should be enabled"
+            assert cache.maxsize == expected_size, f"Cache size should be {expected_size}"
+        else:
+            assert cache is None, "Cache should be disabled"
+
+
+@pytest.mark.parametrize(
+    "env_vars,expected_error_substring",
+    [
+        ({"PYICEBERG_MANIFEST__CACHE__ENABLED": "maybe"}, "manifest.cache.enabled should be a boolean"),
+        ({"PYICEBERG_MANIFEST__CACHE__ENABLED": "invalid"}, "manifest.cache.enabled should be a boolean"),
+        ({"PYICEBERG_MANIFEST__CACHE__SIZE": "abc"}, "manifest.cache.size should be a positive integer"),
+        ({"PYICEBERG_MANIFEST__CACHE__SIZE": "0"}, "manifest.cache.size must be >= 1"),
+        ({"PYICEBERG_MANIFEST__CACHE__SIZE": "-5"}, "manifest.cache.size must be >= 1"),
+    ],
+)
+def test_manifest_cache_config_invalid_values(env_vars: dict[str, str], expected_error_substring: str) -> None:
+    """Test that invalid config values raise ValueError with appropriate message."""
+    import os
+
+    with mock.patch.dict(os.environ, env_vars, clear=False):
+        # Reset cache state so config is re-read
+        manifest_module._manifest_cache_manager._cache = None
+        manifest_module._manifest_cache_manager._initialized = False
+        with pytest.raises(ValueError, match=expected_error_substring):
+            _get_manifest_cache()

--- a/tests/utils/test_manifest.py
+++ b/tests/utils/test_manifest.py
@@ -52,9 +52,9 @@ from pyiceberg.types import IntegerType, NestedField
 
 @pytest.fixture(autouse=True)
 def reset_global_manifests_cache() -> None:
-    # Reset cache state before each test so config is re-read
-    manifest_module._manifest_cache_manager._cache = None
-    manifest_module._manifest_cache_manager._initialized = False
+    with manifest_module._manifest_cache_lock:
+        manifest_module._manifest_cache = manifest_module._init_manifest_cache()
+    clear_manifest_cache()
 
 
 def _verify_metadata_with_fastavro(avro_file: str, expected_metadata: dict[str, str]) -> None:
@@ -810,7 +810,7 @@ def test_manifest_cache_deduplicates_manifest_files() -> None:
 
         # Verify cache size - should only have 3 unique ManifestFile objects
         # instead of 1 + 2 + 3 = 6 objects as with the old approach
-        cache = _get_manifest_cache()
+        cache = manifest_module._manifest_cache
         assert cache is not None, "Manifest cache should be enabled for this test"
         assert len(cache) == 3, f"Cache should contain exactly 3 unique ManifestFile objects, but has {len(cache)}"
 
@@ -885,7 +885,7 @@ def test_manifest_cache_efficiency_with_many_overlapping_lists() -> None:
         # With the new approach, we should have exactly N objects
 
         # Verify cache has exactly N unique entries
-        cache = _get_manifest_cache()
+        cache = manifest_module._manifest_cache
         assert cache is not None, "Manifest cache should be enabled for this test"
         assert len(cache) == num_manifests, (
             f"Cache should contain exactly {num_manifests} ManifestFile objects, "
@@ -1031,7 +1031,7 @@ def test_clear_manifest_cache() -> None:
         _manifests(io, list_path)
 
         # Verify cache has entries
-        cache = _get_manifest_cache()
+        cache = manifest_module._manifest_cache
         assert cache is not None, "Cache should be enabled"
         assert len(cache) > 0, "Cache should have entries after reading manifests"
 
@@ -1039,7 +1039,7 @@ def test_clear_manifest_cache() -> None:
         clear_manifest_cache()
 
         # Verify cache is empty but still enabled
-        cache_after = _get_manifest_cache()
+        cache_after = manifest_module._manifest_cache
         assert cache_after is not None, "Cache should still be enabled after clear"
         assert len(cache_after) == 0, "Cache should be empty after clear"
 
@@ -1048,11 +1048,9 @@ def test_clear_manifest_cache() -> None:
     "env_vars,expected_enabled,expected_size",
     [
         ({}, True, 128),  # defaults
-        ({"PYICEBERG_MANIFEST__CACHE__ENABLED": "true"}, True, 128),
-        ({"PYICEBERG_MANIFEST__CACHE__ENABLED": "false"}, False, 128),
-        ({"PYICEBERG_MANIFEST__CACHE__SIZE": "64"}, True, 64),
-        ({"PYICEBERG_MANIFEST__CACHE__SIZE": "256"}, True, 256),
-        ({"PYICEBERG_MANIFEST__CACHE__ENABLED": "false", "PYICEBERG_MANIFEST__CACHE__SIZE": "64"}, False, 64),
+        ({"PYICEBERG_MANIFEST_CACHE_SIZE": "64"}, True, 64),
+        ({"PYICEBERG_MANIFEST_CACHE_SIZE": "256"}, True, 256),
+        ({"PYICEBERG_MANIFEST_CACHE_SIZE": "0"}, False, 0),  # size=0 disables cache
     ],
 )
 def test_manifest_cache_config_valid_values(env_vars: dict[str, str], expected_enabled: bool, expected_size: int) -> None:
@@ -1060,10 +1058,9 @@ def test_manifest_cache_config_valid_values(env_vars: dict[str, str], expected_e
     import os
 
     with mock.patch.dict(os.environ, env_vars, clear=False):
-        # Reset cache state so config is re-read
-        manifest_module._manifest_cache_manager._cache = None
-        manifest_module._manifest_cache_manager._initialized = False
-        cache = _get_manifest_cache()
+        with manifest_module._manifest_cache_lock:
+            manifest_module._manifest_cache = manifest_module._init_manifest_cache()
+        cache = manifest_module._manifest_cache
 
         if expected_enabled:
             assert cache is not None, "Cache should be enabled"
@@ -1075,11 +1072,8 @@ def test_manifest_cache_config_valid_values(env_vars: dict[str, str], expected_e
 @pytest.mark.parametrize(
     "env_vars,expected_error_substring",
     [
-        ({"PYICEBERG_MANIFEST__CACHE__ENABLED": "maybe"}, "manifest.cache.enabled should be a boolean"),
-        ({"PYICEBERG_MANIFEST__CACHE__ENABLED": "invalid"}, "manifest.cache.enabled should be a boolean"),
-        ({"PYICEBERG_MANIFEST__CACHE__SIZE": "abc"}, "manifest.cache.size should be a positive integer"),
-        ({"PYICEBERG_MANIFEST__CACHE__SIZE": "0"}, "manifest.cache.size must be >= 1"),
-        ({"PYICEBERG_MANIFEST__CACHE__SIZE": "-5"}, "manifest.cache.size must be >= 1"),
+        ({"PYICEBERG_MANIFEST_CACHE_SIZE": "abc"}, "manifest-cache-size should be an integer"),
+        ({"PYICEBERG_MANIFEST_CACHE_SIZE": "-5"}, "manifest-cache-size must be >= 0"),
     ],
 )
 def test_manifest_cache_config_invalid_values(env_vars: dict[str, str], expected_error_substring: str) -> None:
@@ -1087,8 +1081,6 @@ def test_manifest_cache_config_invalid_values(env_vars: dict[str, str], expected
     import os
 
     with mock.patch.dict(os.environ, env_vars, clear=False):
-        # Reset cache state so config is re-read
-        manifest_module._manifest_cache_manager._cache = None
-        manifest_module._manifest_cache_manager._initialized = False
         with pytest.raises(ValueError, match=expected_error_substring):
-            _get_manifest_cache()
+            with manifest_module._manifest_cache_lock:
+                manifest_module._manifest_cache = manifest_module._init_manifest_cache()

--- a/tests/utils/test_manifest.py
+++ b/tests/utils/test_manifest.py
@@ -37,8 +37,6 @@ from pyiceberg.manifest import (
     ManifestFile,
     PartitionFieldSummary,
     _inherit_from_manifest,
-    _manifest_cache,
-    _get_manifest_cache,
     _manifests,
     clear_manifest_cache,
     read_manifest_list,
@@ -980,6 +978,8 @@ def test_inherit_from_manifest_snapshot_id() -> None:
     assert result.snapshot_id == 3051729675574597004
     assert result.sequence_number == 1
     assert result.file_sequence_number == 1
+
+
 def _create_test_manifest_list(module: Any, io: PyArrowFileIO, tmp_dir: str, name: str, snapshot_id: int) -> str:
     schema = Schema(NestedField(field_id=1, name="id", field_type=IntegerType(), required=True))
     spec = UNPARTITIONED_PARTITION_SPEC

--- a/tests/utils/test_manifest.py
+++ b/tests/utils/test_manifest.py
@@ -808,9 +808,9 @@ def test_manifest_cache_deduplicates_manifest_files() -> None:
 
         # Verify cache size - should only have 3 unique ManifestFile objects
         # instead of 1 + 2 + 3 = 6 objects as with the old approach
-        cache = manifest_module._manifest_cache
-        assert cache is not None, "Manifest cache should be enabled for this test"
-        assert len(cache) == 3, f"Cache should contain exactly 3 unique ManifestFile objects, but has {len(cache)}"
+        assert len(manifest_module._manifest_cache) == 3, (
+            f"Cache should contain exactly 3 unique ManifestFile objects, but has {len(manifest_module._manifest_cache)}"
+        )
 
 
 def test_manifest_cache_efficiency_with_many_overlapping_lists() -> None:
@@ -883,11 +883,9 @@ def test_manifest_cache_efficiency_with_many_overlapping_lists() -> None:
         # With the new approach, we should have exactly N objects
 
         # Verify cache has exactly N unique entries
-        cache = manifest_module._manifest_cache
-        assert cache is not None, "Manifest cache should be enabled for this test"
-        assert len(cache) == num_manifests, (
+        assert len(manifest_module._manifest_cache) == num_manifests, (
             f"Cache should contain exactly {num_manifests} ManifestFile objects, "
-            f"but has {len(cache)}. "
+            f"but has {len(manifest_module._manifest_cache)}. "
             f"Old approach would have {num_manifests * (num_manifests + 1) // 2} objects."
         )
 
@@ -1035,27 +1033,22 @@ def test_clear_manifest_cache() -> None:
         _manifests(io, list_path)
 
         # Verify cache has entries
-        cache = manifest_module._manifest_cache
-        assert cache is not None, "Cache should be enabled"
-        assert len(cache) > 0, "Cache should have entries after reading manifests"
+        assert len(manifest_module._manifest_cache) > 0, "Cache should have entries after reading manifests"
 
         # Clear the cache
         clear_manifest_cache()
 
         # Verify cache is empty but still enabled
-        cache_after = manifest_module._manifest_cache
-        assert cache_after is not None, "Cache should still be enabled after clear"
-        assert len(cache_after) == 0, "Cache should be empty after clear"
+        assert len(manifest_module._manifest_cache) == 0, "Cache should be empty after clear"
 
 
-@pytest.mark.parametrize("cache_size", ["0", "-1"])
-def test_manifest_cache_can_be_disabled_with_non_positive_size(monkeypatch: pytest.MonkeyPatch, cache_size: str) -> None:
-    """Test that non-positive manifest-cache-size values disable caching."""
-    monkeypatch.setenv("PYICEBERG_MANIFEST_CACHE_SIZE", cache_size)
+def test_manifest_cache_can_be_disabled_with_size_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that manifest-cache-size=0 disables caching."""
+    monkeypatch.setenv("PYICEBERG_MANIFEST_CACHE_SIZE", "0")
     importlib.reload(manifest_module)
 
     try:
-        assert manifest_module._manifest_cache_size == 0
+        assert manifest_module._manifest_cache.maxsize == 0
         assert len(manifest_module._manifest_cache) == 0
 
         io = PyArrowFileIO()
@@ -1079,7 +1072,7 @@ def test_manifest_cache_respects_positive_env_size(monkeypatch: pytest.MonkeyPat
     importlib.reload(manifest_module)
 
     try:
-        assert manifest_module._manifest_cache_size == 1
+        assert manifest_module._manifest_cache.maxsize == 1
 
         io = PyArrowFileIO()
 
@@ -1112,7 +1105,7 @@ def test_manifest_cache_reads_size_from_configuration_file(monkeypatch: pytest.M
     importlib.reload(manifest_module)
 
     try:
-        assert manifest_module._manifest_cache_size == 2
+        assert manifest_module._manifest_cache.maxsize == 2
 
         io = PyArrowFileIO()
 
@@ -1137,6 +1130,18 @@ def test_invalid_manifest_cache_size_raises_value_error(monkeypatch: pytest.Monk
 
     try:
         with pytest.raises(ValueError, match="manifest-cache-size should be an integer or left unset"):
+            importlib.reload(manifest_module)
+    finally:
+        monkeypatch.delenv("PYICEBERG_MANIFEST_CACHE_SIZE", raising=False)
+        importlib.reload(manifest_module)
+
+
+def test_negative_manifest_cache_size_raises_value_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that negative manifest-cache-size values raise a helpful error."""
+    monkeypatch.setenv("PYICEBERG_MANIFEST_CACHE_SIZE", "-1")
+
+    try:
+        with pytest.raises(ValueError, match="manifest-cache-size should be a non-negative integer or left unset"):
             importlib.reload(manifest_module)
     finally:
         monkeypatch.delenv("PYICEBERG_MANIFEST_CACHE_SIZE", raising=False)


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${2952} -->

Closes #2952

# Rationale for this change
Through discussion in issue #2325, we realized that there was a memory leak in the manifest cache. PR https://github.com/apache/iceberg-python/pull/2951 fixed this memory leak, but we decided that it would be best for developer experience if users could configure the cache for their needs.

This includes the ability to configure the manifest cache size, including setting it to `0` to disable caching.

## Are these changes tested?
Yes - unit tests are included to verify these changes

## Are there any user-facing changes?
Yes:
- `manifest-cache-size` can be used in `.pyiceberg.yaml` to configure the size of the manifest cache
- `PYICEBERG_MANIFEST_CACHE_SIZE` can be used to configure the size of the manifest cache

<!-- In the case of user-facing changes, please add the changelog label. -->
