### PR TITLE
Optimization: Prune manifest in snapshot overwrite operations

### DIFF
--- a/pyiceberg/table/update/snapshot.py
+++ b/pyiceberg/table/update/snapshot.py
@@ -331,10 +331,7 @@ class _SnapshotProducer(UpdateTableMetadata[U], Generic[U]):
     def snapshot_id(self) -> int:
         return self._snapshot_id
 
-    def schema(self, schema_id: int | None = None) -> Schema:
-        if schema_id:
-            if schema := self._transaction.table_metadata.schema_by_id(schema_id):
-                return schema
+    def schema(self) -> Schema:
         return self._transaction.table_metadata.schema()
 
     def spec(self, spec_id: int) -> PartitionSpec:
@@ -381,10 +378,10 @@ class _SnapshotProducer(UpdateTableMetadata[U], Generic[U]):
             group = partition_to_overwrite.setdefault(data_file.spec_id, set())
             group.add(data_file.partition)
 
-        for spec_id, data_files in partition_to_overwrite.items():
+        for spec_id, partition_records in partition_to_overwrite.items():
             self.delete_by_predicate(
                 self._transaction._build_partition_predicate(
-                    partition_records=data_files, schema=self.schema(), spec=self.spec(spec_id)
+                    partition_records=partition_records, schema=self.schema(), spec=self.spec(spec_id)
                 )
             )
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

Doing some performance tests for overwriting partitions, we noticed that PyIceberg took double the time it usually takes java based implementation, we noticed that `_exisiting_manifests` does not take advantage of manifest pruning before reading all Manifest Entries 

In this PR I:
- Moved methods from _DeleteFiles to _SnapshotProducer parent class to share with other classes (_OverwriteFiles)
- Implemented manifest pruning over all deleted files partitions to not read manifests that do not match file partitions
- Refactored the method to only iterate once over all files (instead of multiple)

## Are these changes tested?

I believe current tests in tests/integration/test_writes.py cover all cases

## Are there any user-facing changes?

Nope

<!-- In the case of user-facing changes, please add the changelog label. -->
