### PR TITLE
fix: python version in release docs workflow

### DIFF
--- a/.github/workflows/python-release-docs.yml
+++ b/.github/workflows/python-release-docs.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python }}
+          python-version: 3.12
       - name: Install UV
         uses: astral-sh/setup-uv@v7
       - name: Build docs


### PR DESCRIPTION
# Rationale for this change

This pr is a small change to correct the `python-release-docs.yaml` python version to reference a python version. Today it uses an non existing variable of ${{ matrix.python }. 

This will evaluate to an empty sting and just use the runners system python install which happens to work. So this change will hardcode to use 3.12 to match `python-ci-docs.yml`.

Action warning

Link: https://github.com/apache/iceberg-python/actions/runs/22287174360

<img width="687" height="113" alt="image" src="https://github.com/user-attachments/assets/f4e89403-20b1-4451-b220-3cfb7b84e394" />


## Are these changes tested?

No

## Are there any user-facing changes?

No
