### PR TITLE
feat: Add tell() to OutputStream writers

### DIFF
--- a/pyiceberg/avro/file.py
+++ b/pyiceberg/avro/file.py
@@ -317,3 +317,6 @@ class AvroOutputFile(Generic[D]):
             self.encoder.write(block_content)
 
         self.encoder.write(self.sync_bytes)
+
+    def tell(self) -> int:
+        return self.output_stream.tell()

--- a/pyiceberg/io/__init__.py
+++ b/pyiceberg/io/__init__.py
@@ -141,6 +141,9 @@ class OutputStream(Protocol):  # pragma: no cover
     def write(self, b: bytes) -> int: ...
 
     @abstractmethod
+    def tell(self) -> int: ...
+
+    @abstractmethod
     def close(self) -> None: ...
 
     @abstractmethod

--- a/pyiceberg/manifest.py
+++ b/pyiceberg/manifest.py
@@ -1059,6 +1059,9 @@ class ManifestWriter(ABC):
         self.closed = True
         self._writer.__exit__(exc_type, exc_value, traceback)
 
+    def tell(self) -> int:
+        return self._writer.tell()
+
     @abstractmethod
     def content(self) -> ManifestContent: ...
 


### PR DESCRIPTION
# Rationale for this change

Currently, PyIceberg writes one manifest per snapshot operation regardless of manifest size. In order to eventually support this we need to be able to track written bytes without closing the file, so that we can roll to a new file once we hit target size. 

We had some of this work done in #650, but we can keep this simple and add writers as a follow up. The nice thing is that the underlying streams we support already have a tell() method and we just need to expose it. 

With this change in the follow up we can do:

```
with write_manifest(...) as writer:
    writer.add_entry(entry)
    if writer.tell() >= target_file_size:
        # roll to new file
```

## Are these changes tested?

Yes, added a test :)

## Are there any user-facing changes?

No
