### PR TITLE
fix: add Field alias for SetPartitionStatisticsUpdate.partition_stati…

### DIFF
--- a/pyiceberg/table/update/__init__.py
+++ b/pyiceberg/table/update/__init__.py
@@ -212,7 +212,7 @@ class RemoveSchemasUpdate(IcebergBaseModel):
 
 class SetPartitionStatisticsUpdate(IcebergBaseModel):
     action: Literal["set-partition-statistics"] = Field(default="set-partition-statistics")
-    partition_statistics: PartitionStatisticsFile
+    partition_statistics: PartitionStatisticsFile = Field(alias="partition-statistics")
 
 
 class RemovePartitionStatisticsUpdate(IcebergBaseModel):

--- a/tests/table/test_init.py
+++ b/tests/table/test_init.py
@@ -1605,6 +1605,10 @@ def test_set_partition_statistics_update(table_v2_with_statistics: Table) -> Non
         partition_statistics=partition_statistics_file,
     )
 
+    # Verify that serialization uses 'partition-statistics' alias
+    dumped_with_alias = update.model_dump(by_alias=True)
+    assert "partition-statistics" in dumped_with_alias
+
     new_metadata = update_table_metadata(
         table_v2_with_statistics.metadata,
         (update,),


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

Add `Field(alias="partition-statistics")` to `SetPartitionStatisticsUpdate.partition_statistics` to ensure correct serialization/deserialization with the hyphenated key format.

## Problem
The `partition_statistics` field was missing an explicit `Field` alias, which means:
- When serializing with `model_dump(by_alias=True)`, it would use the Python attribute name `partition_statistics` (with underscore) instead of the Iceberg specification format `partition-statistics` (with hyphen)
- This causes incompatibility with the Iceberg table metadata format specification

## Solution
Added `Field(alias="partition-statistics")` to ensure:
- Proper serialization to JSON/dict using hyphenated key names that comply with Iceberg spec
- Correct deserialization when parsing external metadata with hyphenated keys
- Consistency with other similar fields in the codebase (e.g., `snapshot_ids` with alias `snapshot-ids`)

## Are these changes tested?

Yes. Added verification in `test_set_partition_statistics_update()` to validate that:
1. The update object serializes to JSON with the correct `"partition-statistics"` key
2. The key is present in the serialized output

## Are there any user-facing changes?

No. This is an internal fix to ensure metadata serialization format compliance. The change is transparent to users and improves interoperability with the Iceberg specification.

<!-- In the case of user-facing changes, please add the changelog label. -->
