### PR TITLE
fix: handle bytes values in string column statistics from Parquet

### DIFF
--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -603,3 +603,15 @@ def test_json_single_serialization(primitive_type: PrimitiveType, value: Any, ex
 )
 def test_json_serialize_roundtrip(primitive_type: PrimitiveType, value: Any) -> None:
     assert value == conversions.from_json(primitive_type, conversions.to_json(primitive_type, value))
+
+
+def test_string_type_to_bytes_with_str() -> None:
+    """Test that to_bytes works with str values for StringType."""
+    result = conversions.to_bytes(StringType(), "hello")
+    assert result == b"hello"
+
+
+def test_string_type_to_bytes_with_unicode() -> None:
+    """Test that to_bytes works with unicode str values for StringType."""
+    result = conversions.to_bytes(StringType(), "héllo wörld")
+    assert result == "héllo wörld".encode()


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->
<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

When using `add_files()` to import Parquet files written by DuckDB into PyIceberg tables, the operation fails with `AttributeError: 'bytes' object has no attribute 'encode'`. 

This occurs because the Parquet specification defines column statistics (min_value, max_value) as binary data:
```thrift
struct Statistics {
  5: optional binary max_value;
  6: optional binary min_value;
}
```

This change is a follow-up improvement to https://github.com/apache/iceberg-python/pull/1354, which fixed handling of missing column statistics. This PR addresses the case where statistics **are present** but returned as `bytes` instead of `str`.

This change is indirectly related to broader DuckDB-PyIceberg interoperability challenges documented in https://github.com/duckdb/duckdb/issues/12958

When PyArrow reads these statistics from Parquet files, it may return them as Python `bytes` objects rather than decoded `str` values, which is valid per the Parquet spec. However, PyIceberg's `StatsAggregator` only expected string statistics to be `str` objects, causing failures when processing files from writers like DuckDB that expose this binary representation.

This PR fixes the issue by adding proper handling for `bytes` values in string column statistics:
1. `StatsAggregator.min_as_bytes()`: Decode bytes to UTF-8 before truncation and serialization
2. `StatsAggregator.max_as_bytes()`: Decode bytes to UTF-8 before processing (previously raised ValueError)
3. `to_bytes()` for StringType: Add defensive isinstance check as a safety fallback
4. Add comprehensive unit tests for both StatsAggregator and to_bytes

This improves interoperability with DuckDB and other Parquet writers that expose statistics in their binary form.

## Are these changes tested?

Yes, this PR includes unit tests that verify:
- `StatsAggregator.min_as_bytes()` correctly handles bytes values for string columns
- `StatsAggregator.max_as_bytes()` correctly handles bytes values for string columns
- `to_bytes()` for StringType correctly handles both str and bytes inputs

The tests ensure the fix works correctly while maintaining backward compatibility with existing str-based statistics.

## Are there any user-facing changes?

**Yes** - This is a bug fix that enables users to successfully use `add_files()` with Parquet files written by DuckDB and potentially other writers that return statistics as bytes.

**Before**: `add_files()` would fail with `AttributeError: 'bytes' object has no attribute 'encode'` when processing DuckDB-written Parquet files.

**After**: `add_files()` correctly processes Parquet files regardless of whether statistics are returned as `str` or `bytes`.

This change is backward compatible - existing workflows with Parquet files that return str statistics will continue to work as before.



