### PR TITLE
fix: Hive catalog test failure on CPython 3.13.12

### DIFF
--- a/tests/catalog/test_hive.py
+++ b/tests/catalog/test_hive.py
@@ -1314,8 +1314,8 @@ def test_hive_wait_for_lock() -> None:
     assert catalog._client.check_lock.call_count == 3
 
     # lock wait should exit with WaitingForLockException finally after enough retries
+    catalog._client.check_lock.reset_mock()
     catalog._client.check_lock.side_effect = [waiting for _ in range(10)]
-    catalog._client.check_lock.call_count = 0
     with pytest.raises(WaitingForLockException):
         catalog._wait_for_lock("db", "tbl", lockid, catalog._client)
     assert catalog._client.check_lock.call_count == 5


### PR DESCRIPTION
# Rationale for this change

While reviewing some open PRs #3041, #3042, I noticed CI kept failing on the Python 3.13 job in the hive tests. Turns out [CPython 3.13.12 ](https://docs.python.org/3.13/whatsnew/changelog.html#id3)was just released and included a change https://github.com/python/cpython/issues/142651 which made `Mock.call_count` thread-safe by deriving it from `len(call_args_list)`.

This broke our hive test, which was resetting the counter with `mock.call_count = 0` directly. This switches to use reset_mock(), which properly clears all the internal call tracking state.

## Are these changes tested?

`make test` passes

## Are there any user-facing changes?

no
