### PR TITLE
Update slate config for PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Close Stale Issues"
+name: "Close Stale Issues and PRs"
 on:
   schedule:
     - cron: '0 0 * * *'
@@ -25,6 +25,7 @@ on:
 permissions:
   # All other permissions are set to none
   issues: write
+  pull-requests: write
 
 jobs:
   stale:
@@ -33,12 +34,11 @@ jobs:
     steps:
       - uses: actions/stale@v10.2.0
         with:
-          stale-issue-label: 'stale'
+          # stale issues
+          stale-issue-label: 'stale,security'
           exempt-issue-labels: 'not-stale'
           days-before-issue-stale: 180
           days-before-issue-close: 14
-          # Only close stale issues, leave PRs alone
-          days-before-pr-stale: -1
           stale-issue-message: >
             This issue has been automatically marked as stale because it has been open for 180 days
             with no activity. It will be closed in next 14 days if no further activity occurs. To
@@ -47,3 +47,12 @@ jobs:
           close-issue-message: >
             This issue has been closed because it has not received any activity in the last 14 days
             since being marked as 'stale'
+          # stale PRs
+          stale-pr-label: 'stale'
+          exempt-pr-labels: 'not-stale,security'
+          stale-pr-message: 'This pull request has been marked as stale due to 30 days of inactivity. It will be closed in 1 week if no further activity occurs. If you think that''s incorrect or this pull request requires a review, please simply write any comment. If closed, you can revive the PR at any time and @mention a reviewer or discuss it on the dev@iceberg.apache.org list. Thank you for your contributions.'
+          close-pr-message: 'This pull request has been closed due to lack of activity. This is not a judgement on the merit of the PR in any way. It is just a way of keeping the PR queue manageable. If you think that is incorrect, or the pull request requires review, you can revive the PR at any time.'
+          days-before-pr-stale: 30
+          days-before-pr-close: 7
+          ascending: true
+          operations-per-run: 200


### PR DESCRIPTION
Bring Iceberg Java's stale.yml workflow over to handle stale PRs in addition to the existing stale issues behavior.
Borrowed from the Iceberg rust implementation: https://github.com/apache/iceberg-rust/pull/2171

# Rationale for this change
The iceberg-python PR list is grown over the years and needs clean up

## Are these changes tested?
Existing CI enhancement 

## Are there any user-facing changes?
No