### PR TITLE
fix: properly reset mock in test_hive_wait_for_lock

### DIFF
--- a/tests/catalog/test_hive.py
+++ b/tests/catalog/test_hive.py
@@ -1314,8 +1314,8 @@ def test_hive_wait_for_lock() -> None:
     assert catalog._client.check_lock.call_count == 3
 
     # lock wait should exit with WaitingForLockException finally after enough retries
+    catalog._client.check_lock.reset_mock()
     catalog._client.check_lock.side_effect = [waiting for _ in range(10)]
-    catalog._client.check_lock.call_count = 0
     with pytest.raises(WaitingForLockException):
         catalog._wait_for_lock("db", "tbl", lockid, catalog._client)
     assert catalog._client.check_lock.call_count == 5


### PR DESCRIPTION
## Summary
- Fix flaky `test_hive_wait_for_lock` test by using `reset_mock()` instead of manually setting `call_count = 0`
- Setting `mock.call_count = 0` does not reset the mock's internal call tracking, causing the second assertion to see accumulated calls from both test phases (expected 5, got 8)

## Test plan
- [x] Verify `test_hive_wait_for_lock` passes consistently across all Python versions in CI
