### PR TITLE
docs: release docs improvements

### DIFF
--- a/mkdocs/docs/how-to-release.md
+++ b/mkdocs/docs/how-to-release.md
@@ -309,6 +309,9 @@ Kind regards,
 <!-- prettier-ignore-end -->
 
 ```bash
+: "${VERSION_WITH_RC:?ERROR: VERSION_WITH_RC is not set or is empty}"
+: "${VERSION:?ERROR: VERSION is not set or is empty}"
+
 export SVN_DEV_DIR_VERSIONED="https://dist.apache.org/repos/dist/dev/iceberg/pyiceberg-${VERSION_WITH_RC}"
 export SVN_RELEASE_DIR_VERSIONED="https://dist.apache.org/repos/dist/release/iceberg/pyiceberg-${VERSION}"
 
@@ -337,8 +340,10 @@ The latest version can be pushed to PyPi. Check out the Apache SVN and make sure
 <!-- prettier-ignore-end -->
 
 ```bash
-svn checkout https://dist.apache.org/repos/dist/release/iceberg /tmp/iceberg-dist-release/
+svn checkout https://dist.apache.org/repos/dist/release/iceberg/pyiceberg-${VERSION} /tmp/iceberg-dist-release/pyiceberg-${VERSION}
+
 cd /tmp/iceberg-dist-release/pyiceberg-${VERSION}
+
 twine upload pyiceberg-*.whl pyiceberg-*.tar.gz
 ```
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
2 minor doc improvements
* ensure `VERSION` and `VERSION_WITH_RC` env vars are set before running command. Since most likely theres a long time between waiting for release verification and accepting the release. 
* only download necessary version from svn, previous command downloaded everything which can take a long time

<img width="756" height="371" alt="Screenshot 2026-02-10 at 10 35 37 AM" src="https://github.com/user-attachments/assets/d171ba35-de44-4cd5-8fdc-6497160c0d50" />
<img width="756" height="360" alt="Screenshot 2026-02-10 at 10 35 52 AM" src="https://github.com/user-attachments/assets/fbc290e0-08b3-4396-8a6f-dcc9b9363ec3" />

## Are these changes tested?

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
