### PR TITLE
chore: Remove docs from uv default groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,6 @@ notebook = [
 [tool.uv]
 default-groups = [
     "dev",
-    "docs",
 ]
 
 [build-system]


### PR DESCRIPTION
# Rationale for this change

This is a follow up to #2996. The docs group was factored out and is called directly in it's make target. This drops the 11 package dependencies when just running `make install` now.

## Are these changes tested?
Yes

## Are there any user-facing changes?
No
