### PR TITLE
PR0: forward batch_size parameter to PyArrow Scanner

### DIFF
--- a/mkdocs/docs/api.md
+++ b/mkdocs/docs/api.md
@@ -355,6 +355,13 @@ for buf in tbl.scan().to_arrow_batch_reader():
     print(f"Buffer contains {len(buf)} rows")
 ```
 
+You can control the number of rows per batch using the `batch_size` parameter:
+
+```python
+for buf in tbl.scan().to_arrow_batch_reader(batch_size=1000):
+    print(f"Buffer contains {len(buf)} rows")
+```
+
 To avoid any type inconsistencies during writing, you can convert the Iceberg table schema to Arrow:
 
 ```python
@@ -1617,6 +1624,15 @@ table.scan(
     row_filter=GreaterThanOrEqual("trip_distance", 10.0),
     selected_fields=("VendorID", "tpep_pickup_datetime", "tpep_dropoff_datetime"),
 ).to_arrow_batch_reader()
+```
+
+The `batch_size` parameter controls the maximum number of rows per RecordBatch (default is PyArrow's 131,072 rows):
+
+```python
+table.scan(
+    row_filter=GreaterThanOrEqual("trip_distance", 10.0),
+    selected_fields=("VendorID", "tpep_pickup_datetime", "tpep_dropoff_datetime"),
+).to_arrow_batch_reader(batch_size=1000)
 ```
 
 ### Pandas

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -2157,12 +2157,15 @@ class DataScan(TableScan):
             self.table_metadata, self.io, self.projection(), self.row_filter, self.case_sensitive, self.limit
         ).to_table(self.plan_files())
 
-    def to_arrow_batch_reader(self) -> pa.RecordBatchReader:
+    def to_arrow_batch_reader(self, batch_size: int | None = None) -> pa.RecordBatchReader:
         """Return an Arrow RecordBatchReader from this DataScan.
 
         For large results, using a RecordBatchReader requires less memory than
         loading an Arrow Table for the same DataScan, because a RecordBatch
         is read one at a time.
+
+        Args:
+            batch_size: The number of rows per batch. If None, PyArrow's default is used.
 
         Returns:
             pa.RecordBatchReader: Arrow RecordBatchReader from the Iceberg table's DataScan
@@ -2175,7 +2178,7 @@ class DataScan(TableScan):
         target_schema = schema_to_pyarrow(self.projection())
         batches = ArrowScan(
             self.table_metadata, self.io, self.projection(), self.row_filter, self.case_sensitive, self.limit
-        ).to_record_batches(self.plan_files())
+        ).to_record_batches(self.plan_files(), batch_size=batch_size)
 
         return pa.RecordBatchReader.from_batches(
             target_schema,


### PR DESCRIPTION
# Rationale for this change

Closes partially #3036
 
## Summary
  - Forward `batch_size` parameter to PyArrow's `ds.Scanner.from_fragment()` to control rows per RecordBatch
  - Propagated through `_task_to_record_batches` → `_record_batches_from_scan_tasks_and_deletes` → `ArrowScan.to_record_batches` → `DataScan.to_arrow_batch_reader`

## PR Stack
This is PR 1 of 3 for #3036:
 1. **PR 0 (this)**: `batch_size` forwarding
 2. **PR 1**: `streaming` flag — stop materializing entire files
  3. **PR 2**: `concurrent_files` — bounded concurrent streaming
 

## Are these changes tested?

Yes — unit tests for batch_size=100 and batch_size=None in test_pyarrow.py.

## Are there any user-facing changes?

Yes — new batch_size param on to_arrow_batch_reader().