### PR TITLE
feat(cli): replace REST --prefix with --warehouse

### DIFF
--- a/mkdocs/docs/cli.md
+++ b/mkdocs/docs/cli.md
@@ -26,7 +26,7 @@ hide:
 
 Pyiceberg comes with a CLI that's available after installing the `pyiceberg` package.
 
-You can pass the path to the Catalog using `--uri` and `--credential`. For REST catalogs that require a path prefix, you can also set `--prefix`. It is still recommended to set up a `~/.pyiceberg.yaml` config as described in the [Catalog](configuration.md) section.
+You can pass the path to the Catalog using `--uri` and `--credential`. For REST catalogs, you can also set `--warehouse` to request a specific warehouse from the catalog service. It is still recommended to set up a `~/.pyiceberg.yaml` config as described in the [Catalog](configuration.md) section.
 
 ```sh
 ➜  pyiceberg --help
@@ -39,7 +39,7 @@ Options:
   --ugi TEXT
   --uri TEXT
   --credential TEXT
-  --prefix TEXT
+  --warehouse TEXT
   --help                Show this message and exit.
 
 Commands:

--- a/pyiceberg/cli/console.py
+++ b/pyiceberg/cli/console.py
@@ -30,6 +30,7 @@ from pyiceberg import __version__
 from pyiceberg.catalog import URI, Catalog, load_catalog
 from pyiceberg.cli.output import ConsoleOutput, JsonOutput, Output
 from pyiceberg.exceptions import NoSuchNamespaceError, NoSuchPropertyException, NoSuchTableError
+from pyiceberg.io import WAREHOUSE
 from pyiceberg.table import TableProperties
 from pyiceberg.table.refs import SnapshotRef, SnapshotRefType
 from pyiceberg.utils.properties import property_as_int
@@ -66,7 +67,7 @@ def catch_exception() -> Callable:  # type: ignore
 @click.option("--ugi")
 @click.option("--uri")
 @click.option("--credential")
-@click.option("--prefix")
+@click.option("--warehouse")
 @click.pass_context
 def run(
     ctx: Context,
@@ -77,7 +78,7 @@ def run(
     ugi: str | None,
     uri: str | None,
     credential: str | None,
-    prefix: str | None,
+    warehouse: str | None,
 ) -> None:
     logging.basicConfig(
         level=getattr(logging, log_level.upper()),
@@ -91,8 +92,8 @@ def run(
         properties[URI] = uri
     if credential:
         properties["credential"] = credential
-    if prefix:
-        properties["prefix"] = prefix
+    if warehouse:
+        properties[WAREHOUSE] = warehouse
 
     ctx.ensure_object(dict)
     if output == "text":

--- a/tests/cli/test_console.py
+++ b/tests/cli/test_console.py
@@ -1044,7 +1044,7 @@ def test_log_level_cli_overrides_env(mocker: MockFixture) -> None:
     assert call_kwargs["level"] == logging.ERROR
 
 
-def test_prefix_cli_option_forwarded_to_catalog(mocker: MockFixture) -> None:
+def test_warehouse_cli_option_forwarded_to_catalog(mocker: MockFixture) -> None:
     mock_basicConfig = mocker.patch("logging.basicConfig")
     mock_catalog = MagicMock(spec=InMemoryCatalog)
     mock_catalog.list_tables.return_value = []
@@ -1052,8 +1052,10 @@ def test_prefix_cli_option_forwarded_to_catalog(mocker: MockFixture) -> None:
     mock_load_catalog = mocker.patch("pyiceberg.cli.console.load_catalog", return_value=mock_catalog)
 
     runner = CliRunner()
-    result = runner.invoke(run, ["--catalog", "rest", "--uri", "https://example.invalid", "--prefix", "v1/ws", "list"])
+    result = runner.invoke(
+        run, ["--catalog", "rest", "--uri", "https://catalog.service", "--warehouse", "example-warehouse", "list"]
+    )
 
     assert result.exit_code == 0
     mock_basicConfig.assert_called_once()
-    mock_load_catalog.assert_called_once_with("rest", uri="https://example.invalid", prefix="v1/ws")
+    mock_load_catalog.assert_called_once_with("rest", uri="https://catalog.service", warehouse="example-warehouse")


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
Closes #3059
Follow up to #3061, should use `warehouse` instead of `prefix`

This updates the CLI to use --warehouse for REST catalogs instead of --prefix, aligning CLI behavior with REST catalog configuration semantics.

## Are these changes tested?
Yes

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
