### PR TITLE
Surface too many requests exception

### DIFF
--- a/pyiceberg/catalog/rest/response.py
+++ b/pyiceberg/catalog/rest/response.py
@@ -28,6 +28,7 @@ from pyiceberg.exceptions import (
     RESTError,
     ServerError,
     ServiceUnavailableError,
+    TooManyRequestsError,
     UnauthorizedError,
 )
 from pyiceberg.typedef import IcebergBaseModel
@@ -79,6 +80,8 @@ def _handle_non_200_response(exc: HTTPError, error_handler: dict[int, type[Excep
         exception = RESTError
     elif code == 419:
         exception = AuthorizationExpiredError
+    elif code == 429:
+        exception = TooManyRequestsError
     elif code == 501:
         exception = NotImplementedError
     elif code == 503:

--- a/pyiceberg/exceptions.py
+++ b/pyiceberg/exceptions.py
@@ -84,6 +84,10 @@ class AuthorizationExpiredError(RESTError):
     """When the credentials are expired when performing an action on the REST catalog."""
 
 
+class TooManyRequestsError(RESTError):
+    """Raises when too many requests error is returned by the REST catalog."""
+
+
 class OAuthError(RESTError):
     """Raises when there is an error with the OAuth call."""
 


### PR DESCRIPTION
# Rationale for this change

Currently there's no way to catch just the HTTP code 429

## Are these changes tested?

## Are there any user-facing changes?

No
