### PR TITLE
Added a flag which allows disabling locks with Hive catalog

### DIFF
--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -136,6 +136,9 @@ DEFAULT_LOCK_CHECK_RETRIES = 4
 DO_NOT_UPDATE_STATS = "DO_NOT_UPDATE_STATS"
 DO_NOT_UPDATE_STATS_DEFAULT = "true"
 
+NO_LOCK_EXPECTED_KEY = "expected_parameter_key"
+NO_LOCK_EXPECTED_VALUE = "expected_parameter_value"
+
 logger = logging.getLogger(__name__)
 
 
@@ -499,6 +502,66 @@ class HiveCatalog(MetastoreCatalog):
 
         return _do_wait_for_lock()
 
+    @staticmethod
+    def _hive_lock_enabled(table_properties: Properties, catalog_properties: Properties) -> bool:
+        """Determine whether HMS locking is enabled for a commit.
+
+        Matches the Java implementation in HiveTableOperations: checks the table property first,
+        then falls back to catalog properties, then defaults to True.
+        """
+        if TableProperties.HIVE_LOCK_ENABLED in table_properties:
+            return property_as_bool(
+                table_properties, TableProperties.HIVE_LOCK_ENABLED, TableProperties.HIVE_LOCK_ENABLED_DEFAULT
+            )
+        return property_as_bool(catalog_properties, TableProperties.HIVE_LOCK_ENABLED, TableProperties.HIVE_LOCK_ENABLED_DEFAULT)
+
+    def commit_table(
+        self, table: Table, requirements: tuple[TableRequirement, ...], updates: tuple[TableUpdate, ...]
+    ) -> CommitTableResponse:
+        """Commit updates to a table.
+
+        Args:
+            table (Table): The table to be updated.
+            requirements: (Tuple[TableRequirement, ...]): Table requirements.
+            updates: (Tuple[TableUpdate, ...]): Table updates.
+
+        Returns:
+            CommitTableResponse: The updated metadata.
+
+        Raises:
+            NoSuchTableError: If a table with the given identifier does not exist.
+            CommitFailedException: Requirement not met, or a conflict with a concurrent commit.
+        """
+        table_identifier = table.name()
+        database_name, table_name = self.identifier_to_database_and_table(table_identifier, NoSuchTableError)
+        lock_enabled = self._hive_lock_enabled(table.properties, self.properties)
+        # commit to hive
+        # https://github.com/apache/hive/blob/master/standalone-metastore/metastore-common/src/main/thrift/hive_metastore.thrift#L1232
+        with self._client as open_client:
+            if lock_enabled:
+                lock: LockResponse = open_client.lock(self._create_lock_request(database_name, table_name))
+
+                try:
+                    if lock.state != LockState.ACQUIRED:
+                        if lock.state == LockState.WAITING:
+                            self._wait_for_lock(database_name, table_name, lock.lockid, open_client)
+                        else:
+                            raise CommitFailedException(f"Failed to acquire lock for {table_identifier}, state: {lock.state}")
+
+                    return self._do_commit(
+                        open_client, table_identifier, database_name, table_name, requirements, updates,
+                        lock_enabled=True,
+                    )
+                except WaitingForLockException as e:
+                    raise CommitFailedException(f"Failed to acquire lock for {table_identifier}, state: {lock.state}") from e
+                finally:
+                    open_client.unlock(UnlockRequest(lockid=lock.lockid))
+            else:
+                return self._do_commit(
+                    open_client, table_identifier, database_name, table_name, requirements, updates,
+                    lock_enabled=False,
+                )
+
     def _do_commit(
         self,
         open_client: Client,
@@ -507,10 +570,13 @@ class HiveCatalog(MetastoreCatalog):
         table_name: str,
         requirements: tuple[TableRequirement, ...],
         updates: tuple[TableUpdate, ...],
+        lock_enabled: bool = True,
     ) -> CommitTableResponse:
         """Perform the actual commit logic (get table, update, write metadata, alter/create in HMS).
 
         This method contains the core commit logic, separated from locking concerns.
+        When lock_enabled is False, an optimistic concurrency check via the HMS EnvironmentContext
+        is used instead (requires HIVE-26882 on the server).
         """
         hive_table: HiveTable | None
         current_table: Table | None
@@ -566,11 +632,16 @@ class HiveCatalog(MetastoreCatalog):
                 updated_staged_table.location(),
                 property_as_bool(self.properties, HIVE2_COMPATIBLE, HIVE2_COMPATIBLE_DEFAULT),
             )
+            env_context_properties: dict[str, str] = {DO_NOT_UPDATE_STATS: DO_NOT_UPDATE_STATS_DEFAULT}
+            if not lock_enabled:
+                env_context_properties[NO_LOCK_EXPECTED_KEY] = PROP_METADATA_LOCATION
+                env_context_properties[NO_LOCK_EXPECTED_VALUE] = current_table.metadata_location
+
             open_client.alter_table_with_environment_context(
                 dbname=database_name,
                 tbl_name=table_name,
                 new_tbl=hive_table,
-                environment_context=EnvironmentContext(properties={DO_NOT_UPDATE_STATS: DO_NOT_UPDATE_STATS_DEFAULT}),
+                environment_context=EnvironmentContext(properties=env_context_properties),
             )
         else:
             # Table does not exist, create it.
@@ -588,60 +659,6 @@ class HiveCatalog(MetastoreCatalog):
         return CommitTableResponse(
             metadata=updated_staged_table.metadata, metadata_location=updated_staged_table.metadata_location
         )
-
-    @staticmethod
-    def _hive_lock_enabled(table_properties: Properties, catalog_properties: Properties) -> bool:
-        """Determine whether HMS locking is enabled for a commit.
-
-        Matches the Java implementation in HiveTableOperations: checks the table property first,
-        then falls back to catalog properties, then defaults to True.
-        """
-        if TableProperties.HIVE_LOCK_ENABLED in table_properties:
-            return property_as_bool(
-                table_properties, TableProperties.HIVE_LOCK_ENABLED, TableProperties.HIVE_LOCK_ENABLED_DEFAULT
-            )
-        return property_as_bool(catalog_properties, TableProperties.HIVE_LOCK_ENABLED, TableProperties.HIVE_LOCK_ENABLED_DEFAULT)
-
-    def commit_table(
-        self, table: Table, requirements: tuple[TableRequirement, ...], updates: tuple[TableUpdate, ...]
-    ) -> CommitTableResponse:
-        """Commit updates to a table.
-
-        Args:
-            table (Table): The table to be updated.
-            requirements: (Tuple[TableRequirement, ...]): Table requirements.
-            updates: (Tuple[TableUpdate, ...]): Table updates.
-
-        Returns:
-            CommitTableResponse: The updated metadata.
-
-        Raises:
-            NoSuchTableError: If a table with the given identifier does not exist.
-            CommitFailedException: Requirement not met, or a conflict with a concurrent commit.
-        """
-        table_identifier = table.name()
-        database_name, table_name = self.identifier_to_database_and_table(table_identifier, NoSuchTableError)
-        lock_enabled = self._hive_lock_enabled(table.properties, self.properties)
-        # commit to hive
-        # https://github.com/apache/hive/blob/master/standalone-metastore/metastore-common/src/main/thrift/hive_metastore.thrift#L1232
-        with self._client as open_client:
-            if lock_enabled:
-                lock: LockResponse = open_client.lock(self._create_lock_request(database_name, table_name))
-
-                try:
-                    if lock.state != LockState.ACQUIRED:
-                        if lock.state == LockState.WAITING:
-                            self._wait_for_lock(database_name, table_name, lock.lockid, open_client)
-                        else:
-                            raise CommitFailedException(f"Failed to acquire lock for {table_identifier}, state: {lock.state}")
-
-                    return self._do_commit(open_client, table_identifier, database_name, table_name, requirements, updates)
-                except WaitingForLockException as e:
-                    raise CommitFailedException(f"Failed to acquire lock for {table_identifier}, state: {lock.state}") from e
-                finally:
-                    open_client.unlock(UnlockRequest(lockid=lock.lockid))
-            else:
-                return self._do_commit(open_client, table_identifier, database_name, table_name, requirements, updates)
 
     def load_table(self, identifier: str | Identifier) -> Table:
         """Load the table's metadata and return the table instance.

--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -127,9 +127,6 @@ HIVE_KERBEROS_AUTH_DEFAULT = False
 HIVE_KERBEROS_SERVICE_NAME = "hive.kerberos-service-name"
 HIVE_KERBEROS_SERVICE_NAME_DEFAULT = "hive"
 
-LOCK_ENABLED = "lock-enabled"
-DEFAULT_LOCK_ENABLED = True
-
 LOCK_CHECK_MIN_WAIT_TIME = "lock-check-min-wait-time"
 LOCK_CHECK_MAX_WAIT_TIME = "lock-check-max-wait-time"
 LOCK_CHECK_RETRIES = "lock-check-retries"
@@ -304,7 +301,6 @@ class HiveCatalog(MetastoreCatalog):
         super().__init__(name, **properties)
         self._client = self._create_hive_client(properties)
 
-        self._lock_enabled = property_as_bool(properties, LOCK_ENABLED, DEFAULT_LOCK_ENABLED)
         self._lock_check_min_wait_time = property_as_float(properties, LOCK_CHECK_MIN_WAIT_TIME, DEFAULT_LOCK_CHECK_MIN_WAIT_TIME)
         self._lock_check_max_wait_time = property_as_float(properties, LOCK_CHECK_MAX_WAIT_TIME, DEFAULT_LOCK_CHECK_MAX_WAIT_TIME)
         self._lock_check_retries = property_as_float(
@@ -593,6 +589,19 @@ class HiveCatalog(MetastoreCatalog):
             metadata=updated_staged_table.metadata, metadata_location=updated_staged_table.metadata_location
         )
 
+    @staticmethod
+    def _hive_lock_enabled(table_properties: Properties, catalog_properties: Properties) -> bool:
+        """Determine whether HMS locking is enabled for a commit.
+
+        Matches the Java implementation in HiveTableOperations: checks the table property first,
+        then falls back to catalog properties, then defaults to True.
+        """
+        if TableProperties.HIVE_LOCK_ENABLED in table_properties:
+            return property_as_bool(
+                table_properties, TableProperties.HIVE_LOCK_ENABLED, TableProperties.HIVE_LOCK_ENABLED_DEFAULT
+            )
+        return property_as_bool(catalog_properties, TableProperties.HIVE_LOCK_ENABLED, TableProperties.HIVE_LOCK_ENABLED_DEFAULT)
+
     def commit_table(
         self, table: Table, requirements: tuple[TableRequirement, ...], updates: tuple[TableUpdate, ...]
     ) -> CommitTableResponse:
@@ -612,10 +621,11 @@ class HiveCatalog(MetastoreCatalog):
         """
         table_identifier = table.name()
         database_name, table_name = self.identifier_to_database_and_table(table_identifier, NoSuchTableError)
+        lock_enabled = self._hive_lock_enabled(table.properties, self.properties)
         # commit to hive
         # https://github.com/apache/hive/blob/master/standalone-metastore/metastore-common/src/main/thrift/hive_metastore.thrift#L1232
         with self._client as open_client:
-            if self._lock_enabled:
+            if lock_enabled:
                 lock: LockResponse = open_client.lock(self._create_lock_request(database_name, table_name))
 
                 try:

--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -133,11 +133,15 @@ LOCK_CHECK_RETRIES = "lock-check-retries"
 DEFAULT_LOCK_CHECK_MIN_WAIT_TIME = 0.1  # 100 milliseconds
 DEFAULT_LOCK_CHECK_MAX_WAIT_TIME = 60  # 1 min
 DEFAULT_LOCK_CHECK_RETRIES = 4
+
 DO_NOT_UPDATE_STATS = "DO_NOT_UPDATE_STATS"
 DO_NOT_UPDATE_STATS_DEFAULT = "true"
 
 NO_LOCK_EXPECTED_KEY = "expected_parameter_key"
 NO_LOCK_EXPECTED_VALUE = "expected_parameter_value"
+
+HIVE_LOCK_ENABLED = "engine.hive.lock-enabled"
+HIVE_LOCK_ENABLED_DEFAULT = True
 
 logger = logging.getLogger(__name__)
 
@@ -509,11 +513,9 @@ class HiveCatalog(MetastoreCatalog):
         Matches the Java implementation in HiveTableOperations: checks the table property first,
         then falls back to catalog properties, then defaults to True.
         """
-        if TableProperties.HIVE_LOCK_ENABLED in table_properties:
-            return property_as_bool(
-                table_properties, TableProperties.HIVE_LOCK_ENABLED, TableProperties.HIVE_LOCK_ENABLED_DEFAULT
-            )
-        return property_as_bool(catalog_properties, TableProperties.HIVE_LOCK_ENABLED, TableProperties.HIVE_LOCK_ENABLED_DEFAULT)
+        if HIVE_LOCK_ENABLED in table_properties:
+            return property_as_bool(table_properties, HIVE_LOCK_ENABLED, HIVE_LOCK_ENABLED_DEFAULT)
+        return property_as_bool(catalog_properties, HIVE_LOCK_ENABLED, HIVE_LOCK_ENABLED_DEFAULT)
 
     def commit_table(
         self, table: Table, requirements: tuple[TableRequirement, ...], updates: tuple[TableUpdate, ...]

--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -504,8 +504,13 @@ class HiveCatalog(MetastoreCatalog):
         return _do_wait_for_lock()
 
     def _do_commit(
-        self, open_client: Client, table_identifier: Identifier, database_name: str, table_name: str,
-        requirements: tuple[TableRequirement, ...], updates: tuple[TableUpdate, ...],
+        self,
+        open_client: Client,
+        table_identifier: Identifier,
+        database_name: str,
+        table_name: str,
+        requirements: tuple[TableRequirement, ...],
+        updates: tuple[TableUpdate, ...],
     ) -> CommitTableResponse:
         """Perform the actual commit logic (get table, update, write metadata, alter/create in HMS).
 

--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -551,7 +551,12 @@ class HiveCatalog(MetastoreCatalog):
                             raise CommitFailedException(f"Failed to acquire lock for {table_identifier}, state: {lock.state}")
 
                     return self._do_commit(
-                        open_client, table_identifier, database_name, table_name, requirements, updates,
+                        open_client,
+                        table_identifier,
+                        database_name,
+                        table_name,
+                        requirements,
+                        updates,
                         lock_enabled=True,
                     )
                 except WaitingForLockException as e:
@@ -560,7 +565,12 @@ class HiveCatalog(MetastoreCatalog):
                     open_client.unlock(UnlockRequest(lockid=lock.lockid))
             else:
                 return self._do_commit(
-                    open_client, table_identifier, database_name, table_name, requirements, updates,
+                    open_client,
+                    table_identifier,
+                    database_name,
+                    table_name,
+                    requirements,
+                    updates,
                     lock_enabled=False,
                 )
 

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -2002,11 +2002,13 @@ class DataScan(TableScan):
         # The lambda created here is run in multiple threads.
         # So we avoid creating _EvaluatorExpression methods bound to a single
         # shared instance across multiple threads.
-        return lambda datafile: residual_evaluator_of(
-            spec=spec,
-            expr=self.row_filter,
-            case_sensitive=self.case_sensitive,
-            schema=self.table_metadata.schema(),
+        return lambda datafile: (
+            residual_evaluator_of(
+                spec=spec,
+                expr=self.row_filter,
+                case_sensitive=self.case_sensitive,
+                schema=self.table_metadata.schema(),
+            )
         )
 
     @staticmethod

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -247,6 +247,9 @@ class TableProperties:
     MIN_SNAPSHOTS_TO_KEEP = "history.expire.min-snapshots-to-keep"
     MIN_SNAPSHOTS_TO_KEEP_DEFAULT = 1
 
+    HIVE_LOCK_ENABLED = "engine.hive.lock-enabled"
+    HIVE_LOCK_ENABLED_DEFAULT = True
+
 
 class Transaction:
     _table: Table
@@ -2002,13 +2005,11 @@ class DataScan(TableScan):
         # The lambda created here is run in multiple threads.
         # So we avoid creating _EvaluatorExpression methods bound to a single
         # shared instance across multiple threads.
-        return lambda datafile: (
-            residual_evaluator_of(
-                spec=spec,
-                expr=self.row_filter,
-                case_sensitive=self.case_sensitive,
-                schema=self.table_metadata.schema(),
-            )
+        return lambda datafile: residual_evaluator_of(
+            spec=spec,
+            expr=self.row_filter,
+            case_sensitive=self.case_sensitive,
+            schema=self.table_metadata.schema(),
         )
 
     @staticmethod

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -2005,11 +2005,13 @@ class DataScan(TableScan):
         # The lambda created here is run in multiple threads.
         # So we avoid creating _EvaluatorExpression methods bound to a single
         # shared instance across multiple threads.
-        return lambda datafile: residual_evaluator_of(
-            spec=spec,
-            expr=self.row_filter,
-            case_sensitive=self.case_sensitive,
-            schema=self.table_metadata.schema(),
+        return lambda datafile: (
+            residual_evaluator_of(
+                spec=spec,
+                expr=self.row_filter,
+                case_sensitive=self.case_sensitive,
+                schema=self.table_metadata.schema(),
+            )
         )
 
     @staticmethod

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -247,9 +247,6 @@ class TableProperties:
     MIN_SNAPSHOTS_TO_KEEP = "history.expire.min-snapshots-to-keep"
     MIN_SNAPSHOTS_TO_KEEP_DEFAULT = 1
 
-    HIVE_LOCK_ENABLED = "engine.hive.lock-enabled"
-    HIVE_LOCK_ENABLED_DEFAULT = True
-
 
 class Transaction:
     _table: Table
@@ -2005,13 +2002,11 @@ class DataScan(TableScan):
         # The lambda created here is run in multiple threads.
         # So we avoid creating _EvaluatorExpression methods bound to a single
         # shared instance across multiple threads.
-        return lambda datafile: (
-            residual_evaluator_of(
-                spec=spec,
-                expr=self.row_filter,
-                case_sensitive=self.case_sensitive,
-                schema=self.table_metadata.schema(),
-            )
+        return lambda datafile: residual_evaluator_of(
+            spec=spec,
+            expr=self.row_filter,
+            case_sensitive=self.case_sensitive,
+            schema=self.table_metadata.schema(),
         )
 
     @staticmethod

--- a/tests/catalog/test_hive.py
+++ b/tests/catalog/test_hive.py
@@ -51,6 +51,9 @@ from pyiceberg.catalog.hive import (
     LOCK_CHECK_MAX_WAIT_TIME,
     LOCK_CHECK_MIN_WAIT_TIME,
     LOCK_CHECK_RETRIES,
+    NO_LOCK_EXPECTED_KEY,
+    NO_LOCK_EXPECTED_VALUE,
+    PROP_METADATA_LOCATION,
     HiveCatalog,
     _construct_hive_storage_descriptor,
     _HiveClient,
@@ -1455,6 +1458,8 @@ def test_commit_table_skips_locking_when_table_property_disables_it() -> None:
         catalog.commit_table(mock_table, requirements=(), updates=())
 
     mock_do_commit.assert_called_once()
+    _, kwargs = mock_do_commit.call_args
+    assert kwargs["lock_enabled"] is False
     catalog._client.__enter__().lock.assert_not_called()
     catalog._client.__enter__().check_lock.assert_not_called()
     catalog._client.__enter__().unlock.assert_not_called()
@@ -1507,3 +1512,94 @@ def test_commit_table_uses_locking_by_default() -> None:
     mock_client.lock.assert_called_once()
     mock_client.unlock.assert_called_once()
     mock_do_commit.assert_called_once()
+    _, kwargs = mock_do_commit.call_args
+    assert kwargs["lock_enabled"] is True
+
+
+def test_do_commit_env_context_includes_expected_params_when_lock_disabled() -> None:
+    """When lock_enabled=False, alter_table_with_environment_context must include
+    expected_parameter_key and expected_parameter_value for optimistic concurrency."""
+    prop = {"uri": HIVE_METASTORE_FAKE_URL}
+    catalog = HiveCatalog(HIVE_CATALOG_NAME, **prop)
+
+    current_metadata_location = "s3://bucket/db/table/metadata/v1.metadata.json"
+
+    mock_client = MagicMock()
+    mock_hive_table = MagicMock()
+    mock_hive_table.parameters = {
+        "table_type": "ICEBERG",
+        "metadata_location": current_metadata_location,
+    }
+    mock_client.get_table.return_value = mock_hive_table
+
+    with (
+        patch.object(catalog, "_convert_hive_into_iceberg") as mock_convert,
+        patch.object(catalog, "_update_and_stage_table") as mock_stage,
+        patch.object(catalog, "_write_metadata"),
+        patch.object(catalog, "_convert_iceberg_into_hive"),
+        patch("pyiceberg.catalog.hive.CommitTableResponse"),
+    ):
+        mock_current_table = MagicMock()
+        mock_current_table.metadata_location = current_metadata_location
+        mock_current_table.metadata = MagicMock()
+        mock_current_table.properties = {}
+        mock_convert.return_value = mock_current_table
+
+        mock_staged = MagicMock()
+        mock_staged.metadata = MagicMock()
+        mock_staged.properties = {}
+        mock_stage.return_value = mock_staged
+
+        catalog._do_commit(
+            mock_client, ("default", "my_table"), "default", "my_table",
+            requirements=(), updates=(), lock_enabled=False,
+        )
+
+    mock_client.alter_table_with_environment_context.assert_called_once()
+    env_ctx = mock_client.alter_table_with_environment_context.call_args[1]["environment_context"]
+    assert env_ctx.properties[NO_LOCK_EXPECTED_KEY] == PROP_METADATA_LOCATION
+    assert env_ctx.properties[NO_LOCK_EXPECTED_VALUE] == current_metadata_location
+    assert env_ctx.properties[DO_NOT_UPDATE_STATS] == DO_NOT_UPDATE_STATS_DEFAULT
+
+
+def test_do_commit_env_context_excludes_expected_params_when_lock_enabled() -> None:
+    """When lock_enabled=True (default), alter_table_with_environment_context must NOT include
+    expected_parameter_key or expected_parameter_value."""
+    prop = {"uri": HIVE_METASTORE_FAKE_URL}
+    catalog = HiveCatalog(HIVE_CATALOG_NAME, **prop)
+
+    mock_client = MagicMock()
+    mock_hive_table = MagicMock()
+    mock_hive_table.parameters = {
+        "table_type": "ICEBERG",
+        "metadata_location": "s3://bucket/db/table/metadata/v1.metadata.json",
+    }
+    mock_client.get_table.return_value = mock_hive_table
+
+    with (
+        patch.object(catalog, "_convert_hive_into_iceberg") as mock_convert,
+        patch.object(catalog, "_update_and_stage_table") as mock_stage,
+        patch.object(catalog, "_write_metadata"),
+        patch.object(catalog, "_convert_iceberg_into_hive"),
+        patch("pyiceberg.catalog.hive.CommitTableResponse"),
+    ):
+        mock_current_table = MagicMock()
+        mock_current_table.metadata = MagicMock()
+        mock_current_table.properties = {}
+        mock_convert.return_value = mock_current_table
+
+        mock_staged = MagicMock()
+        mock_staged.metadata = MagicMock()
+        mock_staged.properties = {}
+        mock_stage.return_value = mock_staged
+
+        catalog._do_commit(
+            mock_client, ("default", "my_table"), "default", "my_table",
+            requirements=(), updates=(), lock_enabled=True,
+        )
+
+    mock_client.alter_table_with_environment_context.assert_called_once()
+    env_ctx = mock_client.alter_table_with_environment_context.call_args[1]["environment_context"]
+    assert NO_LOCK_EXPECTED_KEY not in env_ctx.properties
+    assert NO_LOCK_EXPECTED_VALUE not in env_ctx.properties
+    assert env_ctx.properties[DO_NOT_UPDATE_STATS] == DO_NOT_UPDATE_STATS_DEFAULT

--- a/tests/catalog/test_hive.py
+++ b/tests/catalog/test_hive.py
@@ -48,6 +48,7 @@ from pyiceberg.catalog.hive import (
     DO_NOT_UPDATE_STATS_DEFAULT,
     HIVE_KERBEROS_AUTH,
     HIVE_KERBEROS_SERVICE_NAME,
+    HIVE_LOCK_ENABLED,
     LOCK_CHECK_MAX_WAIT_TIME,
     LOCK_CHECK_MIN_WAIT_TIME,
     LOCK_CHECK_RETRIES,
@@ -68,7 +69,6 @@ from pyiceberg.exceptions import (
 )
 from pyiceberg.partitioning import PartitionField, PartitionSpec
 from pyiceberg.schema import Schema
-from pyiceberg.table import TableProperties
 from pyiceberg.table.metadata import TableMetadataUtil, TableMetadataV1, TableMetadataV2
 from pyiceberg.table.refs import SnapshotRef, SnapshotRefType
 from pyiceberg.table.snapshots import (
@@ -1420,24 +1420,24 @@ def test_hive_lock_enabled_defaults_to_true() -> None:
 
 def test_hive_lock_enabled_table_property_disables_lock() -> None:
     """Table property engine.hive.lock-enabled=false disables locking."""
-    table_props = {TableProperties.HIVE_LOCK_ENABLED: "false"}
+    table_props = {HIVE_LOCK_ENABLED: "false"}
     assert HiveCatalog._hive_lock_enabled(table_properties=table_props, catalog_properties={}) is False
 
 
 def test_hive_lock_enabled_catalog_property_disables_lock() -> None:
     """Catalog property engine.hive.lock-enabled=false disables locking when table doesn't set it."""
-    catalog_props = {TableProperties.HIVE_LOCK_ENABLED: "false"}
+    catalog_props = {HIVE_LOCK_ENABLED: "false"}
     assert HiveCatalog._hive_lock_enabled(table_properties={}, catalog_properties=catalog_props) is False
 
 
 def test_hive_lock_enabled_table_property_overrides_catalog() -> None:
     """Table property takes precedence over catalog property."""
-    table_props = {TableProperties.HIVE_LOCK_ENABLED: "true"}
-    catalog_props = {TableProperties.HIVE_LOCK_ENABLED: "false"}
+    table_props = {HIVE_LOCK_ENABLED: "true"}
+    catalog_props = {HIVE_LOCK_ENABLED: "false"}
     assert HiveCatalog._hive_lock_enabled(table_properties=table_props, catalog_properties=catalog_props) is True
 
-    table_props = {TableProperties.HIVE_LOCK_ENABLED: "false"}
-    catalog_props = {TableProperties.HIVE_LOCK_ENABLED: "true"}
+    table_props = {HIVE_LOCK_ENABLED: "false"}
+    catalog_props = {HIVE_LOCK_ENABLED: "true"}
     assert HiveCatalog._hive_lock_enabled(table_properties=table_props, catalog_properties=catalog_props) is False
 
 
@@ -1449,7 +1449,7 @@ def test_commit_table_skips_locking_when_table_property_disables_it() -> None:
 
     mock_table = MagicMock()
     mock_table.name.return_value = ("default", "my_table")
-    mock_table.properties = {TableProperties.HIVE_LOCK_ENABLED: "false"}
+    mock_table.properties = {HIVE_LOCK_ENABLED: "false"}
 
     mock_do_commit = MagicMock()
     mock_do_commit.return_value = MagicMock()
@@ -1467,7 +1467,7 @@ def test_commit_table_skips_locking_when_table_property_disables_it() -> None:
 
 def test_commit_table_skips_locking_when_catalog_property_disables_it() -> None:
     """When catalog property engine.hive.lock-enabled=false, commit_table must not lock/unlock."""
-    prop = {"uri": HIVE_METASTORE_FAKE_URL, TableProperties.HIVE_LOCK_ENABLED: "false"}
+    prop = {"uri": HIVE_METASTORE_FAKE_URL, HIVE_LOCK_ENABLED: "false"}
     catalog = HiveCatalog(HIVE_CATALOG_NAME, **prop)
     catalog._client = MagicMock()
 
@@ -1551,8 +1551,13 @@ def test_do_commit_env_context_includes_expected_params_when_lock_disabled() -> 
         mock_stage.return_value = mock_staged
 
         catalog._do_commit(
-            mock_client, ("default", "my_table"), "default", "my_table",
-            requirements=(), updates=(), lock_enabled=False,
+            mock_client,
+            ("default", "my_table"),
+            "default",
+            "my_table",
+            requirements=(),
+            updates=(),
+            lock_enabled=False,
         )
 
     mock_client.alter_table_with_environment_context.assert_called_once()
@@ -1594,8 +1599,13 @@ def test_do_commit_env_context_excludes_expected_params_when_lock_enabled() -> N
         mock_stage.return_value = mock_staged
 
         catalog._do_commit(
-            mock_client, ("default", "my_table"), "default", "my_table",
-            requirements=(), updates=(), lock_enabled=True,
+            mock_client,
+            ("default", "my_table"),
+            "default",
+            "my_table",
+            requirements=(),
+            updates=(),
+            lock_enabled=True,
         )
 
     mock_client.alter_table_with_environment_context.assert_called_once()

--- a/tests/catalog/test_hive.py
+++ b/tests/catalog/test_hive.py
@@ -51,7 +51,6 @@ from pyiceberg.catalog.hive import (
     LOCK_CHECK_MAX_WAIT_TIME,
     LOCK_CHECK_MIN_WAIT_TIME,
     LOCK_CHECK_RETRIES,
-    LOCK_ENABLED,
     HiveCatalog,
     _construct_hive_storage_descriptor,
     _HiveClient,
@@ -66,6 +65,7 @@ from pyiceberg.exceptions import (
 )
 from pyiceberg.partitioning import PartitionField, PartitionSpec
 from pyiceberg.schema import Schema
+from pyiceberg.table import TableProperties
 from pyiceberg.table.metadata import TableMetadataUtil, TableMetadataV1, TableMetadataV2
 from pyiceberg.table.refs import SnapshotRef, SnapshotRefType
 from pyiceberg.table.snapshots import (
@@ -1410,28 +1410,43 @@ def test_create_hive_client_with_kerberos_using_context_manager(
             assert open_client._iprot.trans.isOpen()
 
 
-def test_lock_enabled_defaults_to_true() -> None:
-    """Verify that lock-enabled defaults to True for backward compatibility."""
+def test_hive_lock_enabled_defaults_to_true() -> None:
+    """Without any lock property set, locking should be enabled (backward compatible)."""
+    assert HiveCatalog._hive_lock_enabled(table_properties={}, catalog_properties={}) is True
+
+
+def test_hive_lock_enabled_table_property_disables_lock() -> None:
+    """Table property engine.hive.lock-enabled=false disables locking."""
+    table_props = {TableProperties.HIVE_LOCK_ENABLED: "false"}
+    assert HiveCatalog._hive_lock_enabled(table_properties=table_props, catalog_properties={}) is False
+
+
+def test_hive_lock_enabled_catalog_property_disables_lock() -> None:
+    """Catalog property engine.hive.lock-enabled=false disables locking when table doesn't set it."""
+    catalog_props = {TableProperties.HIVE_LOCK_ENABLED: "false"}
+    assert HiveCatalog._hive_lock_enabled(table_properties={}, catalog_properties=catalog_props) is False
+
+
+def test_hive_lock_enabled_table_property_overrides_catalog() -> None:
+    """Table property takes precedence over catalog property."""
+    table_props = {TableProperties.HIVE_LOCK_ENABLED: "true"}
+    catalog_props = {TableProperties.HIVE_LOCK_ENABLED: "false"}
+    assert HiveCatalog._hive_lock_enabled(table_properties=table_props, catalog_properties=catalog_props) is True
+
+    table_props = {TableProperties.HIVE_LOCK_ENABLED: "false"}
+    catalog_props = {TableProperties.HIVE_LOCK_ENABLED: "true"}
+    assert HiveCatalog._hive_lock_enabled(table_properties=table_props, catalog_properties=catalog_props) is False
+
+
+def test_commit_table_skips_locking_when_table_property_disables_it() -> None:
+    """When table property engine.hive.lock-enabled=false, commit_table must not lock/unlock."""
     prop = {"uri": HIVE_METASTORE_FAKE_URL}
-    catalog = HiveCatalog(HIVE_CATALOG_NAME, **prop)
-    assert catalog._lock_enabled is True
-
-
-def test_lock_enabled_can_be_disabled() -> None:
-    """Verify that lock-enabled can be set to false."""
-    prop = {"uri": HIVE_METASTORE_FAKE_URL, LOCK_ENABLED: "false"}
-    catalog = HiveCatalog(HIVE_CATALOG_NAME, **prop)
-    assert catalog._lock_enabled is False
-
-
-def test_commit_table_skips_locking_when_lock_disabled() -> None:
-    """When lock-enabled is false, commit_table must not call lock, check_lock, or unlock."""
-    prop = {"uri": HIVE_METASTORE_FAKE_URL, LOCK_ENABLED: "false"}
     catalog = HiveCatalog(HIVE_CATALOG_NAME, **prop)
     catalog._client = MagicMock()
 
     mock_table = MagicMock()
     mock_table.name.return_value = ("default", "my_table")
+    mock_table.properties = {TableProperties.HIVE_LOCK_ENABLED: "false"}
 
     mock_do_commit = MagicMock()
     mock_do_commit.return_value = MagicMock()
@@ -1439,17 +1454,36 @@ def test_commit_table_skips_locking_when_lock_disabled() -> None:
     with patch.object(catalog, "_do_commit", mock_do_commit):
         catalog.commit_table(mock_table, requirements=(), updates=())
 
-    # The core commit logic should still be called
     mock_do_commit.assert_called_once()
-
-    # But no locking operations should have been performed
     catalog._client.__enter__().lock.assert_not_called()
     catalog._client.__enter__().check_lock.assert_not_called()
     catalog._client.__enter__().unlock.assert_not_called()
 
 
-def test_commit_table_uses_locking_when_lock_enabled() -> None:
-    """When lock-enabled is true (default), commit_table must call lock and unlock."""
+def test_commit_table_skips_locking_when_catalog_property_disables_it() -> None:
+    """When catalog property engine.hive.lock-enabled=false, commit_table must not lock/unlock."""
+    prop = {"uri": HIVE_METASTORE_FAKE_URL, TableProperties.HIVE_LOCK_ENABLED: "false"}
+    catalog = HiveCatalog(HIVE_CATALOG_NAME, **prop)
+    catalog._client = MagicMock()
+
+    mock_table = MagicMock()
+    mock_table.name.return_value = ("default", "my_table")
+    mock_table.properties = {}
+
+    mock_do_commit = MagicMock()
+    mock_do_commit.return_value = MagicMock()
+
+    with patch.object(catalog, "_do_commit", mock_do_commit):
+        catalog.commit_table(mock_table, requirements=(), updates=())
+
+    mock_do_commit.assert_called_once()
+    catalog._client.__enter__().lock.assert_not_called()
+    catalog._client.__enter__().check_lock.assert_not_called()
+    catalog._client.__enter__().unlock.assert_not_called()
+
+
+def test_commit_table_uses_locking_by_default() -> None:
+    """When no lock property is set, commit_table must acquire and release a lock."""
     lockid = 99999
     prop = {"uri": HIVE_METASTORE_FAKE_URL}
     catalog = HiveCatalog(HIVE_CATALOG_NAME, **prop)
@@ -1462,6 +1496,7 @@ def test_commit_table_uses_locking_when_lock_enabled() -> None:
 
     mock_table = MagicMock()
     mock_table.name.return_value = ("default", "my_table")
+    mock_table.properties = {}
 
     mock_do_commit = MagicMock()
     mock_do_commit.return_value = MagicMock()
@@ -1469,8 +1504,6 @@ def test_commit_table_uses_locking_when_lock_enabled() -> None:
     with patch.object(catalog, "_do_commit", mock_do_commit):
         catalog.commit_table(mock_table, requirements=(), updates=())
 
-    # Locking operations should have been performed
     mock_client.lock.assert_called_once()
     mock_client.unlock.assert_called_once()
-    # The core commit logic should still be called
     mock_do_commit.assert_called_once()


### PR DESCRIPTION
This PR introduces a new flag LOCK_ENABLED in hive catalog. It is set to true by default to allow for backwards compatibility. If set to false no locks are being created when writing/committing a table.

# Rationale for this change

In our production environment we are relying on our own external locking mechanism, so locks are not needed here and furthermore they are causing deadlocks. The current implementation creates a lock, writes data and then removes the lock. When the application dies during data write in a hard way (without a chance to run the finally clause of try catch) then the lock is never removed. There is no mechanism in the lib of removing stale old locks and checking their age. So the effect of that is that when one of the job dies in the wrong moment, all other jobs are stuck forever. Currently in our prod environment every few weeks we have to remove the contents of `HIVE_LOCKS` table to unblock jobs. 

To prevent this from happening we introduced a flag which allows skipping creation of locks.

## Are these changes tested?

Yes, we are running a fork with these changes on our production cluster

## Are there any user-facing changes?

No
