### PR TITLE
BigQuery metastore: implement commit_table with commit status verification

### DIFF
--- a/pyiceberg/catalog/bigquery_metastore.py
+++ b/pyiceberg/catalog/bigquery_metastore.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import json
+from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 from google.api_core.exceptions import NotFound
@@ -67,6 +68,12 @@ ICEBERG_TABLE_TYPE_VALUE = "ICEBERG"
 HIVE_SERIALIZATION_LIBRARY = "org.apache.iceberg.mr.hive.HiveIcebergSerDe"
 HIVE_FILE_INPUT_FORMAT = "org.apache.iceberg.mr.hive.HiveIcebergInputFormat"
 HIVE_FILE_OUTPUT_FORMAT = "org.apache.iceberg.mr.hive.HiveIcebergOutputFormat"
+
+
+class BigqueryCommitStatus(str, Enum):
+    SUCCESS = "SUCCESS"
+    FAILURE = "FAILURE"
+    UNKNOWN = "UNKNOWN"
 
 
 class BigQueryMetastoreCatalog(MetastoreCatalog):
@@ -307,9 +314,9 @@ class BigQueryMetastoreCatalog(MetastoreCatalog):
         finally:
             if commit_error:
                 commit_status = self._check_bigquery_commit_status(table_ref, updated_staged_table.metadata_location)
-                if commit_status == "SUCCESS":
+                if commit_status == BigqueryCommitStatus.SUCCESS:
                     commit_error = None
-                elif commit_status == "UNKNOWN":
+                elif commit_status == BigqueryCommitStatus.UNKNOWN:
                     raise CommitStateUnknownException(
                         f"Commit state unknown for table {dataset_name}.{table_name}"
                     ) from commit_error
@@ -539,10 +546,10 @@ class BigQueryMetastoreCatalog(MetastoreCatalog):
             )
             current_metadata_location = parameters.get(METADATA_LOCATION_PROP)
             if current_metadata_location == new_metadata_location:
-                return "SUCCESS"
+                return BigqueryCommitStatus.SUCCESS
 
             if not current_metadata_location:
-                return "FAILURE"
+                return BigqueryCommitStatus.FAILURE
 
             io = self._load_file_io(location=current_metadata_location)
             current_metadata = FromInputFile.table_metadata(io.new_input(current_metadata_location))
@@ -552,11 +559,11 @@ class BigQueryMetastoreCatalog(MetastoreCatalog):
             if previous_metadata_location:
                 previous_metadata_locations.add(previous_metadata_location)
 
-            return "SUCCESS" if new_metadata_location in previous_metadata_locations else "FAILURE"
+            return BigqueryCommitStatus.SUCCESS if new_metadata_location in previous_metadata_locations else "FAILURE"
         except NotFound:
-            return "FAILURE"
+            return BigqueryCommitStatus.FAILURE
         except Exception:
-            return "UNKNOWN"
+            return BigqueryCommitStatus.UNKNOWN
 
     def _default_storage_location(self, location: str | None, dataset_ref: DatasetReference) -> str | None:
         if location:

--- a/pyiceberg/catalog/bigquery_metastore.py
+++ b/pyiceberg/catalog/bigquery_metastore.py
@@ -537,7 +537,22 @@ class BigQueryMetastoreCatalog(MetastoreCatalog):
                 if bq_table.external_catalog_table_options and bq_table.external_catalog_table_options.parameters
                 else {}
             )
-            return "SUCCESS" if parameters.get(METADATA_LOCATION_PROP) == new_metadata_location else "FAILURE"
+            current_metadata_location = parameters.get(METADATA_LOCATION_PROP)
+            if current_metadata_location == new_metadata_location:
+                return "SUCCESS"
+
+            if not current_metadata_location:
+                return "FAILURE"
+
+            io = self._load_file_io(location=current_metadata_location)
+            current_metadata = FromInputFile.table_metadata(io.new_input(current_metadata_location))
+
+            previous_metadata_locations = {log.metadata_file for log in current_metadata.metadata_log}
+            previous_metadata_location = parameters.get(PREVIOUS_METADATA_LOCATION_PROP)
+            if previous_metadata_location:
+                previous_metadata_locations.add(previous_metadata_location)
+
+            return "SUCCESS" if new_metadata_location in previous_metadata_locations else "FAILURE"
         except NotFound:
             return "FAILURE"
         except Exception:

--- a/pyiceberg/catalog/bigquery_metastore.py
+++ b/pyiceberg/catalog/bigquery_metastore.py
@@ -29,7 +29,14 @@ from google.oauth2 import service_account
 from typing_extensions import override
 
 from pyiceberg.catalog import WAREHOUSE_LOCATION, MetastoreCatalog, PropertiesUpdateSummary
-from pyiceberg.exceptions import NamespaceAlreadyExistsError, NoSuchNamespaceError, NoSuchTableError, TableAlreadyExistsError
+from pyiceberg.exceptions import (
+    CommitFailedException,
+    CommitStateUnknownException,
+    NamespaceAlreadyExistsError,
+    NoSuchNamespaceError,
+    NoSuchTableError,
+    TableAlreadyExistsError,
+)
 from pyiceberg.io import load_file_io
 from pyiceberg.partitioning import UNPARTITIONED_PARTITION_SPEC, PartitionSpec
 from pyiceberg.schema import Schema
@@ -234,7 +241,88 @@ class BigQueryMetastoreCatalog(MetastoreCatalog):
     def commit_table(
         self, table: Table, requirements: tuple[TableRequirement, ...], updates: tuple[TableUpdate, ...]
     ) -> CommitTableResponse:
-        raise NotImplementedError
+        table_identifier = table.name()
+        dataset_name, table_name = self.identifier_to_database_and_table(table_identifier, NoSuchTableError)
+        table_ref = TableReference(
+            dataset_ref=DatasetReference(project=self.project_id, dataset_id=dataset_name),
+            table_id=table_name,
+        )
+
+        current_bq_table: BQTable | None
+        current_table: Table | None
+        try:
+            current_bq_table = self.client.get_table(table_ref)
+        except NotFound:
+            current_bq_table = None
+            current_table = None
+        else:
+            current_table = self._convert_bigquery_table_to_iceberg_table(table_identifier, current_bq_table)
+
+        updated_staged_table = self._update_and_stage_table(current_table, table_identifier, requirements, updates)
+        if current_table and updated_staged_table.metadata == current_table.metadata:
+            return CommitTableResponse(metadata=current_table.metadata, metadata_location=current_table.metadata_location)
+
+        self._write_metadata(
+            metadata=updated_staged_table.metadata,
+            io=updated_staged_table.io,
+            metadata_path=updated_staged_table.metadata_location,
+        )
+
+        commit_error: Exception | None = None
+        try:
+            if current_bq_table and current_table:
+                current_bq_table.external_catalog_table_options = self._create_external_catalog_table_options(
+                    updated_staged_table.metadata.location,
+                    self._create_table_parameters(
+                        metadata_file_location=updated_staged_table.metadata_location,
+                        table_metadata=updated_staged_table.metadata,
+                        previous_metadata_location=current_table.metadata_location,
+                    ),
+                )
+                self.client.update_table(current_bq_table, ["external_catalog_table_options"])
+            else:
+                self.client.create_table(
+                    self._make_new_table(
+                        updated_staged_table.metadata,
+                        updated_staged_table.metadata_location,
+                        table_ref,
+                    )
+                )
+        except NotFound as e:
+            commit_error = (
+                CommitFailedException(f"Table does not exist: {dataset_name}.{table_name}")
+                if current_table
+                else NoSuchNamespaceError(f"Namespace does not exist: {dataset_name}")
+            )
+            commit_error.__cause__ = e
+        except Conflict as e:
+            commit_error = (
+                CommitFailedException(f"Table has been updated by another process: {dataset_name}.{table_name}")
+                if current_table
+                else TableAlreadyExistsError(f"Table {table_name} already exists")
+            )
+            commit_error.__cause__ = e
+        except Exception as e:
+            commit_error = e
+        finally:
+            if commit_error:
+                commit_status = self._check_bigquery_commit_status(table_ref, updated_staged_table.metadata_location)
+                if commit_status == "SUCCESS":
+                    commit_error = None
+                elif commit_status == "UNKNOWN":
+                    raise CommitStateUnknownException(
+                        f"Commit state unknown for table {dataset_name}.{table_name}"
+                    ) from commit_error
+
+        if commit_error:
+            raise commit_error
+
+        if current_table:
+            self._delete_old_metadata(updated_staged_table.io, current_table.metadata, updated_staged_table.metadata)
+
+        return CommitTableResponse(
+            metadata=updated_staged_table.metadata, metadata_location=updated_staged_table.metadata_location
+        )
 
     @override
     def rename_table(self, from_identifier: str | Identifier, to_identifier: str | Identifier) -> Table:
@@ -408,11 +496,20 @@ class BigQueryMetastoreCatalog(MetastoreCatalog):
             catalog=self,
         )
 
-    def _create_table_parameters(self, metadata_file_location: str, table_metadata: TableMetadata) -> dict[str, Any]:
-        parameters: dict[str, Any] = table_metadata.properties
+    def _create_table_parameters(
+        self,
+        metadata_file_location: str,
+        table_metadata: TableMetadata,
+        previous_metadata_location: str | None = None,
+    ) -> dict[str, Any]:
+        parameters: dict[str, Any] = dict(table_metadata.properties)
         if table_metadata.table_uuid:
             parameters["uuid"] = str(table_metadata.table_uuid)
         parameters[METADATA_LOCATION_PROP] = metadata_file_location
+        if previous_metadata_location:
+            parameters[PREVIOUS_METADATA_LOCATION_PROP] = previous_metadata_location
+        else:
+            parameters.pop(PREVIOUS_METADATA_LOCATION_PROP, None)
         parameters[TABLE_TYPE_PROP] = ICEBERG_TABLE_TYPE_VALUE
         parameters["EXTERNAL"] = True
 
@@ -431,6 +528,20 @@ class BigQueryMetastoreCatalog(MetastoreCatalog):
                     parameters["totalSize"] = summary.get(TOTAL_FILE_SIZE)
 
         return parameters
+
+    def _check_bigquery_commit_status(self, table_ref: TableReference, new_metadata_location: str) -> str:
+        try:
+            bq_table = self.client.get_table(table_ref)
+            parameters = (
+                bq_table.external_catalog_table_options.parameters
+                if bq_table.external_catalog_table_options and bq_table.external_catalog_table_options.parameters
+                else {}
+            )
+            return "SUCCESS" if parameters.get(METADATA_LOCATION_PROP) == new_metadata_location else "FAILURE"
+        except NotFound:
+            return "FAILURE"
+        except Exception:
+            return "UNKNOWN"
 
     def _default_storage_location(self, location: str | None, dataset_ref: DatasetReference) -> str | None:
         if location:

--- a/pyiceberg/catalog/bigquery_metastore.py
+++ b/pyiceberg/catalog/bigquery_metastore.py
@@ -324,9 +324,6 @@ class BigQueryMetastoreCatalog(MetastoreCatalog):
         if commit_error:
             raise commit_error
 
-        if current_table:
-            self._delete_old_metadata(updated_staged_table.io, current_table.metadata, updated_staged_table.metadata)
-
         return CommitTableResponse(
             metadata=updated_staged_table.metadata, metadata_location=updated_staged_table.metadata_location
         )

--- a/pyiceberg/catalog/bigquery_metastore.py
+++ b/pyiceberg/catalog/bigquery_metastore.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
@@ -68,6 +69,8 @@ ICEBERG_TABLE_TYPE_VALUE = "ICEBERG"
 HIVE_SERIALIZATION_LIBRARY = "org.apache.iceberg.mr.hive.HiveIcebergSerDe"
 HIVE_FILE_INPUT_FORMAT = "org.apache.iceberg.mr.hive.HiveIcebergInputFormat"
 HIVE_FILE_OUTPUT_FORMAT = "org.apache.iceberg.mr.hive.HiveIcebergOutputFormat"
+
+logger = logging.getLogger(__name__)
 
 
 class BigqueryCommitStatus(str, Enum):
@@ -320,6 +323,17 @@ class BigQueryMetastoreCatalog(MetastoreCatalog):
                     raise CommitStateUnknownException(
                         f"Commit state unknown for table {dataset_name}.{table_name}"
                     ) from commit_error
+                elif commit_status == BigqueryCommitStatus.FAILURE:
+                    logger.warning("Failed to commit updates to table %s", table_name)
+                    try:
+                        updated_staged_table.io.delete(updated_staged_table.metadata_location)
+                    except Exception:
+                        logger.error(
+                            "Failed to cleanup metadata file at %s for table %s",
+                            updated_staged_table.metadata_location,
+                            table_name,
+                            exc_info=logger.isEnabledFor(logging.DEBUG),
+                        )
 
         if commit_error:
             raise commit_error

--- a/tests/catalog/test_bigquery_metastore.py
+++ b/tests/catalog/test_bigquery_metastore.py
@@ -17,13 +17,14 @@
 import os
 from unittest.mock import MagicMock
 
+import pytest
 from google.api_core.exceptions import NotFound
 from google.cloud.bigquery import Dataset, DatasetReference, Table, TableReference
 from google.cloud.bigquery.external_config import ExternalCatalogDatasetOptions, ExternalCatalogTableOptions
 from pytest_mock import MockFixture
 
 from pyiceberg.catalog.bigquery_metastore import ICEBERG_TABLE_TYPE_VALUE, TABLE_TYPE_PROP, BigQueryMetastoreCatalog
-from pyiceberg.exceptions import NoSuchTableError
+from pyiceberg.exceptions import CommitStateUnknownException, NoSuchTableError
 from pyiceberg.schema import Schema
 
 
@@ -178,3 +179,101 @@ def test_list_namespaces(mocker: MockFixture) -> None:
     assert ("dataset1",) in namespaces
     assert ("dataset2",) in namespaces
     client_mock.list_datasets.assert_called_once()
+
+
+def test_commit_table_create_path_uses_create_table(mocker: MockFixture) -> None:
+    client_mock = MagicMock()
+    client_mock.get_table.side_effect = NotFound("missing")
+    mocker.patch("pyiceberg.catalog.bigquery_metastore.Client", return_value=client_mock)
+    mocker.patch.dict(os.environ, values={"PYICEBERG_LEGACY_CURRENT_SNAPSHOT_ID": "True"})
+
+    catalog = BigQueryMetastoreCatalog("test_catalog", **{"gcp.bigquery.project-id": "my-project"})
+    table = MagicMock()
+    table.name.return_value = ("my-dataset", "my-table")
+
+    staged = MagicMock()
+    staged.metadata = MagicMock()
+    staged.metadata_location = "gs://bucket/db/table/metadata/00001.metadata.json"
+    staged.io = MagicMock()
+    mocker.patch.object(catalog, "_update_and_stage_table", return_value=staged)
+    mocker.patch.object(catalog, "_write_metadata")
+    mocker.patch.object(catalog, "_make_new_table", return_value=MagicMock())
+    commit_response = MagicMock()
+    commit_response.metadata_location = staged.metadata_location
+    mocker.patch("pyiceberg.catalog.bigquery_metastore.CommitTableResponse", return_value=commit_response)
+
+    response = catalog.commit_table(table, requirements=(), updates=())
+
+    client_mock.create_table.assert_called_once()
+    client_mock.update_table.assert_not_called()
+    assert response.metadata_location == staged.metadata_location
+
+
+def test_commit_table_update_path_uses_update_table(mocker: MockFixture) -> None:
+    client_mock = MagicMock()
+    current_bq_table = MagicMock()
+    client_mock.get_table.return_value = current_bq_table
+    mocker.patch("pyiceberg.catalog.bigquery_metastore.Client", return_value=client_mock)
+    mocker.patch.dict(os.environ, values={"PYICEBERG_LEGACY_CURRENT_SNAPSHOT_ID": "True"})
+
+    catalog = BigQueryMetastoreCatalog("test_catalog", **{"gcp.bigquery.project-id": "my-project"})
+    table = MagicMock()
+    table.name.return_value = ("my-dataset", "my-table")
+
+    current_table = MagicMock()
+    current_table.metadata = MagicMock()
+    current_table.metadata_location = "gs://bucket/db/table/metadata/00000.metadata.json"
+    mocker.patch.object(catalog, "_convert_bigquery_table_to_iceberg_table", return_value=current_table)
+
+    staged = MagicMock()
+    staged.metadata = MagicMock()
+    staged.metadata.location = "gs://bucket/db/table"
+    staged.metadata_location = "gs://bucket/db/table/metadata/00001.metadata.json"
+    staged.io = MagicMock()
+    mocker.patch.object(catalog, "_update_and_stage_table", return_value=staged)
+    mocker.patch.object(catalog, "_write_metadata")
+    mocker.patch.object(catalog, "_create_table_parameters", return_value={"metadata_location": staged.metadata_location})
+    mocker.patch.object(catalog, "_create_external_catalog_table_options", return_value=MagicMock())
+    delete_old_metadata = mocker.patch.object(catalog, "_delete_old_metadata")
+    commit_response = MagicMock()
+    commit_response.metadata_location = staged.metadata_location
+    mocker.patch("pyiceberg.catalog.bigquery_metastore.CommitTableResponse", return_value=commit_response)
+
+    response = catalog.commit_table(table, requirements=(), updates=())
+
+    client_mock.update_table.assert_called_once_with(current_bq_table, ["external_catalog_table_options"])
+    client_mock.create_table.assert_not_called()
+    delete_old_metadata.assert_called_once_with(staged.io, current_table.metadata, staged.metadata)
+    assert response.metadata_location == staged.metadata_location
+
+
+def test_commit_table_raises_unknown_when_commit_status_is_unknown(mocker: MockFixture) -> None:
+    client_mock = MagicMock()
+    current_bq_table = MagicMock()
+    client_mock.get_table.return_value = current_bq_table
+    client_mock.update_table.side_effect = RuntimeError("boom")
+    mocker.patch("pyiceberg.catalog.bigquery_metastore.Client", return_value=client_mock)
+    mocker.patch.dict(os.environ, values={"PYICEBERG_LEGACY_CURRENT_SNAPSHOT_ID": "True"})
+
+    catalog = BigQueryMetastoreCatalog("test_catalog", **{"gcp.bigquery.project-id": "my-project"})
+    table = MagicMock()
+    table.name.return_value = ("my-dataset", "my-table")
+
+    current_table = MagicMock()
+    current_table.metadata = MagicMock()
+    current_table.metadata_location = "gs://bucket/db/table/metadata/00000.metadata.json"
+    mocker.patch.object(catalog, "_convert_bigquery_table_to_iceberg_table", return_value=current_table)
+
+    staged = MagicMock()
+    staged.metadata = MagicMock()
+    staged.metadata.location = "gs://bucket/db/table"
+    staged.metadata_location = "gs://bucket/db/table/metadata/00001.metadata.json"
+    staged.io = MagicMock()
+    mocker.patch.object(catalog, "_update_and_stage_table", return_value=staged)
+    mocker.patch.object(catalog, "_write_metadata")
+    mocker.patch.object(catalog, "_create_table_parameters", return_value={"metadata_location": staged.metadata_location})
+    mocker.patch.object(catalog, "_create_external_catalog_table_options", return_value=MagicMock())
+    mocker.patch.object(catalog, "_check_bigquery_commit_status", return_value="UNKNOWN")
+
+    with pytest.raises(CommitStateUnknownException):
+        catalog.commit_table(table, requirements=(), updates=())

--- a/tests/catalog/test_bigquery_metastore.py
+++ b/tests/catalog/test_bigquery_metastore.py
@@ -23,7 +23,12 @@ from google.cloud.bigquery import Dataset, DatasetReference, Table, TableReferen
 from google.cloud.bigquery.external_config import ExternalCatalogDatasetOptions, ExternalCatalogTableOptions
 from pytest_mock import MockFixture
 
-from pyiceberg.catalog.bigquery_metastore import ICEBERG_TABLE_TYPE_VALUE, TABLE_TYPE_PROP, BigQueryMetastoreCatalog
+from pyiceberg.catalog.bigquery_metastore import (
+    ICEBERG_TABLE_TYPE_VALUE,
+    TABLE_TYPE_PROP,
+    BigqueryCommitStatus,
+    BigQueryMetastoreCatalog,
+)
 from pyiceberg.exceptions import CommitStateUnknownException, NoSuchTableError
 from pyiceberg.schema import Schema
 
@@ -309,3 +314,37 @@ def test_check_bigquery_commit_status_returns_success_when_metadata_in_history(m
     )
 
     assert status == "SUCCESS"
+
+
+def test_commit_table_deletes_written_metadata_when_commit_status_is_failure(mocker: MockFixture) -> None:
+    client_mock = MagicMock()
+    current_bq_table = MagicMock()
+    client_mock.get_table.return_value = current_bq_table
+    client_mock.update_table.side_effect = RuntimeError("boom")
+    mocker.patch("pyiceberg.catalog.bigquery_metastore.Client", return_value=client_mock)
+    mocker.patch.dict(os.environ, values={"PYICEBERG_LEGACY_CURRENT_SNAPSHOT_ID": "True"})
+
+    catalog = BigQueryMetastoreCatalog("test_catalog", **{"gcp.bigquery.project-id": "my-project"})
+    table = MagicMock()
+    table.name.return_value = ("my-dataset", "my-table")
+
+    current_table = MagicMock()
+    current_table.metadata = MagicMock()
+    current_table.metadata_location = "gs://bucket/db/table/metadata/00000.metadata.json"
+    mocker.patch.object(catalog, "_convert_bigquery_table_to_iceberg_table", return_value=current_table)
+
+    staged = MagicMock()
+    staged.metadata = MagicMock()
+    staged.metadata.location = "gs://bucket/db/table"
+    staged.metadata_location = "gs://bucket/db/table/metadata/00001.metadata.json"
+    staged.io = MagicMock()
+    mocker.patch.object(catalog, "_update_and_stage_table", return_value=staged)
+    mocker.patch.object(catalog, "_write_metadata")
+    mocker.patch.object(catalog, "_create_table_parameters", return_value={"metadata_location": staged.metadata_location})
+    mocker.patch.object(catalog, "_create_external_catalog_table_options", return_value=MagicMock())
+    mocker.patch.object(catalog, "_check_bigquery_commit_status", return_value=BigqueryCommitStatus.FAILURE)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        catalog.commit_table(table, requirements=(), updates=())
+
+    staged.io.delete.assert_called_once_with(staged.metadata_location)

--- a/tests/catalog/test_bigquery_metastore.py
+++ b/tests/catalog/test_bigquery_metastore.py
@@ -227,14 +227,16 @@ def test_commit_table_update_path_uses_update_table(mocker: MockFixture) -> None
 
     staged = MagicMock()
     staged.metadata = MagicMock()
+    staged.metadata.table_uuid = "test-table-uuid"
     staged.metadata.location = "gs://bucket/db/table"
     staged.metadata_location = "gs://bucket/db/table/metadata/00001.metadata.json"
     staged.io = MagicMock()
     mocker.patch.object(catalog, "_update_and_stage_table", return_value=staged)
     mocker.patch.object(catalog, "_write_metadata")
-    mocker.patch.object(catalog, "_create_table_parameters", return_value={"metadata_location": staged.metadata_location})
+    create_table_parameters = mocker.patch.object(
+        catalog, "_create_table_parameters", return_value={"metadata_location": staged.metadata_location}
+    )
     mocker.patch.object(catalog, "_create_external_catalog_table_options", return_value=MagicMock())
-    delete_old_metadata = mocker.patch.object(catalog, "_delete_old_metadata")
     commit_response = MagicMock()
     commit_response.metadata_location = staged.metadata_location
     mocker.patch("pyiceberg.catalog.bigquery_metastore.CommitTableResponse", return_value=commit_response)
@@ -243,7 +245,11 @@ def test_commit_table_update_path_uses_update_table(mocker: MockFixture) -> None
 
     client_mock.update_table.assert_called_once_with(current_bq_table, ["external_catalog_table_options"])
     client_mock.create_table.assert_not_called()
-    delete_old_metadata.assert_called_once_with(staged.io, current_table.metadata, staged.metadata)
+    create_table_parameters.assert_called_once_with(
+        metadata_file_location=staged.metadata_location,
+        table_metadata=staged.metadata,
+        previous_metadata_location=current_table.metadata_location,
+    )
     assert response.metadata_location == staged.metadata_location
 
 


### PR DESCRIPTION
Closes #2893

  # Rationale for this change

  `BigQueryMetastoreCatalog.commit_table` was not implemented.

  This PR implements `commit_table` for the BigQuery metastore catalog with:
  - create/update commit branching based on table existence
  - commit status verification on ambiguous failures
  - success detection when the committed metadata location is found in current metadata history (`metadata_log`)

  ## Are these changes tested?

  Yes.

`uv run pytest -q tests/catalog/test_bigquery_metastore.py -q`

  ## Are there any user-facing changes?
Maybe no.