### PR TITLE
feat: Add metadata-only replace API to Table for REPLACE snapshot operations

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -450,6 +450,32 @@ class Transaction:
         """
         return UpdateStatistics(transaction=self)
 
+    def replace(
+        self,
+        files_to_delete: Iterable[DataFile],
+        files_to_add: Iterable[DataFile],
+        snapshot_properties: dict[str, str] = EMPTY_DICT,
+        branch: str | None = MAIN_BRANCH,
+    ) -> None:
+        """
+        Shorthand for replacing existing files with new files.
+
+        A replace will produce a REPLACE snapshot that will ignore existing
+        files and replace them with the new files.
+
+        Args:
+            files_to_delete: The files to delete
+            files_to_add: The new files to add that replace the deleted files
+            snapshot_properties: Custom properties to be added to the snapshot summary
+            branch: Branch Reference to run the replace operation
+        """
+        with self.update_snapshot(snapshot_properties=snapshot_properties, branch=branch).replace() as replace_snapshot:
+            for file_to_delete in files_to_delete:
+                replace_snapshot.delete_data_file(file_to_delete)
+
+            for data_file in files_to_add:
+                replace_snapshot.append_data_file(data_file)
+
     def append(self, df: pa.Table, snapshot_properties: dict[str, str] = EMPTY_DICT, branch: str | None = MAIN_BRANCH) -> None:
         """
         Shorthand API for appending a PyArrow table to a table transaction.
@@ -1384,6 +1410,33 @@ class Table:
         """
         with self.transaction() as tx:
             tx.append(df=df, snapshot_properties=snapshot_properties, branch=branch)
+
+    def replace(
+        self,
+        files_to_delete: Iterable[DataFile],
+        files_to_add: Iterable[DataFile],
+        snapshot_properties: dict[str, str] = EMPTY_DICT,
+        branch: str | None = MAIN_BRANCH,
+    ) -> None:
+        """
+        Shorthand for replacing existing files with new files.
+
+        A replace will produce a REPLACE snapshot that will ignore existing
+        files and replace them with the new files.
+
+        Args:
+            files_to_delete: The files to delete
+            files_to_add: The new files to add that replace the deleted files
+            snapshot_properties: Custom properties to be added to the snapshot summary
+            branch: Branch Reference to run the replace operation
+        """
+        with self.transaction() as tx:
+            tx.replace(
+                files_to_delete=files_to_delete,
+                files_to_add=files_to_add,
+                snapshot_properties=snapshot_properties,
+                branch=branch,
+            )
 
     def dynamic_partition_overwrite(
         self, df: pa.Table, snapshot_properties: dict[str, str] = EMPTY_DICT, branch: str | None = MAIN_BRANCH

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -450,32 +450,6 @@ class Transaction:
         """
         return UpdateStatistics(transaction=self)
 
-    def replace(
-        self,
-        files_to_delete: Iterable[DataFile],
-        files_to_add: Iterable[DataFile],
-        snapshot_properties: dict[str, str] = EMPTY_DICT,
-        branch: str | None = MAIN_BRANCH,
-    ) -> None:
-        """
-        Shorthand for replacing existing files with new files.
-
-        A replace will produce a REPLACE snapshot that will ignore existing
-        files and replace them with the new files.
-
-        Args:
-            files_to_delete: The files to delete
-            files_to_add: The new files to add that replace the deleted files
-            snapshot_properties: Custom properties to be added to the snapshot summary
-            branch: Branch Reference to run the replace operation
-        """
-        with self.update_snapshot(snapshot_properties=snapshot_properties, branch=branch).replace() as replace_snapshot:
-            for file_to_delete in files_to_delete:
-                replace_snapshot.delete_data_file(file_to_delete)
-
-            for data_file in files_to_add:
-                replace_snapshot.append_data_file(data_file)
-
     def append(self, df: pa.Table, snapshot_properties: dict[str, str] = EMPTY_DICT, branch: str | None = MAIN_BRANCH) -> None:
         """
         Shorthand API for appending a PyArrow table to a table transaction.
@@ -1410,33 +1384,6 @@ class Table:
         """
         with self.transaction() as tx:
             tx.append(df=df, snapshot_properties=snapshot_properties, branch=branch)
-
-    def replace(
-        self,
-        files_to_delete: Iterable[DataFile],
-        files_to_add: Iterable[DataFile],
-        snapshot_properties: dict[str, str] = EMPTY_DICT,
-        branch: str | None = MAIN_BRANCH,
-    ) -> None:
-        """
-        Shorthand for replacing existing files with new files.
-
-        A replace will produce a REPLACE snapshot that will ignore existing
-        files and replace them with the new files.
-
-        Args:
-            files_to_delete: The files to delete
-            files_to_add: The new files to add that replace the deleted files
-            snapshot_properties: Custom properties to be added to the snapshot summary
-            branch: Branch Reference to run the replace operation
-        """
-        with self.transaction() as tx:
-            tx.replace(
-                files_to_delete=files_to_delete,
-                files_to_add=files_to_add,
-                snapshot_properties=snapshot_properties,
-                branch=branch,
-            )
 
     def dynamic_partition_overwrite(
         self, df: pa.Table, snapshot_properties: dict[str, str] = EMPTY_DICT, branch: str | None = MAIN_BRANCH

--- a/pyiceberg/table/snapshots.py
+++ b/pyiceberg/table/snapshots.py
@@ -344,7 +344,7 @@ class SnapshotSummaryCollector:
 
 
 def update_snapshot_summaries(summary: Summary, previous_summary: Mapping[str, str] | None = None) -> Summary:
-    if summary.operation not in {Operation.APPEND, Operation.OVERWRITE, Operation.DELETE}:
+    if summary.operation not in {Operation.APPEND, Operation.OVERWRITE, Operation.DELETE, Operation.REPLACE}:
         raise ValueError(f"Operation not implemented: {summary.operation}")
 
     if not previous_summary:

--- a/pyiceberg/table/snapshots.py
+++ b/pyiceberg/table/snapshots.py
@@ -351,7 +351,7 @@ class SnapshotSummaryCollector:
 
 
 def update_snapshot_summaries(summary: Summary, previous_summary: Mapping[str, str] | None = None) -> Summary:
-    if summary.operation not in {Operation.APPEND, Operation.OVERWRITE, Operation.DELETE}:
+    if summary.operation not in {Operation.APPEND, Operation.OVERWRITE, Operation.DELETE, Operation.REPLACE}:
         raise ValueError(f"Operation not implemented: {summary.operation}")
 
     if not previous_summary:

--- a/pyiceberg/table/update/snapshot.py
+++ b/pyiceberg/table/update/snapshot.py
@@ -166,7 +166,7 @@ class _SnapshotProducer(UpdateTableMetadata[U], Generic[U]):
         return added_rows
 
     def _get_existing_manifests(self) -> list[ManifestFile]:
-        """Filters existing manifests and rewrites those containing deleted data files."""
+        """Filter existing manifests and rewrite those containing deleted data files."""
         existing_files = []
         # Use manifest pruning if a predicate is set (primarily for Overwrite)
         manifest_evaluators: dict[int, Callable[[ManifestFile], bool]] = KeyDefaultDict(self._build_manifest_evaluator)

--- a/pyiceberg/table/update/snapshot.py
+++ b/pyiceberg/table/update/snapshot.py
@@ -681,6 +681,20 @@ class _RewriteFiles(_SnapshotProducer["_RewriteFiles"]):
     def _commit(self) -> UpdatesAndRequirements:
         # Only produce a commit when there is something to rewrite
         if self._deleted_data_files or self._added_data_files:
+            # Grab the entries that we actually found in the table's manifests
+            deleted_entries = self._deleted_entries()
+            found_deleted_files = {entry.data_file for entry in deleted_entries}
+
+            # If the user asked to delete files that aren't in the table, abort.
+            if len(found_deleted_files) != len(self._deleted_data_files):
+                raise ValueError("Cannot delete files that are not present in the table")
+
+            added_records = sum(f.record_count for f in self._added_data_files)
+            deleted_records = sum(entry.data_file.record_count for entry in deleted_entries)
+
+            if added_records > deleted_records:
+                raise ValueError(f"Invalid replace: records added ({added_records}) exceeds records removed ({deleted_records})")
+
             return super()._commit()
         else:
             return (), ()

--- a/pyiceberg/table/update/snapshot.py
+++ b/pyiceberg/table/update/snapshot.py
@@ -677,9 +677,6 @@ class _OverwriteFiles(_SnapshotProducer["_OverwriteFiles"]):
 class _RewriteFiles(_SnapshotProducer["_RewriteFiles"]):
     """A snapshot producer that rewrites data files."""
 
-    def __init__(self, operation: Operation, transaction: Transaction, io: FileIO, snapshot_properties: dict[str, str]):
-        super().__init__(operation, transaction, io, snapshot_properties=snapshot_properties)
-
     def _commit(self) -> UpdatesAndRequirements:
         # Only produce a commit when there is something to rewrite
         if self._deleted_data_files or self._added_data_files:
@@ -800,6 +797,7 @@ class UpdateSnapshot:
             operation=Operation.REPLACE,
             transaction=self._transaction,
             io=self._io,
+            branch=self._branch,
             snapshot_properties=self._snapshot_properties,
         )
 

--- a/pyiceberg/table/update/snapshot.py
+++ b/pyiceberg/table/update/snapshot.py
@@ -167,7 +167,7 @@ class _SnapshotProducer(UpdateTableMetadata[U], Generic[U]):
 
     def _get_existing_manifests(self) -> list[ManifestFile]:
         """Filter existing manifests and rewrite those containing deleted data files."""
-        existing_files = []
+        existing_files: list[ManifestFile] = []
         # Use manifest pruning if a predicate is set (primarily for Overwrite)
         manifest_evaluators: dict[int, Callable[[ManifestFile], bool]] = KeyDefaultDict(self._build_manifest_evaluator)
 
@@ -206,6 +206,7 @@ class _SnapshotProducer(UpdateTableMetadata[U], Generic[U]):
                                 )
                             )
                     existing_files.append(writer.to_manifest_file())
+
         return existing_files
 
     @abstractmethod
@@ -700,7 +701,8 @@ class _RewriteFiles(_SnapshotProducer["_RewriteFiles"]):
         else:
             return (), ()
 
-    def _deleted_entries(self) -> list[ManifestEntry]:
+    @cached_property
+    def _cached_deleted_entries(self) -> list[ManifestEntry]:
         """Check if we need to mark the files as deleted."""
         if self._parent_snapshot_id is not None:
             previous_snapshot = self._transaction.table_metadata.snapshot_by_id(self._parent_snapshot_id)
@@ -726,6 +728,10 @@ class _RewriteFiles(_SnapshotProducer["_RewriteFiles"]):
             return list(itertools.chain(*list_of_entries))
         else:
             return []
+
+    def _deleted_entries(self) -> list[ManifestEntry]:
+        """Check if we need to mark the files as deleted."""
+        return self._cached_deleted_entries
 
     def _existing_manifests(self) -> list[ManifestFile]:
         """To determine if there are any existing manifests."""

--- a/pyiceberg/table/update/snapshot.py
+++ b/pyiceberg/table/update/snapshot.py
@@ -725,11 +725,9 @@ class _RewriteFiles(_SnapshotProducer["_RewriteFiles"]):
             return []
 
     def _deleted_entries(self) -> list[ManifestEntry]:
-        """Check if we need to mark the files as deleted."""
         return self._cached_deleted_entries
 
     def _existing_manifests(self) -> list[ManifestFile]:
-        """To determine if there are any existing manifests."""
         return self._get_existing_manifests()
 
 

--- a/pyiceberg/table/update/snapshot.py
+++ b/pyiceberg/table/update/snapshot.py
@@ -671,6 +671,81 @@ class _OverwriteFiles(_SnapshotProducer["_OverwriteFiles"]):
         else:
             return []
 
+class _RewriteFiles(_SnapshotProducer["_RewriteFiles"]):
+    """A snapshot producer that rewrites data files."""
+
+    def __init__(self, operation: Operation, transaction: Transaction, io: FileIO, snapshot_properties: dict[str, str]):
+        super().__init__(operation, transaction, io, snapshot_properties)
+
+    def _commit(self) -> UpdatesAndRequirements:
+        # Only produce a commit when there is something to rewrite
+        if self._deleted_data_files or self._added_data_files:
+            return super()._commit()
+        else:
+            return (), ()
+
+    def _deleted_entries(self) -> list[ManifestEntry]:
+        """Check if we need to mark the files as deleted."""
+        if self._parent_snapshot_id is not None:
+            previous_snapshot = self._transaction.table_metadata.snapshot_by_id(self._parent_snapshot_id)
+            if previous_snapshot is None:
+                raise ValueError(f"Could not find the previous snapshot: {self._parent_snapshot_id}")
+
+            executor = ExecutorFactory.get_or_create()
+
+            def _get_entries(manifest: ManifestFile) -> list[ManifestEntry]:
+                return [
+                    ManifestEntry.from_args(
+                        status=ManifestEntryStatus.DELETED,
+                        snapshot_id=entry.snapshot_id,
+                        sequence_number=entry.sequence_number,
+                        file_sequence_number=entry.file_sequence_number,
+                        data_file=entry.data_file,
+                    )
+                    for entry in manifest.fetch_manifest_entry(self._io, discard_deleted=True)
+                    if entry.data_file.content == DataFileContent.DATA and entry.data_file in self._deleted_data_files
+                ]
+
+            list_of_entries = executor.map(_get_entries, previous_snapshot.manifests(self._io))
+            return list(itertools.chain(*list_of_entries))
+        else:
+            return []
+
+    def _existing_manifests(self) -> list[ManifestFile]:
+        """To determine if there are any existing manifests."""
+        existing_files = []
+        if snapshot := self._transaction.table_metadata.snapshot_by_name(name=self._target_branch):
+            for manifest_file in snapshot.manifests(io=self._io):
+                entries_to_write: set[ManifestEntry] = set()
+                found_deleted_entries: set[ManifestEntry] = set()
+
+                for entry in manifest_file.fetch_manifest_entry(io=self._io, discard_deleted=True):
+                    if entry.data_file in self._deleted_data_files:
+                        found_deleted_entries.add(entry)
+                    else:
+                        entries_to_write.add(entry)
+
+                if len(found_deleted_entries) == 0:
+                    existing_files.append(manifest_file)
+                    continue
+
+                if len(entries_to_write) == 0:
+                    continue
+
+                with self.new_manifest_writer(self.spec(manifest_file.partition_spec_id)) as writer:
+                    for entry in entries_to_write:
+                        writer.add_entry(
+                            ManifestEntry.from_args(
+                                status=ManifestEntryStatus.EXISTING,
+                                snapshot_id=entry.snapshot_id,
+                                sequence_number=entry.sequence_number,
+                                file_sequence_number=entry.file_sequence_number,
+                                data_file=entry.data_file,
+                            )
+                        )
+                existing_files.append(writer.to_manifest_file())
+        return existing_files
+
 
 class UpdateSnapshot:
     _transaction: Transaction
@@ -729,7 +804,13 @@ class UpdateSnapshot:
             snapshot_properties=self._snapshot_properties,
         )
 
-
+    def replace(self) -> _RewriteFiles:
+        return _RewriteFiles(
+            operation=Operation.REPLACE,
+            transaction=self._transaction,
+            io=self._io,
+            snapshot_properties=self._snapshot_properties,
+        )
 class _ManifestMergeManager(Generic[U]):
     _target_size_bytes: int
     _min_count_to_merge: int

--- a/pyiceberg/table/update/snapshot.py
+++ b/pyiceberg/table/update/snapshot.py
@@ -671,11 +671,12 @@ class _OverwriteFiles(_SnapshotProducer["_OverwriteFiles"]):
         else:
             return []
 
+
 class _RewriteFiles(_SnapshotProducer["_RewriteFiles"]):
     """A snapshot producer that rewrites data files."""
 
     def __init__(self, operation: Operation, transaction: Transaction, io: FileIO, snapshot_properties: dict[str, str]):
-        super().__init__(operation, transaction, io, snapshot_properties)
+        super().__init__(operation, transaction, io, snapshot_properties=snapshot_properties)
 
     def _commit(self) -> UpdatesAndRequirements:
         # Only produce a commit when there is something to rewrite
@@ -811,6 +812,8 @@ class UpdateSnapshot:
             io=self._io,
             snapshot_properties=self._snapshot_properties,
         )
+
+
 class _ManifestMergeManager(Generic[U]):
     _target_size_bytes: int
     _min_count_to_merge: int

--- a/pyiceberg/table/update/snapshot.py
+++ b/pyiceberg/table/update/snapshot.py
@@ -698,7 +698,7 @@ class _RewriteFiles(_SnapshotProducer["_RewriteFiles"]):
                 return [
                     ManifestEntry.from_args(
                         status=ManifestEntryStatus.DELETED,
-                        snapshot_id=entry.snapshot_id,
+                        snapshot_id=self.snapshot_id,
                         sequence_number=entry.sequence_number,
                         file_sequence_number=entry.file_sequence_number,
                         data_file=entry.data_file,

--- a/pyiceberg/table/update/snapshot.py
+++ b/pyiceberg/table/update/snapshot.py
@@ -165,6 +165,49 @@ class _SnapshotProducer(UpdateTableMetadata[U], Generic[U]):
                 added_rows += manifest.added_rows_count
         return added_rows
 
+    def _get_existing_manifests(self) -> list[ManifestFile]:
+        """Filters existing manifests and rewrites those containing deleted data files."""
+        existing_files = []
+        # Use manifest pruning if a predicate is set (primarily for Overwrite)
+        manifest_evaluators: dict[int, Callable[[ManifestFile], bool]] = KeyDefaultDict(self._build_manifest_evaluator)
+
+        if snapshot := self._transaction.table_metadata.snapshot_by_name(name=self._target_branch):
+            for manifest_file in snapshot.manifests(io=self._io):
+                # Skip pruning for rewrite operations unless we want to optimize later
+                if self._operation == Operation.OVERWRITE and not manifest_evaluators[manifest_file.partition_spec_id](
+                    manifest_file
+                ):
+                    existing_files.append(manifest_file)
+                    continue
+
+                entries_to_write: list[ManifestEntry] = []
+                found_deleted_entries = False
+
+                for entry in manifest_file.fetch_manifest_entry(io=self._io, discard_deleted=True):
+                    if entry.data_file in self._deleted_data_files:
+                        found_deleted_entries = True
+                    else:
+                        entries_to_write.append(entry)
+
+                if not found_deleted_entries:
+                    existing_files.append(manifest_file)
+                    continue
+
+                if len(entries_to_write) > 0:
+                    with self.new_manifest_writer(self.spec(manifest_file.partition_spec_id)) as writer:
+                        for entry in entries_to_write:
+                            writer.add_entry(
+                                ManifestEntry.from_args(
+                                    status=ManifestEntryStatus.EXISTING,
+                                    snapshot_id=entry.snapshot_id,
+                                    sequence_number=entry.sequence_number,
+                                    file_sequence_number=entry.file_sequence_number,
+                                    data_file=entry.data_file,
+                                )
+                            )
+                    existing_files.append(writer.to_manifest_file())
+        return existing_files
+
     @abstractmethod
     def _deleted_entries(self) -> list[ManifestEntry]: ...
 
@@ -590,49 +633,7 @@ class _OverwriteFiles(_SnapshotProducer["_OverwriteFiles"]):
 
     def _existing_manifests(self) -> list[ManifestFile]:
         """Determine if there are any existing manifest files."""
-        existing_files = []
-
-        manifest_evaluators: dict[int, Callable[[ManifestFile], bool]] = KeyDefaultDict(self._build_manifest_evaluator)
-        if snapshot := self._transaction.table_metadata.snapshot_by_name(name=self._target_branch):
-            for manifest_file in snapshot.manifests(io=self._io):
-                # Manifest does not contain rows that match the files to delete partitions
-                if not manifest_evaluators[manifest_file.partition_spec_id](manifest_file):
-                    existing_files.append(manifest_file)
-                    continue
-
-                entries_to_write: set[ManifestEntry] = set()
-                found_deleted_entries: set[ManifestEntry] = set()
-
-                for entry in manifest_file.fetch_manifest_entry(io=self._io, discard_deleted=True):
-                    if entry.data_file in self._deleted_data_files:
-                        found_deleted_entries.add(entry)
-                    else:
-                        entries_to_write.add(entry)
-
-                # Is the intercept the empty set?
-                if len(found_deleted_entries) == 0:
-                    existing_files.append(manifest_file)
-                    continue
-
-                # Delete all files from manifest
-                if len(entries_to_write) == 0:
-                    continue
-
-                # We have to rewrite the manifest file without the deleted data files
-                with self.new_manifest_writer(self.spec(manifest_file.partition_spec_id)) as writer:
-                    for entry in entries_to_write:
-                        writer.add_entry(
-                            ManifestEntry.from_args(
-                                status=ManifestEntryStatus.EXISTING,
-                                snapshot_id=entry.snapshot_id,
-                                sequence_number=entry.sequence_number,
-                                file_sequence_number=entry.file_sequence_number,
-                                data_file=entry.data_file,
-                            )
-                        )
-                existing_files.append(writer.to_manifest_file())
-
-        return existing_files
+        return self._get_existing_manifests()
 
     def _deleted_entries(self) -> list[ManifestEntry]:
         """To determine if we need to record any deleted entries.
@@ -728,38 +729,7 @@ class _RewriteFiles(_SnapshotProducer["_RewriteFiles"]):
 
     def _existing_manifests(self) -> list[ManifestFile]:
         """To determine if there are any existing manifests."""
-        existing_files = []
-        if snapshot := self._transaction.table_metadata.snapshot_by_name(name=self._target_branch):
-            for manifest_file in snapshot.manifests(io=self._io):
-                entries_to_write: set[ManifestEntry] = set()
-                found_deleted_entries: set[ManifestEntry] = set()
-
-                for entry in manifest_file.fetch_manifest_entry(io=self._io, discard_deleted=True):
-                    if entry.data_file in self._deleted_data_files:
-                        found_deleted_entries.add(entry)
-                    else:
-                        entries_to_write.add(entry)
-
-                if len(found_deleted_entries) == 0:
-                    existing_files.append(manifest_file)
-                    continue
-
-                if len(entries_to_write) == 0:
-                    continue
-
-                with self.new_manifest_writer(self.spec(manifest_file.partition_spec_id)) as writer:
-                    for entry in entries_to_write:
-                        writer.add_entry(
-                            ManifestEntry.from_args(
-                                status=ManifestEntryStatus.EXISTING,
-                                snapshot_id=entry.snapshot_id,
-                                sequence_number=entry.sequence_number,
-                                file_sequence_number=entry.file_sequence_number,
-                                data_file=entry.data_file,
-                            )
-                        )
-                existing_files.append(writer.to_manifest_file())
-        return existing_files
+        return self._get_existing_manifests()
 
 
 class UpdateSnapshot:

--- a/pyiceberg/table/update/snapshot.py
+++ b/pyiceberg/table/update/snapshot.py
@@ -165,7 +165,7 @@ class _SnapshotProducer(UpdateTableMetadata[U], Generic[U]):
                 added_rows += manifest.added_rows_count
         return added_rows
 
-    def _get_existing_manifests(self) -> list[ManifestFile]:
+    def _get_existing_manifests(self, should_use_manifest_pruning: bool = False) -> list[ManifestFile]:
         """Filter existing manifests and rewrite those containing deleted data files."""
         existing_files: list[ManifestFile] = []
         # Use manifest pruning if a predicate is set (primarily for Overwrite)
@@ -174,9 +174,7 @@ class _SnapshotProducer(UpdateTableMetadata[U], Generic[U]):
         if snapshot := self._transaction.table_metadata.snapshot_by_name(name=self._target_branch):
             for manifest_file in snapshot.manifests(io=self._io):
                 # Skip pruning for rewrite operations unless we want to optimize later
-                if self._operation == Operation.OVERWRITE and not manifest_evaluators[manifest_file.partition_spec_id](
-                    manifest_file
-                ):
+                if should_use_manifest_pruning and not manifest_evaluators[manifest_file.partition_spec_id](manifest_file):
                     existing_files.append(manifest_file)
                     continue
 
@@ -634,7 +632,7 @@ class _OverwriteFiles(_SnapshotProducer["_OverwriteFiles"]):
 
     def _existing_manifests(self) -> list[ManifestFile]:
         """Determine if there are any existing manifest files."""
-        return self._get_existing_manifests()
+        return self._get_existing_manifests(should_use_manifest_pruning=True)
 
     def _deleted_entries(self) -> list[ManifestEntry]:
         """To determine if we need to record any deleted entries.

--- a/pyiceberg/table/update/snapshot.py
+++ b/pyiceberg/table/update/snapshot.py
@@ -216,8 +216,75 @@ class _SnapshotProducer(UpdateTableMetadata[U], Generic[U]):
                 added_rows += manifest.added_rows_count
         return added_rows
 
-    @abstractmethod
-    def _deleted_entries(self) -> list[ManifestEntry]: ...
+    def _get_existing_manifests(self, should_use_manifest_pruning: bool) -> list[ManifestFile]:
+        """Filter existing manifests and rewrite those containing deleted data files."""
+        existing_files: list[ManifestFile] = []
+        manifest_evaluators: dict[int, Callable[[ManifestFile], bool]] = KeyDefaultDict(self._build_manifest_evaluator)
+
+        if snapshot := self._transaction.table_metadata.snapshot_by_name(name=self._target_branch):
+            for manifest_file in snapshot.manifests(io=self._io):
+                if should_use_manifest_pruning and not manifest_evaluators[manifest_file.partition_spec_id](manifest_file):
+                    existing_files.append(manifest_file)
+                    continue
+
+                entries_to_write: list[ManifestEntry] = []
+                found_deleted_entries = False
+
+                for entry in manifest_file.fetch_manifest_entry(io=self._io, discard_deleted=True):
+                    if entry.data_file in self._deleted_data_files:
+                        found_deleted_entries = True
+                    else:
+                        entries_to_write.append(entry)
+
+                if not found_deleted_entries:
+                    existing_files.append(manifest_file)
+                    continue
+
+                if len(entries_to_write) > 0:
+                    with self.new_manifest_writer(self.spec(manifest_file.partition_spec_id)) as writer:
+                        for entry in entries_to_write:
+                            writer.add_entry(
+                                ManifestEntry.from_args(
+                                    status=ManifestEntryStatus.EXISTING,
+                                    snapshot_id=entry.snapshot_id,
+                                    sequence_number=entry.sequence_number,
+                                    file_sequence_number=entry.file_sequence_number,
+                                    data_file=entry.data_file,
+                                )
+                            )
+                    existing_files.append(writer.to_manifest_file())
+
+        return existing_files
+
+    def _get_deleted_manifest_entries(self, manifest: ManifestFile) -> list[ManifestEntry]:
+        """Return the entries from the given manifest that should be marked as DELETED.
+
+        Subclasses override this to control which entries are selected for deletion
+        and whether partition-level pruning is applied. The default returns no entries.
+        """
+        return []
+
+    @cached_property
+    def _cached_deleted_entries(self) -> list[ManifestEntry]:
+        """Scan the parent snapshot's manifests and collect entries to delete."""
+        if self._parent_snapshot_id is not None:
+            previous_snapshot = self._transaction.table_metadata.snapshot_by_id(self._parent_snapshot_id)
+            if previous_snapshot is None:
+                raise ValueError(f"Could not find the previous snapshot: {self._parent_snapshot_id}")
+
+            executor = ExecutorFactory.get_or_create()
+            list_of_entries = executor.map(self._get_deleted_manifest_entries, previous_snapshot.manifests(self._io))
+            return list(itertools.chain(*list_of_entries))
+        else:
+            return []
+
+    def _deleted_entries(self) -> list[ManifestEntry]:
+        return self._cached_deleted_entries
+
+    def _refresh_deleted_entries_cache(self) -> None:
+        """Clear the cached deleted entries so they are recomputed on next access."""
+        if "_cached_deleted_entries" in self.__dict__:
+            del self.__dict__["_cached_deleted_entries"]
 
     @abstractmethod
     def _existing_manifests(self) -> list[ManifestFile]: ...
@@ -773,89 +840,28 @@ class _OverwriteFiles(_SnapshotProducer["_OverwriteFiles"]):
 
     def _existing_manifests(self) -> list[ManifestFile]:
         """Determine if there are any existing manifest files."""
-        existing_files = []
+        return self._get_existing_manifests(should_use_manifest_pruning=True)
 
+    def _get_deleted_manifest_entries(self, manifest: ManifestFile) -> list[ManifestEntry]:
         manifest_evaluators: dict[int, Callable[[ManifestFile], bool]] = KeyDefaultDict(self._build_manifest_evaluator)
-        if snapshot := self._transaction.table_metadata.snapshot_by_name(name=self._target_branch):
-            for manifest_file in snapshot.manifests(io=self._io):
-                # Manifest does not contain rows that match the files to delete partitions
-                if not manifest_evaluators[manifest_file.partition_spec_id](manifest_file):
-                    existing_files.append(manifest_file)
-                    continue
+        if not manifest_evaluators[manifest.partition_spec_id](manifest):
+            return []
 
-                entries_to_write: set[ManifestEntry] = set()
-                found_deleted_entries: set[ManifestEntry] = set()
-
-                for entry in manifest_file.fetch_manifest_entry(io=self._io, discard_deleted=True):
-                    if entry.data_file in self._deleted_data_files:
-                        found_deleted_entries.add(entry)
-                    else:
-                        entries_to_write.add(entry)
-
-                # Is the intercept the empty set?
-                if len(found_deleted_entries) == 0:
-                    existing_files.append(manifest_file)
-                    continue
-
-                # Delete all files from manifest
-                if len(entries_to_write) == 0:
-                    continue
-
-                # We have to rewrite the manifest file without the deleted data files
-                with self.new_manifest_writer(self.spec(manifest_file.partition_spec_id)) as writer:
-                    for entry in entries_to_write:
-                        writer.add_entry(
-                            ManifestEntry.from_args(
-                                status=ManifestEntryStatus.EXISTING,
-                                snapshot_id=entry.snapshot_id,
-                                sequence_number=entry.sequence_number,
-                                file_sequence_number=entry.file_sequence_number,
-                                data_file=entry.data_file,
-                            )
-                        )
-                existing_files.append(writer.to_manifest_file())
-
-        return existing_files
+        return [
+            ManifestEntry.from_args(
+                status=ManifestEntryStatus.DELETED,
+                snapshot_id=self._snapshot_id,
+                sequence_number=entry.sequence_number,
+                file_sequence_number=entry.file_sequence_number,
+                data_file=entry.data_file,
+            )
+            for entry in manifest.fetch_manifest_entry(self._io, discard_deleted=True)
+            if entry.data_file.content == DataFileContent.DATA and entry.data_file in self._deleted_data_files
+        ]
 
     def _deleted_entries(self) -> list[ManifestEntry]:
-        """To determine if we need to record any deleted entries.
-
-        With a full overwrite all the entries are considered deleted.
-        With partial overwrites we have to use the predicate to evaluate
-        which entries are affected.
-        """
-        if self._parent_snapshot_id is not None:
-            previous_snapshot = self._transaction.table_metadata.snapshot_by_id(self._parent_snapshot_id)
-            if previous_snapshot is None:
-                # This should never happen since you cannot overwrite an empty table
-                raise ValueError(f"Could not find the previous snapshot: {self._parent_snapshot_id}")
-
-            executor = ExecutorFactory.get_or_create()
-            manifest_evaluators: dict[int, Callable[[ManifestFile], bool]] = KeyDefaultDict(self._build_manifest_evaluator)
-
-            def _get_entries(manifest: ManifestFile) -> list[ManifestEntry]:
-                if not manifest_evaluators[manifest.partition_spec_id](manifest):
-                    return []
-
-                return [
-                    ManifestEntry.from_args(
-                        status=ManifestEntryStatus.DELETED,
-                        snapshot_id=self._snapshot_id,
-                        sequence_number=entry.sequence_number,
-                        file_sequence_number=entry.file_sequence_number,
-                        data_file=entry.data_file,
-                    )
-                    for entry in manifest.fetch_manifest_entry(self._io, discard_deleted=True)
-                    if entry.data_file.content == DataFileContent.DATA and entry.data_file in self._deleted_data_files
-                ]
-
-            list_of_entries = executor.map(_get_entries, previous_snapshot.manifests(self._io))
-            deleted_entries = list(itertools.chain(*list_of_entries))
-        else:
-            deleted_entries = []
-
+        deleted_entries = self._cached_deleted_entries
         self._validate_required_deletes(deleted_entries)
-
         return deleted_entries
 
     def _validate_required_deletes(self, deleted_entries: list[ManifestEntry]) -> None:
@@ -874,6 +880,97 @@ class _OverwriteFiles(_SnapshotProducer["_OverwriteFiles"]):
         found_data_files = {entry.data_file for entry in deleted_entries}
         if missing := [data_file.file_path for data_file in self._deleted_data_files if data_file not in found_data_files]:
             raise ValidationException(f"Missing required files to delete: {', '.join(sorted(missing))}")
+
+
+class _RewriteFiles(_SnapshotProducer["_RewriteFiles"]):
+    """A snapshot producer that rewrites data files.
+
+    Produces a REPLACE snapshot that swaps existing data files for new ones without
+    changing the logical contents of the table. This is the metadata-only operation
+    used by compaction (bin-packing, sort, format migration).
+
+    Current scope:
+        - Data file rewriting only (delete + add DataFiles)
+        - Validates: files-to-delete exist, added_records <= deleted_records,
+          no new delete files conflict with replaced data files
+
+    Future work (additive — no structural changes needed):
+        - Delete-file rewriting (add _deleted_delete_files set + separate manifest handling)
+        - dataSequenceNumber override (pin new files' seq to match replaced, for eq-delete safety)
+        - validateFromSnapshot (expose _starting_snapshot_id setter for long-running planners)
+        - ignoreEqualityDeletes in validation (coupled with dataSequenceNumber)
+    """
+
+    def _commit(self) -> UpdatesAndRequirements:
+        if not self._deleted_data_files and not self._added_data_files:
+            return (), ()
+
+        deleted_entries = self._deleted_entries()
+        found_deleted_files = {entry.data_file for entry in deleted_entries}
+
+        if len(found_deleted_files) != len(self._deleted_data_files):
+            raise ValidationException("Cannot commit, missing data files to be rewritten that are not in the table")
+
+        added_records = sum(f.record_count for f in self._added_data_files)
+        deleted_records = sum(entry.data_file.record_count for entry in deleted_entries)
+
+        if added_records > deleted_records:
+            raise ValidationException(
+                f"Invalid replace: records added ({added_records}) exceeds records removed ({deleted_records})"
+            )
+
+        return super()._commit()
+
+    def _get_deleted_manifest_entries(self, manifest: ManifestFile) -> list[ManifestEntry]:
+        return [
+            ManifestEntry.from_args(
+                status=ManifestEntryStatus.DELETED,
+                snapshot_id=self.snapshot_id,
+                sequence_number=entry.sequence_number,
+                file_sequence_number=entry.file_sequence_number,
+                data_file=entry.data_file,
+            )
+            for entry in manifest.fetch_manifest_entry(self._io, discard_deleted=True)
+            if entry.data_file.content == DataFileContent.DATA and entry.data_file in self._deleted_data_files
+        ]
+
+    def _existing_manifests(self) -> list[ManifestFile]:
+        return self._get_existing_manifests(should_use_manifest_pruning=False)
+
+    def _validate_concurrency(self) -> None:
+        """Validate that concurrent changes do not conflict with this replace.
+
+        Unlike overwrite/delete, a replace operation only needs to validate that no new
+        delete files have been added that would apply to the data files being replaced.
+        Concurrent data file additions (appends) do NOT conflict with a replace because
+        the replace only touches files it explicitly planned to rewrite.
+
+        This matches Java's BaseRewriteFiles.validate() which only calls
+        validateNoNewDeletesForDataFiles, not validateAddedDataFiles or
+        validateDeletedDataFiles.
+        """
+        from pyiceberg.table.update.validate import _validate_no_new_deletes_for_data_files
+
+        if self._commit_window is None or self._commit_window.is_empty():
+            return
+
+        catalog_head = self._commit_window.head
+        starting_snapshot = self._commit_window.base
+
+        if catalog_head is None:
+            return
+
+        if self._deleted_data_files:
+            table = self._transaction._table
+            conflict_detection_filter = self._predicate if self._predicate != AlwaysFalse() else None
+            _validate_no_new_deletes_for_data_files(
+                table, catalog_head, conflict_detection_filter, self._deleted_data_files, starting_snapshot
+            )
+
+    def _refresh_for_retry(self) -> None:
+        """Reset state for a retry attempt, clearing the cached deleted entries."""
+        super()._refresh_for_retry()
+        self._refresh_deleted_entries_cache()
 
 
 class UpdateSnapshot:
@@ -927,6 +1024,15 @@ class UpdateSnapshot:
     def delete(self) -> _DeleteFiles:
         return _DeleteFiles(
             operation=Operation.DELETE,
+            transaction=self._transaction,
+            io=self._io,
+            branch=self._branch,
+            snapshot_properties=self._snapshot_properties,
+        )
+
+    def replace(self) -> _RewriteFiles:
+        return _RewriteFiles(
+            operation=Operation.REPLACE,
             transaction=self._transaction,
             io=self._io,
             branch=self._branch,

--- a/tests/table/test_replace.py
+++ b/tests/table/test_replace.py
@@ -696,7 +696,8 @@ def test_replace_on_custom_branch(catalog: Catalog) -> None:
     # Assert that the "test-branch" reference now points to a REPLACE snapshot
     new_snapshot = table.snapshot_by_id(test_branch_ref.snapshot_id)
     assert new_snapshot is not None
-    assert new_snapshot.summary["operation"] == Operation.REPLACE
+    summary = cast(Summary, new_snapshot.summary)
+    assert summary["operation"] == Operation.REPLACE
 
     # Assert that the "main" branch reference was completely untouched
     assert main_branch_ref.snapshot_id == initial_main_snapshot_id

--- a/tests/table/test_replace.py
+++ b/tests/table/test_replace.py
@@ -31,6 +31,28 @@ from pyiceberg.table.snapshots import Operation, Snapshot, Summary
 from pyiceberg.typedef import Record
 
 
+def _create_dummy_data_file(
+    file_path: str,
+    record_count: int,
+    file_size_in_bytes: int = 1024,
+    content: DataFileContent = DataFileContent.DATA,
+    partition: Record | None = None,
+    spec_id: int = 0,
+) -> DataFile:
+    if partition is None:
+        partition = Record()
+    df = DataFile.from_args(
+        file_path=file_path,
+        file_format=FileFormat.PARQUET,
+        partition=partition,
+        record_count=record_count,
+        file_size_in_bytes=file_size_in_bytes,
+        content=content,
+    )
+    df.spec_id = spec_id
+    return df
+
+
 def test_replace_internally(catalog: Catalog) -> None:
     # Setup a basic table using the catalog fixture
     catalog.create_namespace("default")
@@ -40,37 +62,23 @@ def test_replace_internally(catalog: Catalog) -> None:
     )
 
     # 1. File we will delete
-    file_to_delete = DataFile.from_args(
+    file_to_delete = _create_dummy_data_file(
         file_path="s3://bucket/test/data/deleted.parquet",
-        file_format=FileFormat.PARQUET,
-        partition=Record(),
         record_count=100,
-        file_size_in_bytes=1024,
-        content=DataFileContent.DATA,
     )
-    file_to_delete.spec_id = 0
 
     # 2. File we will leave completely untouched
-    file_to_keep = DataFile.from_args(
+    file_to_keep = _create_dummy_data_file(
         file_path="s3://bucket/test/data/kept.parquet",
-        file_format=FileFormat.PARQUET,
-        partition=Record(),
         record_count=50,
         file_size_in_bytes=512,
-        content=DataFileContent.DATA,
     )
-    file_to_keep.spec_id = 0
 
     # 3. File we are adding as a replacement
-    file_to_add = DataFile.from_args(
+    file_to_add = _create_dummy_data_file(
         file_path="s3://bucket/test/data/added.parquet",
-        file_format=FileFormat.PARQUET,
-        partition=Record(),
         record_count=100,
-        file_size_in_bytes=1024,
-        content=DataFileContent.DATA,
     )
-    file_to_add.spec_id = 0
 
     # Initially append BOTH the file to delete and the file to keep
     with table.transaction() as tx:
@@ -152,35 +160,23 @@ def test_replace_reuses_unaffected_manifests(catalog: Catalog) -> None:
         schema=Schema(),
     )
 
-    file_a = DataFile.from_args(
+    file_a = _create_dummy_data_file(
         file_path="s3://bucket/test/data/a.parquet",
-        file_format=FileFormat.PARQUET,
-        partition=Record(),
         record_count=10,
         file_size_in_bytes=100,
-        content=DataFileContent.DATA,
     )
-    file_a.spec_id = 0
 
-    file_b = DataFile.from_args(
+    file_b = _create_dummy_data_file(
         file_path="s3://bucket/test/data/b.parquet",
-        file_format=FileFormat.PARQUET,
-        partition=Record(),
         record_count=10,
         file_size_in_bytes=100,
-        content=DataFileContent.DATA,
     )
-    file_b.spec_id = 0
 
-    file_c = DataFile.from_args(
+    file_c = _create_dummy_data_file(
         file_path="s3://bucket/test/data/c.parquet",
-        file_format=FileFormat.PARQUET,
-        partition=Record(),
         record_count=10,
         file_size_in_bytes=100,
-        content=DataFileContent.DATA,
     )
-    file_c.spec_id = 0
 
     # Commit 1: Append file A (Creates Manifest 1)
     with table.transaction() as tx:
@@ -260,25 +256,15 @@ def test_replace_missing_file_abort(catalog: Catalog) -> None:
         schema=Schema(),
     )
 
-    fake_data_file = DataFile.from_args(
+    fake_data_file = _create_dummy_data_file(
         file_path="s3://bucket/test/data/does_not_exist.parquet",
-        file_format=FileFormat.PARQUET,
-        partition=Record(),
         record_count=100,
-        file_size_in_bytes=1024,
-        content=DataFileContent.DATA,
     )
-    fake_data_file.spec_id = 0
 
-    new_data_file = DataFile.from_args(
+    new_data_file = _create_dummy_data_file(
         file_path="s3://bucket/test/data/new.parquet",
-        file_format=FileFormat.PARQUET,
-        partition=Record(),
         record_count=100,
-        file_size_in_bytes=1024,
-        content=DataFileContent.DATA,
     )
-    new_data_file.spec_id = 0
 
     # Ensure it aborts when trying to replace a file that isn't in the table
     with pytest.raises(ValueError, match="Cannot delete files that are not present in the table"):
@@ -296,26 +282,16 @@ def test_replace_invariant_violation(catalog: Catalog) -> None:
         schema=Schema(),
     )
 
-    file_to_delete = DataFile.from_args(
+    file_to_delete = _create_dummy_data_file(
         file_path="s3://bucket/test/data/deleted.parquet",
-        file_format=FileFormat.PARQUET,
-        partition=Record(),
         record_count=100,
-        file_size_in_bytes=1024,
-        content=DataFileContent.DATA,
     )
-    file_to_delete.spec_id = 0
 
     # Create a new file with MORE records than the one we are deleting
-    too_many_records_file = DataFile.from_args(
+    too_many_records_file = _create_dummy_data_file(
         file_path="s3://bucket/test/data/too_many.parquet",
-        file_format=FileFormat.PARQUET,
-        partition=Record(),
         record_count=101,
-        file_size_in_bytes=1024,
-        content=DataFileContent.DATA,
     )
-    too_many_records_file.spec_id = 0
 
     # Initially append to have something to replace
     with table.transaction() as tx:
@@ -339,26 +315,17 @@ def test_replace_allows_shrinking_for_soft_deletes(catalog: Catalog) -> None:
     )
 
     # Old data file has 100 records
-    file_to_delete = DataFile.from_args(
+    file_to_delete = _create_dummy_data_file(
         file_path="s3://bucket/test/data/deleted.parquet",
-        file_format=FileFormat.PARQUET,
-        partition=Record(),
         record_count=100,
-        file_size_in_bytes=1024,
-        content=DataFileContent.DATA,
     )
-    file_to_delete.spec_id = 0
 
     # New data file only has 90 records (simulating 10 records were soft-deleted)
-    shrunk_file_to_add = DataFile.from_args(
+    shrunk_file_to_add = _create_dummy_data_file(
         file_path="s3://bucket/test/data/shrunk.parquet",
-        file_format=FileFormat.PARQUET,
-        partition=Record(),
         record_count=90,
         file_size_in_bytes=900,
-        content=DataFileContent.DATA,
     )
-    shrunk_file_to_add.spec_id = 0
 
     # Initially append
     with table.transaction() as tx:
@@ -389,37 +356,26 @@ def test_replace_passes_through_delete_manifests(catalog: Catalog) -> None:
     )
 
     # 1. Data file we will replace
-    file_a = DataFile.from_args(
+    file_a = _create_dummy_data_file(
         file_path="s3://bucket/test/data/a.parquet",
-        file_format=FileFormat.PARQUET,
-        partition=Record(),
         record_count=10,
         file_size_in_bytes=100,
-        content=DataFileContent.DATA,
     )
-    file_a.spec_id = 0
 
     # 2. A Position Delete file (representing row-level deletes)
-    file_a_deletes = DataFile.from_args(
+    file_a_deletes = _create_dummy_data_file(
         file_path="s3://bucket/test/data/a_deletes.parquet",
-        file_format=FileFormat.PARQUET,
-        partition=Record(),
         record_count=2,
         file_size_in_bytes=50,
         content=DataFileContent.POSITION_DELETES,
     )
-    file_a_deletes.spec_id = 0
 
     # 3. Data file we are adding as a replacement
-    file_b = DataFile.from_args(
+    file_b = _create_dummy_data_file(
         file_path="s3://bucket/test/data/b.parquet",
-        file_format=FileFormat.PARQUET,
-        partition=Record(),
         record_count=10,
         file_size_in_bytes=100,
-        content=DataFileContent.DATA,
     )
-    file_b.spec_id = 0
 
     # Commit 1: Append the data file
     with table.transaction() as tx:
@@ -467,45 +423,27 @@ def test_replace_multiple_files(catalog: Catalog) -> None:
         schema=Schema(),
     )
 
-    file_1 = DataFile.from_args(
+    file_1 = _create_dummy_data_file(
         file_path="s3://bucket/test/data/1.parquet",
-        file_format=FileFormat.PARQUET,
-        partition=Record(),
         record_count=100,
-        file_size_in_bytes=1024,
-        content=DataFileContent.DATA,
     )
-    file_1.spec_id = 0
 
-    file_2 = DataFile.from_args(
+    file_2 = _create_dummy_data_file(
         file_path="s3://bucket/test/data/2.parquet",
-        file_format=FileFormat.PARQUET,
-        partition=Record(),
         record_count=100,
-        file_size_in_bytes=1024,
-        content=DataFileContent.DATA,
     )
-    file_2.spec_id = 0
 
-    file_1_new = DataFile.from_args(
+    file_1_new = _create_dummy_data_file(
         file_path="s3://bucket/test/data/1_new.parquet",
-        file_format=FileFormat.PARQUET,
-        partition=Record(),
         record_count=50,
         file_size_in_bytes=512,
-        content=DataFileContent.DATA,
     )
-    file_1_new.spec_id = 0
 
-    file_2_new = DataFile.from_args(
+    file_2_new = _create_dummy_data_file(
         file_path="s3://bucket/test/data/2_new.parquet",
-        file_format=FileFormat.PARQUET,
-        partition=Record(),
         record_count=50,
         file_size_in_bytes=512,
-        content=DataFileContent.DATA,
     )
-    file_2_new.spec_id = 0
 
     # Append initial files
     with table.transaction() as tx:
@@ -550,26 +488,20 @@ def test_replace_partitioned_table(catalog: Catalog) -> None:
     )
 
     # File in partition id=1
-    file_part1 = DataFile.from_args(
+    file_part1 = _create_dummy_data_file(
         file_path="s3://bucket/test/data/part1.parquet",
-        file_format=FileFormat.PARQUET,
         partition=Record(1),
         record_count=100,
-        file_size_in_bytes=1024,
-        content=DataFileContent.DATA,
+        spec_id=table.spec().spec_id,
     )
-    file_part1.spec_id = table.spec().spec_id
 
     # File in partition id=2
-    file_part2 = DataFile.from_args(
+    file_part2 = _create_dummy_data_file(
         file_path="s3://bucket/test/data/part2.parquet",
-        file_format=FileFormat.PARQUET,
         partition=Record(2),
         record_count=100,
-        file_size_in_bytes=1024,
-        content=DataFileContent.DATA,
+        spec_id=table.spec().spec_id,
     )
-    file_part2.spec_id = table.spec().spec_id
 
     # Add initial files
     with table.transaction() as tx:
@@ -578,15 +510,13 @@ def test_replace_partitioned_table(catalog: Catalog) -> None:
             append_snapshot.append_data_file(file_part2)
 
     # Replace file in partition 1
-    file_part1_new = DataFile.from_args(
+    file_part1_new = _create_dummy_data_file(
         file_path="s3://bucket/test/data/part1_new.parquet",
-        file_format=FileFormat.PARQUET,
         partition=Record(1),
         record_count=50,
         file_size_in_bytes=512,
-        content=DataFileContent.DATA,
+        spec_id=table.spec().spec_id,
     )
-    file_part1_new.spec_id = table.spec().spec_id
 
     with table.transaction() as tx:
         with tx.update_snapshot().replace() as rewrite:
@@ -609,15 +539,11 @@ def test_replace_no_op_on_non_empty_table(catalog: Catalog) -> None:
         schema=Schema(),
     )
 
-    file_a = DataFile.from_args(
+    file_a = _create_dummy_data_file(
         file_path="s3://bucket/test/data/a.parquet",
-        file_format=FileFormat.PARQUET,
-        partition=Record(),
         record_count=10,
         file_size_in_bytes=100,
-        content=DataFileContent.DATA,
     )
-    file_a.spec_id = 0
 
     # Commit 1: Append file A
     with table.transaction() as tx:
@@ -646,26 +572,16 @@ def test_replace_on_custom_branch(catalog: Catalog) -> None:
     )
 
     # 1. File we will delete
-    file_to_delete = DataFile.from_args(
+    file_to_delete = _create_dummy_data_file(
         file_path="s3://bucket/test/data/deleted.parquet",
-        file_format=FileFormat.PARQUET,
-        partition=Record(),
         record_count=100,
-        file_size_in_bytes=1024,
-        content=DataFileContent.DATA,
     )
-    file_to_delete.spec_id = 0
 
     # 2. File we are adding as a replacement
-    file_to_add = DataFile.from_args(
+    file_to_add = _create_dummy_data_file(
         file_path="s3://bucket/test/data/added.parquet",
-        file_format=FileFormat.PARQUET,
-        partition=Record(),
         record_count=100,
-        file_size_in_bytes=1024,
-        content=DataFileContent.DATA,
     )
-    file_to_add.spec_id = 0
 
     # Initially append to have something to replace on main
     with table.transaction() as tx:

--- a/tests/table/test_replace.py
+++ b/tests/table/test_replace.py
@@ -635,3 +635,68 @@ def test_replace_no_op_on_non_empty_table(catalog: Catalog) -> None:
     # Successive calls to current_snapshot() should yield the same snapshot
     assert table.current_snapshot() == initial_snapshot
     assert len(table.history()) == 1
+
+
+def test_replace_on_custom_branch(catalog: Catalog) -> None:
+    # Setup a basic table using the catalog fixture
+    catalog.create_namespace("default")
+    table = catalog.create_table(
+        identifier="default.test_replace_branch",
+        schema=Schema(),
+    )
+
+    # 1. File we will delete
+    file_to_delete = DataFile.from_args(
+        file_path="s3://bucket/test/data/deleted.parquet",
+        file_format=FileFormat.PARQUET,
+        partition=Record(),
+        record_count=100,
+        file_size_in_bytes=1024,
+        content=DataFileContent.DATA,
+    )
+    file_to_delete.spec_id = 0
+
+    # 2. File we are adding as a replacement
+    file_to_add = DataFile.from_args(
+        file_path="s3://bucket/test/data/added.parquet",
+        file_format=FileFormat.PARQUET,
+        partition=Record(),
+        record_count=100,
+        file_size_in_bytes=1024,
+        content=DataFileContent.DATA,
+    )
+    file_to_add.spec_id = 0
+
+    # Initially append to have something to replace on main
+    with table.transaction() as tx:
+        with tx.update_snapshot().fast_append() as append_snapshot:
+            append_snapshot.append_data_file(file_to_delete)
+
+    initial_main_snapshot = cast(Snapshot, table.current_snapshot())
+    initial_main_snapshot_id = initial_main_snapshot.snapshot_id
+
+    # Create a new branch called "test-branch" pointing to the initial snapshot
+    table.manage_snapshots().create_branch(branch_name="test-branch", snapshot_id=initial_main_snapshot_id).commit()
+
+    # Perform a replace() operation explicitly targeting "test-branch"
+    with table.transaction() as tx:
+        with tx.update_snapshot(branch="test-branch").replace() as rewrite:
+            rewrite.delete_data_file(file_to_delete)
+            rewrite.append_data_file(file_to_add)
+
+    # Reload table to get updated refs
+    table = catalog.load_table("default.test_replace_branch")
+
+    test_branch_ref = table.metadata.refs["test-branch"]
+    main_branch_ref = table.metadata.refs["main"]
+
+    # Assert that the operation was successful on test-branch
+    assert test_branch_ref.snapshot_id != initial_main_snapshot_id
+
+    # Assert that the "test-branch" reference now points to a REPLACE snapshot
+    new_snapshot = table.snapshot_by_id(test_branch_ref.snapshot_id)
+    assert new_snapshot is not None
+    assert new_snapshot.summary["operation"] == Operation.REPLACE
+
+    # Assert that the "main" branch reference was completely untouched
+    assert main_branch_ref.snapshot_id == initial_main_snapshot_id

--- a/tests/table/test_replace.py
+++ b/tests/table/test_replace.py
@@ -141,6 +141,7 @@ def test_replace_internally(catalog: Catalog) -> None:
     assert len(existing_entries) == 1
     assert existing_entries[0].data_file.file_path == file_to_keep.file_path
     assert existing_entries[0].snapshot_id == old_snapshot_id
+    assert existing_entries[0].sequence_number == old_sequence_number
 
 
 def test_replace_reuses_unaffected_manifests(catalog: Catalog) -> None:
@@ -456,3 +457,181 @@ def test_replace_passes_through_delete_manifests(catalog: Catalog) -> None:
     manifest_paths_after = [m.manifest_path for m in manifests_after]
 
     assert delete_manifest_path in manifest_paths_after
+
+
+def test_replace_multiple_files(catalog: Catalog) -> None:
+    # Setup a basic table
+    catalog.create_namespace("default")
+    table = catalog.create_table(
+        identifier="default.test_replace_multiple",
+        schema=Schema(),
+    )
+
+    file_1 = DataFile.from_args(
+        file_path="s3://bucket/test/data/1.parquet",
+        file_format=FileFormat.PARQUET,
+        partition=Record(),
+        record_count=100,
+        file_size_in_bytes=1024,
+        content=DataFileContent.DATA,
+    )
+    file_1.spec_id = 0
+
+    file_2 = DataFile.from_args(
+        file_path="s3://bucket/test/data/2.parquet",
+        file_format=FileFormat.PARQUET,
+        partition=Record(),
+        record_count=100,
+        file_size_in_bytes=1024,
+        content=DataFileContent.DATA,
+    )
+    file_2.spec_id = 0
+
+    file_1_new = DataFile.from_args(
+        file_path="s3://bucket/test/data/1_new.parquet",
+        file_format=FileFormat.PARQUET,
+        partition=Record(),
+        record_count=50,
+        file_size_in_bytes=512,
+        content=DataFileContent.DATA,
+    )
+    file_1_new.spec_id = 0
+
+    file_2_new = DataFile.from_args(
+        file_path="s3://bucket/test/data/2_new.parquet",
+        file_format=FileFormat.PARQUET,
+        partition=Record(),
+        record_count=50,
+        file_size_in_bytes=512,
+        content=DataFileContent.DATA,
+    )
+    file_2_new.spec_id = 0
+
+    # Append initial files
+    with table.transaction() as tx:
+        with tx.update_snapshot().fast_append() as append_snapshot:
+            append_snapshot.append_data_file(file_1)
+            append_snapshot.append_data_file(file_2)
+
+    # Replace both files with new ones
+    with table.transaction() as tx:
+        with tx.update_snapshot().replace() as rewrite:
+            rewrite.delete_data_file(file_1)
+            rewrite.delete_data_file(file_2)
+            rewrite.append_data_file(file_1_new)
+            rewrite.append_data_file(file_2_new)
+
+    snapshot = cast(Snapshot, table.current_snapshot())
+    summary = cast(Summary, snapshot.summary)
+
+    assert summary["added-data-files"] == "2"
+    assert summary["deleted-data-files"] == "2"
+    assert summary["added-records"] == "100"
+    assert summary["deleted-records"] == "200"
+    assert summary["total-records"] == "100"
+
+
+def test_replace_partitioned_table(catalog: Catalog) -> None:
+    from pyiceberg.partitioning import PartitionField, PartitionSpec
+    from pyiceberg.transforms import IdentityTransform
+    from pyiceberg.types import IntegerType, NestedField, StringType
+
+    # Setup a partitioned table
+    catalog.create_namespace("default")
+    schema = Schema(
+        NestedField(field_id=1, name="id", field_type=IntegerType(), required=True),
+        NestedField(field_id=2, name="data", field_type=StringType(), required=True),
+    )
+    spec = PartitionSpec(PartitionField(source_id=1, field_id=1001, transform=IdentityTransform(), name="id"))
+    table = catalog.create_table(
+        identifier="default.test_replace_partitioned",
+        schema=schema,
+        partition_spec=spec,
+    )
+
+    # File in partition id=1
+    file_part1 = DataFile.from_args(
+        file_path="s3://bucket/test/data/part1.parquet",
+        file_format=FileFormat.PARQUET,
+        partition=Record(1),
+        record_count=100,
+        file_size_in_bytes=1024,
+        content=DataFileContent.DATA,
+    )
+    file_part1.spec_id = table.spec().spec_id
+
+    # File in partition id=2
+    file_part2 = DataFile.from_args(
+        file_path="s3://bucket/test/data/part2.parquet",
+        file_format=FileFormat.PARQUET,
+        partition=Record(2),
+        record_count=100,
+        file_size_in_bytes=1024,
+        content=DataFileContent.DATA,
+    )
+    file_part2.spec_id = table.spec().spec_id
+
+    # Add initial files
+    with table.transaction() as tx:
+        with tx.update_snapshot().fast_append() as append_snapshot:
+            append_snapshot.append_data_file(file_part1)
+            append_snapshot.append_data_file(file_part2)
+
+    # Replace file in partition 1
+    file_part1_new = DataFile.from_args(
+        file_path="s3://bucket/test/data/part1_new.parquet",
+        file_format=FileFormat.PARQUET,
+        partition=Record(1),
+        record_count=50,
+        file_size_in_bytes=512,
+        content=DataFileContent.DATA,
+    )
+    file_part1_new.spec_id = table.spec().spec_id
+
+    with table.transaction() as tx:
+        with tx.update_snapshot().replace() as rewrite:
+            rewrite.delete_data_file(file_part1)
+            rewrite.append_data_file(file_part1_new)
+
+    snapshot = cast(Snapshot, table.current_snapshot())
+    summary = cast(Summary, snapshot.summary)
+
+    assert summary["added-data-files"] == "1"
+    assert summary["deleted-data-files"] == "1"
+    assert summary["total-records"] == "150"
+
+
+def test_replace_no_op_on_non_empty_table(catalog: Catalog) -> None:
+    # Setup a basic table
+    catalog.create_namespace("default")
+    table = catalog.create_table(
+        identifier="default.test_replace_noop_nonempty",
+        schema=Schema(),
+    )
+
+    file_a = DataFile.from_args(
+        file_path="s3://bucket/test/data/a.parquet",
+        file_format=FileFormat.PARQUET,
+        partition=Record(),
+        record_count=10,
+        file_size_in_bytes=100,
+        content=DataFileContent.DATA,
+    )
+    file_a.spec_id = 0
+
+    # Commit 1: Append file A
+    with table.transaction() as tx:
+        with tx.update_snapshot().fast_append() as append_snapshot:
+            append_snapshot.append_data_file(file_a)
+
+    initial_snapshot = table.current_snapshot()
+    assert initial_snapshot is not None
+
+    # Perform a no-op replace
+    with table.transaction() as tx:
+        with tx.update_snapshot().replace():
+            pass
+
+    # Successive calls to current_snapshot() should yield the same snapshot
+    assert table.current_snapshot() == initial_snapshot
+    assert len(table.history()) == 1

--- a/tests/table/test_replace.py
+++ b/tests/table/test_replace.py
@@ -1,19 +1,18 @@
-import uuid
-import pytest
+from pyiceberg.catalog import Catalog
 from pyiceberg.manifest import DataFile, DataFileContent, FileFormat
-from pyiceberg.table.snapshots import Operation
-from pyiceberg.partitioning import PartitionSpec
 from pyiceberg.schema import Schema
+from pyiceberg.table.snapshots import Operation
 from pyiceberg.typedef import Record
 
-def test_replace_api(catalog):
+
+def test_replace_api(catalog: Catalog) -> None:
     # Setup a basic table using the catalog fixture
     catalog.create_namespace("default")
     table = catalog.create_table(
         identifier="default.test_replace",
         schema=Schema(),
     )
-    
+
     # Create mock DataFiles for the test
     file_to_delete = DataFile.from_args(
         file_path="s3://bucket/test/data/deleted.parquet",
@@ -24,7 +23,7 @@ def test_replace_api(catalog):
         content=DataFileContent.DATA,
     )
     file_to_delete.spec_id = 0
-    
+
     file_to_add = DataFile.from_args(
         file_path="s3://bucket/test/data/added.parquet",
         file_format=FileFormat.PARQUET,
@@ -34,28 +33,29 @@ def test_replace_api(catalog):
         content=DataFileContent.DATA,
     )
     file_to_add.spec_id = 0
-    
+
     # Initially append to have something to replace
     with table.transaction() as tx:
         with tx.update_snapshot().fast_append() as append_snapshot:
             append_snapshot.append_data_file(file_to_delete)
-    
+
     # Verify initial append snapshot
     assert len(table.history()) == 1
     snapshot = table.current_snapshot()
+    assert snapshot is not None
+    assert snapshot.summary is not None
     assert snapshot.summary["operation"] == Operation.APPEND
-    
+
     # Call the replace API
-    table.replace(
-        files_to_delete=[file_to_delete],
-        files_to_add=[file_to_add]
-    )
-    
+    table.replace(files_to_delete=[file_to_delete], files_to_add=[file_to_add])
+
     # Verify the replacement created a REPLACE snapshot
     assert len(table.history()) == 2
     snapshot = table.current_snapshot()
+    assert snapshot is not None
+    assert snapshot.summary is not None
     assert snapshot.summary["operation"] == Operation.REPLACE
-    
+
     # Verify the correct files are added and deleted
     # The summary property tracks these counts
     assert snapshot.summary["added-data-files"] == "1"
@@ -65,28 +65,29 @@ def test_replace_api(catalog):
 
     # Verify the new file exists in the new manifest
     manifest_files = snapshot.manifests(table.io)
-    assert len(manifest_files) == 2 # One for ADDED, one for DELETED
-    
+    assert len(manifest_files) == 2  # One for ADDED, one for DELETED
+
     # Check that sequence numbers were handled properly natively by verifying the manifest contents
     entries = []
     for manifest in manifest_files:
         for entry in manifest.fetch_manifest_entry(table.io, discard_deleted=False):
             entries.append(entry)
-            
+
     # One entry for ADDED (new file), one for DELETED (old file)
     assert len(entries) == 2
-    
-def test_replace_empty_files(catalog):
+
+
+def test_replace_empty_files(catalog: Catalog) -> None:
     # Setup a basic table using the catalog fixture
     catalog.create_namespace("default")
     table = catalog.create_table(
         identifier="default.test_replace_empty",
         schema=Schema(),
     )
-    
+
     # Replacing empty lists should not throw errors, but should produce no changes.
     table.replace([], [])
-    
+
     # History should be completely empty since no files were rewritten
     assert len(table.history()) == 0
     assert table.current_snapshot() is None

--- a/tests/table/test_replace.py
+++ b/tests/table/test_replace.py
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 from pyiceberg.catalog import Catalog
 from pyiceberg.manifest import DataFile, DataFileContent, FileFormat
 from pyiceberg.schema import Schema

--- a/tests/table/test_replace.py
+++ b/tests/table/test_replace.py
@@ -15,13 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 from pyiceberg.catalog import Catalog
-from pyiceberg.manifest import DataFile, DataFileContent, FileFormat
+from pyiceberg.manifest import DataFile, DataFileContent, FileFormat, ManifestEntryStatus
 from pyiceberg.schema import Schema
 from pyiceberg.table.snapshots import Operation
 from pyiceberg.typedef import Record
 
 
-def test_replace_api(catalog: Catalog) -> None:
+def test_replace_internally(catalog: Catalog) -> None:
     # Setup a basic table using the catalog fixture
     catalog.create_namespace("default")
     table = catalog.create_table(
@@ -29,7 +29,7 @@ def test_replace_api(catalog: Catalog) -> None:
         schema=Schema(),
     )
 
-    # Create mock DataFiles for the test
+    # 1. File we will delete
     file_to_delete = DataFile.from_args(
         file_path="s3://bucket/test/data/deleted.parquet",
         file_format=FileFormat.PARQUET,
@@ -40,6 +40,18 @@ def test_replace_api(catalog: Catalog) -> None:
     )
     file_to_delete.spec_id = 0
 
+    # 2. File we will leave completely untouched
+    file_to_keep = DataFile.from_args(
+        file_path="s3://bucket/test/data/kept.parquet",
+        file_format=FileFormat.PARQUET,
+        partition=Record(),
+        record_count=50,
+        file_size_in_bytes=512,
+        content=DataFileContent.DATA,
+    )
+    file_to_keep.spec_id = 0
+
+    # 3. File we are adding as a replacement
     file_to_add = DataFile.from_args(
         file_path="s3://bucket/test/data/added.parquet",
         file_format=FileFormat.PARQUET,
@@ -50,47 +62,163 @@ def test_replace_api(catalog: Catalog) -> None:
     )
     file_to_add.spec_id = 0
 
-    # Initially append to have something to replace
+    # Initially append BOTH the file to delete and the file to keep
     with table.transaction() as tx:
         with tx.update_snapshot().fast_append() as append_snapshot:
             append_snapshot.append_data_file(file_to_delete)
+            append_snapshot.append_data_file(file_to_keep)
 
-    # Verify initial append snapshot
-    assert len(table.history()) == 1
+    old_snapshot = table.current_snapshot()
+    old_snapshot_id = old_snapshot.snapshot_id
+    old_sequence_number = old_snapshot.sequence_number
+
+    # Call the internal replace API
+    with table.transaction() as tx:
+        with tx.update_snapshot().replace() as rewrite:
+            rewrite.delete_data_file(file_to_delete)
+            rewrite.append_data_file(file_to_add)
+
     snapshot = table.current_snapshot()
-    assert snapshot is not None
-    assert snapshot.summary is not None
-    assert snapshot.summary["operation"] == Operation.APPEND
-
-    # Call the replace API
-    table.replace(files_to_delete=[file_to_delete], files_to_add=[file_to_add])
-
-    # Verify the replacement created a REPLACE snapshot
-    assert len(table.history()) == 2
-    snapshot = table.current_snapshot()
-    assert snapshot is not None
-    assert snapshot.summary is not None
+    
+    # 1. Has a unique snapshot ID
+    assert snapshot.snapshot_id is not None
+    assert snapshot.snapshot_id != old_snapshot_id
+    
+    # 2. Parent points to the previous snapshot
+    assert snapshot.parent_snapshot_id == old_snapshot_id
+    
+    # 3. Sequence number is exactly previous + 1
+    assert snapshot.sequence_number == old_sequence_number + 1
+    
+    # 4. Operation type is set to "replace"
     assert snapshot.summary["operation"] == Operation.REPLACE
-
-    # Verify the correct files are added and deleted
-    # The summary property tracks these counts
+    
+    # 5. Manifest list path is correct (just verify it exists and is a string path)
+    assert snapshot.manifest_list is not None
+    assert isinstance(snapshot.manifest_list, str)
+    
+    # 6. Summary counts are accurate
     assert snapshot.summary["added-data-files"] == "1"
     assert snapshot.summary["deleted-data-files"] == "1"
     assert snapshot.summary["added-records"] == "100"
     assert snapshot.summary["deleted-records"] == "100"
+    assert snapshot.summary["total-records"] == "150"
 
-    # Verify the new file exists in the new manifest
+    # Fetch all entries from the new manifests
     manifest_files = snapshot.manifests(table.io)
-    assert len(manifest_files) == 2  # One for ADDED, one for DELETED
-
-    # Check that sequence numbers were handled properly natively by verifying the manifest contents
     entries = []
     for manifest in manifest_files:
-        for entry in manifest.fetch_manifest_entry(table.io, discard_deleted=False):
-            entries.append(entry)
+        entries.extend(manifest.fetch_manifest_entry(table.io, discard_deleted=False))
 
-    # One entry for ADDED (new file), one for DELETED (old file)
-    assert len(entries) == 2
+    # We expect 3 entries: ADDED, DELETED, and EXISTING
+    assert len(entries) == 3
+    
+    # Check ADDED
+    added_entries = [e for e in entries if e.status == ManifestEntryStatus.ADDED]
+    assert len(added_entries) == 1
+    assert added_entries[0].data_file.file_path == file_to_add.file_path
+    assert added_entries[0].snapshot_id == snapshot.snapshot_id
+
+    # Check DELETED
+    deleted_entries = [e for e in entries if e.status == ManifestEntryStatus.DELETED]
+    assert len(deleted_entries) == 1
+    assert deleted_entries[0].data_file.file_path == file_to_delete.file_path
+    assert deleted_entries[0].snapshot_id == snapshot.snapshot_id
+
+    # Check EXISTING
+    existing_entries = [e for e in entries if e.status == ManifestEntryStatus.EXISTING]
+    assert len(existing_entries) == 1
+    assert existing_entries[0].data_file.file_path == file_to_keep.file_path
+    assert existing_entries[0].snapshot_id == old_snapshot_id
+
+
+def test_replace_reuses_unaffected_manifests(catalog: Catalog) -> None:
+    # Setup a basic table
+    catalog.create_namespace("default")
+    table = catalog.create_table(
+        identifier="default.test_replace_reuse_manifest",
+        schema=Schema(),
+    )
+
+    file_a = DataFile.from_args(
+        file_path="s3://bucket/test/data/a.parquet",
+        file_format=FileFormat.PARQUET,
+        partition=Record(),
+        record_count=10,
+        file_size_in_bytes=100,
+        content=DataFileContent.DATA,
+    )
+    file_a.spec_id = 0
+
+    file_b = DataFile.from_args(
+        file_path="s3://bucket/test/data/b.parquet",
+        file_format=FileFormat.PARQUET,
+        partition=Record(),
+        record_count=10,
+        file_size_in_bytes=100,
+        content=DataFileContent.DATA,
+    )
+    file_b.spec_id = 0
+
+    file_c = DataFile.from_args(
+        file_path="s3://bucket/test/data/c.parquet",
+        file_format=FileFormat.PARQUET,
+        partition=Record(),
+        record_count=10,
+        file_size_in_bytes=100,
+        content=DataFileContent.DATA,
+    )
+    file_c.spec_id = 0
+
+    # Commit 1: Append file A (Creates Manifest 1)
+    with table.transaction() as tx:
+        with tx.update_snapshot().fast_append() as append_snapshot:
+            append_snapshot.append_data_file(file_a)
+
+    # Commit 2: Append file B (Creates Manifest 2)
+    with table.transaction() as tx:
+        with tx.update_snapshot().fast_append() as append_snapshot:
+            append_snapshot.append_data_file(file_b)
+
+    snapshot_before = table.current_snapshot()
+    manifests_before = snapshot_before.manifests(table.io)
+    assert len(manifests_before) == 2
+
+    # Identify which manifest belongs to file_b and file_a
+    manifest_b_path = None
+    manifest_a_path = None
+    for m in manifests_before:
+        entries = m.fetch_manifest_entry(table.io, discard_deleted=False)
+        if any(e.data_file.file_path == file_b.file_path for e in entries):
+            manifest_b_path = m.manifest_path
+        if any(e.data_file.file_path == file_a.file_path for e in entries):
+            manifest_a_path = m.manifest_path
+
+    assert manifest_b_path is not None
+    assert manifest_a_path is not None
+
+    # Commit 3: Replace file A with file C
+    with table.transaction() as tx:
+        with tx.update_snapshot().replace() as rewrite:
+            rewrite.delete_data_file(file_a)
+            rewrite.append_data_file(file_c)
+
+    snapshot_after = table.current_snapshot()
+    manifests_after = snapshot_after.manifests(table.io)
+    
+    # We expect 3 manifests: 
+    # 1. The reused one for file B
+    # 2. The newly rewritten one marking file A as DELETED
+    # 3. The new one for file C (ADDED)
+    assert len(manifests_after) == 3
+    
+    manifest_paths_after = [m.manifest_path for m in manifests_after]
+    
+    # ASSERTION 1: The untouched manifest is completely reused (the path matches exactly)
+    assert manifest_b_path in manifest_paths_after
+
+    # ASSERTION 2: File A's old manifest is NOT reused (since it was rewritten to change status to DELETED)
+    assert manifest_a_path not in manifest_paths_after
 
 
 def test_replace_empty_files(catalog: Catalog) -> None:
@@ -102,8 +230,211 @@ def test_replace_empty_files(catalog: Catalog) -> None:
     )
 
     # Replacing empty lists should not throw errors, but should produce no changes.
-    table.replace([], [])
+    with table.transaction() as tx:
+        with tx.update_snapshot().replace():
+            pass  # Entering and exiting the context manager without adding/deleting
 
     # History should be completely empty since no files were rewritten
     assert len(table.history()) == 0
     assert table.current_snapshot() is None
+
+
+def test_replace_missing_file_abort(catalog: Catalog) -> None:
+    # Setup a basic table
+    catalog.create_namespace("default")
+    table = catalog.create_table(
+        identifier="default.test_replace_missing",
+        schema=Schema(),
+    )
+
+    fake_data_file = DataFile.from_args(
+        file_path="s3://bucket/test/data/does_not_exist.parquet",
+        file_format=FileFormat.PARQUET,
+        partition=Record(),
+        record_count=100,
+        file_size_in_bytes=1024,
+        content=DataFileContent.DATA,
+    )
+    fake_data_file.spec_id = 0
+
+    new_data_file = DataFile.from_args(
+        file_path="s3://bucket/test/data/new.parquet",
+        file_format=FileFormat.PARQUET,
+        partition=Record(),
+        record_count=100,
+        file_size_in_bytes=1024,
+        content=DataFileContent.DATA,
+    )
+    new_data_file.spec_id = 0
+
+    # Ensure it aborts when trying to replace a file that isn't in the table
+    with pytest.raises(ValueError, match="Cannot delete files that are not present in the table"):
+        with table.transaction() as tx:
+            with tx.update_snapshot().replace() as rewrite:
+                rewrite.delete_data_file(fake_data_file)
+                rewrite.append_data_file(new_data_file)
+
+
+def test_replace_invariant_violation(catalog: Catalog) -> None:
+    # Setup a basic table
+    catalog.create_namespace("default")
+    table = catalog.create_table(
+        identifier="default.test_replace_invariant",
+        schema=Schema(),
+    )
+
+    file_to_delete = DataFile.from_args(
+        file_path="s3://bucket/test/data/deleted.parquet",
+        file_format=FileFormat.PARQUET,
+        partition=Record(),
+        record_count=100,
+        file_size_in_bytes=1024,
+        content=DataFileContent.DATA,
+    )
+    file_to_delete.spec_id = 0
+
+    # Create a new file with MORE records than the one we are deleting
+    too_many_records_file = DataFile.from_args(
+        file_path="s3://bucket/test/data/too_many.parquet",
+        file_format=FileFormat.PARQUET,
+        partition=Record(),
+        record_count=101, 
+        file_size_in_bytes=1024,
+        content=DataFileContent.DATA,
+    )
+    too_many_records_file.spec_id = 0
+
+    # Initially append to have something to replace
+    with table.transaction() as tx:
+        with tx.update_snapshot().fast_append() as append_snapshot:
+            append_snapshot.append_data_file(file_to_delete)
+
+    # Ensure it enforces the invariant: records added <= records removed
+    with pytest.raises(ValueError, match=r"Invalid replace: records added \(101\) exceeds records removed \(100\)"):
+        with table.transaction() as tx:
+            with tx.update_snapshot().replace() as rewrite:
+                rewrite.delete_data_file(file_to_delete)
+                rewrite.append_data_file(too_many_records_file)
+
+
+def test_replace_allows_shrinking_for_soft_deletes(catalog: Catalog) -> None:
+    # Setup a basic table
+    catalog.create_namespace("default")
+    table = catalog.create_table(
+        identifier="default.test_replace_shrink",
+        schema=Schema(),
+    )
+
+    # Old data file has 100 records
+    file_to_delete = DataFile.from_args(
+        file_path="s3://bucket/test/data/deleted.parquet",
+        file_format=FileFormat.PARQUET,
+        partition=Record(),
+        record_count=100,
+        file_size_in_bytes=1024,
+        content=DataFileContent.DATA,
+    )
+    file_to_delete.spec_id = 0
+
+    # New data file only has 90 records (simulating 10 records were soft-deleted)
+    shrunk_file_to_add = DataFile.from_args(
+        file_path="s3://bucket/test/data/shrunk.parquet",
+        file_format=FileFormat.PARQUET,
+        partition=Record(),
+        record_count=90, 
+        file_size_in_bytes=900,
+        content=DataFileContent.DATA,
+    )
+    shrunk_file_to_add.spec_id = 0
+
+    # Initially append
+    with table.transaction() as tx:
+        with tx.update_snapshot().fast_append() as append_snapshot:
+            append_snapshot.append_data_file(file_to_delete)
+
+    # This should succeed without throwing an invariant violation
+    with table.transaction() as tx:
+        with tx.update_snapshot().replace() as rewrite:
+            rewrite.delete_data_file(file_to_delete)
+            rewrite.append_data_file(shrunk_file_to_add)
+
+    snapshot = table.current_snapshot()
+    assert snapshot.summary["operation"] == Operation.REPLACE
+    assert snapshot.summary["added-records"] == "90"
+    assert snapshot.summary["deleted-records"] == "100"
+
+
+def test_replace_passes_through_delete_manifests(catalog: Catalog) -> None:
+    # Setup a basic table
+    catalog.create_namespace("default")
+    table = catalog.create_table(
+        identifier="default.test_replace_delete_manifests",
+        schema=Schema(),
+    )
+
+    # 1. Data file we will replace
+    file_a = DataFile.from_args(
+        file_path="s3://bucket/test/data/a.parquet",
+        file_format=FileFormat.PARQUET,
+        partition=Record(),
+        record_count=10,
+        file_size_in_bytes=100,
+        content=DataFileContent.DATA,
+    )
+    file_a.spec_id = 0
+
+    # 2. A Position Delete file (representing row-level deletes)
+    file_a_deletes = DataFile.from_args(
+        file_path="s3://bucket/test/data/a_deletes.parquet",
+        file_format=FileFormat.PARQUET,
+        partition=Record(),
+        record_count=2,
+        file_size_in_bytes=50,
+        content=DataFileContent.POSITION_DELETES,
+    )
+    file_a_deletes.spec_id = 0
+
+    # 3. Data file we are adding as a replacement
+    file_b = DataFile.from_args(
+        file_path="s3://bucket/test/data/b.parquet",
+        file_format=FileFormat.PARQUET,
+        partition=Record(),
+        record_count=10,
+        file_size_in_bytes=100,
+        content=DataFileContent.DATA,
+    )
+    file_b.spec_id = 0
+
+    # Commit 1: Append the data file
+    with table.transaction() as tx:
+        with tx.update_snapshot().fast_append() as append_snapshot:
+            append_snapshot.append_data_file(file_a)
+
+    # Commit 2: Append the delete file
+    with table.transaction() as tx:
+        with tx.update_snapshot().fast_append() as append_snapshot:
+            append_snapshot.append_data_file(file_a_deletes)
+
+    # Find the path of the delete manifest so we can verify it survives
+    snapshot_before = table.current_snapshot()
+    manifests_before = snapshot_before.manifests(table.io)
+    
+    delete_manifest_path = None
+    for m in manifests_before:
+        if m.content == ManifestContent.DELETES:
+            delete_manifest_path = m.manifest_path
+            
+    assert delete_manifest_path is not None
+
+    # Commit 3: Replace data file A with data file B
+    with table.transaction() as tx:
+        with tx.update_snapshot().replace() as rewrite:
+            rewrite.delete_data_file(file_a)
+            rewrite.append_data_file(file_b)
+
+    # Verify the delete manifest was passed through unchanged
+    snapshot_after = table.current_snapshot()
+    manifests_after = snapshot_after.manifests(table.io)
+    manifest_paths_after = [m.manifest_path for m in manifests_after]
+
+    assert delete_manifest_path in manifest_paths_after

--- a/tests/table/test_replace.py
+++ b/tests/table/test_replace.py
@@ -1,0 +1,92 @@
+import uuid
+import pytest
+from pyiceberg.manifest import DataFile, DataFileContent, FileFormat
+from pyiceberg.table.snapshots import Operation
+from pyiceberg.partitioning import PartitionSpec
+from pyiceberg.schema import Schema
+from pyiceberg.typedef import Record
+
+def test_replace_api(catalog):
+    # Setup a basic table using the catalog fixture
+    catalog.create_namespace("default")
+    table = catalog.create_table(
+        identifier="default.test_replace",
+        schema=Schema(),
+    )
+    
+    # Create mock DataFiles for the test
+    file_to_delete = DataFile.from_args(
+        file_path="s3://bucket/test/data/deleted.parquet",
+        file_format=FileFormat.PARQUET,
+        partition=Record(),
+        record_count=100,
+        file_size_in_bytes=1024,
+        content=DataFileContent.DATA,
+    )
+    file_to_delete.spec_id = 0
+    
+    file_to_add = DataFile.from_args(
+        file_path="s3://bucket/test/data/added.parquet",
+        file_format=FileFormat.PARQUET,
+        partition=Record(),
+        record_count=100,
+        file_size_in_bytes=1024,
+        content=DataFileContent.DATA,
+    )
+    file_to_add.spec_id = 0
+    
+    # Initially append to have something to replace
+    with table.transaction() as tx:
+        with tx.update_snapshot().fast_append() as append_snapshot:
+            append_snapshot.append_data_file(file_to_delete)
+    
+    # Verify initial append snapshot
+    assert len(table.history()) == 1
+    snapshot = table.current_snapshot()
+    assert snapshot.summary["operation"] == Operation.APPEND
+    
+    # Call the replace API
+    table.replace(
+        files_to_delete=[file_to_delete],
+        files_to_add=[file_to_add]
+    )
+    
+    # Verify the replacement created a REPLACE snapshot
+    assert len(table.history()) == 2
+    snapshot = table.current_snapshot()
+    assert snapshot.summary["operation"] == Operation.REPLACE
+    
+    # Verify the correct files are added and deleted
+    # The summary property tracks these counts
+    assert snapshot.summary["added-data-files"] == "1"
+    assert snapshot.summary["deleted-data-files"] == "1"
+    assert snapshot.summary["added-records"] == "100"
+    assert snapshot.summary["deleted-records"] == "100"
+
+    # Verify the new file exists in the new manifest
+    manifest_files = snapshot.manifests(table.io)
+    assert len(manifest_files) == 2 # One for ADDED, one for DELETED
+    
+    # Check that sequence numbers were handled properly natively by verifying the manifest contents
+    entries = []
+    for manifest in manifest_files:
+        for entry in manifest.fetch_manifest_entry(table.io, discard_deleted=False):
+            entries.append(entry)
+            
+    # One entry for ADDED (new file), one for DELETED (old file)
+    assert len(entries) == 2
+    
+def test_replace_empty_files(catalog):
+    # Setup a basic table using the catalog fixture
+    catalog.create_namespace("default")
+    table = catalog.create_table(
+        identifier="default.test_replace_empty",
+        schema=Schema(),
+    )
+    
+    # Replacing empty lists should not throw errors, but should produce no changes.
+    table.replace([], [])
+    
+    # History should be completely empty since no files were rewritten
+    assert len(table.history()) == 0
+    assert table.current_snapshot() is None

--- a/tests/table/test_replace.py
+++ b/tests/table/test_replace.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import cast
 import pytest
 from pyiceberg.catalog import Catalog
 from pyiceberg.manifest import (
@@ -25,7 +26,7 @@ from pyiceberg.manifest import (
     ManifestEntryStatus,
 )
 from pyiceberg.schema import Schema
-from pyiceberg.table.snapshots import Operation
+from pyiceberg.table.snapshots import Operation, Snapshot, Summary
 from pyiceberg.typedef import Record
 
 
@@ -76,9 +77,9 @@ def test_replace_internally(catalog: Catalog) -> None:
             append_snapshot.append_data_file(file_to_delete)
             append_snapshot.append_data_file(file_to_keep)
 
-    old_snapshot = table.current_snapshot()
+    old_snapshot = cast(Snapshot, table.current_snapshot())
     old_snapshot_id = old_snapshot.snapshot_id
-    old_sequence_number = old_snapshot.sequence_number
+    old_sequence_number = cast(int, old_snapshot.sequence_number)
 
     # Call the internal replace API
     with table.transaction() as tx:
@@ -86,8 +87,9 @@ def test_replace_internally(catalog: Catalog) -> None:
             rewrite.delete_data_file(file_to_delete)
             rewrite.append_data_file(file_to_add)
 
-    snapshot = table.current_snapshot()
-    
+    snapshot = cast(Snapshot, table.current_snapshot())
+    summary = cast(Summary, snapshot.summary)
+
     # 1. Has a unique snapshot ID
     assert snapshot.snapshot_id is not None
     assert snapshot.snapshot_id != old_snapshot_id
@@ -99,22 +101,22 @@ def test_replace_internally(catalog: Catalog) -> None:
     assert snapshot.sequence_number == old_sequence_number + 1
     
     # 4. Operation type is set to "replace"
-    assert snapshot.summary["operation"] == Operation.REPLACE
+    assert summary["operation"] == Operation.REPLACE
     
     # 5. Manifest list path is correct (just verify it exists and is a string path)
     assert snapshot.manifest_list is not None
     assert isinstance(snapshot.manifest_list, str)
     
     # 6. Summary counts are accurate
-    assert snapshot.summary["added-data-files"] == "1"
-    assert snapshot.summary["deleted-data-files"] == "1"
-    assert snapshot.summary["added-records"] == "100"
-    assert snapshot.summary["deleted-records"] == "100"
-    assert snapshot.summary["total-records"] == "150"
+    assert summary["added-data-files"] == "1"
+    assert summary["deleted-data-files"] == "1"
+    assert summary["added-records"] == "100"
+    assert summary["deleted-records"] == "100"
+    assert summary["total-records"] == "150"
 
     # Fetch all entries from the new manifests
     manifest_files = snapshot.manifests(table.io)
-    entries = []
+    entries: list[ManifestEntry] = []
     for manifest in manifest_files:
         entries.extend(manifest.fetch_manifest_entry(table.io, discard_deleted=False))
 
@@ -188,7 +190,7 @@ def test_replace_reuses_unaffected_manifests(catalog: Catalog) -> None:
         with tx.update_snapshot().fast_append() as append_snapshot:
             append_snapshot.append_data_file(file_b)
 
-    snapshot_before = table.current_snapshot()
+    snapshot_before = cast(Snapshot, table.current_snapshot())
     manifests_before = snapshot_before.manifests(table.io)
     assert len(manifests_before) == 2
 
@@ -211,7 +213,7 @@ def test_replace_reuses_unaffected_manifests(catalog: Catalog) -> None:
             rewrite.delete_data_file(file_a)
             rewrite.append_data_file(file_c)
 
-    snapshot_after = table.current_snapshot()
+    snapshot_after = cast(Snapshot, table.current_snapshot())
     assert snapshot_after is not None
     manifests_after = snapshot_after.manifests(table.io)
     
@@ -367,10 +369,12 @@ def test_replace_allows_shrinking_for_soft_deletes(catalog: Catalog) -> None:
             rewrite.delete_data_file(file_to_delete)
             rewrite.append_data_file(shrunk_file_to_add)
 
-    snapshot = table.current_snapshot()
-    assert snapshot.summary["operation"] == Operation.REPLACE
-    assert snapshot.summary["added-records"] == "90"
-    assert snapshot.summary["deleted-records"] == "100"
+    snapshot = cast(Snapshot, table.current_snapshot())
+    summary = cast(Summary, snapshot.summary)
+
+    assert summary["operation"] == Operation.REPLACE
+    assert summary["added-records"] == "90"
+    assert summary["deleted-records"] == "100"
 
 
 def test_replace_passes_through_delete_manifests(catalog: Catalog) -> None:
@@ -425,9 +429,9 @@ def test_replace_passes_through_delete_manifests(catalog: Catalog) -> None:
             append_snapshot.append_data_file(file_a_deletes)
 
     # Find the path of the delete manifest so we can verify it survives
-    snapshot_before = table.current_snapshot()
+    snapshot_before = cast(Snapshot, table.current_snapshot())
     manifests_before = snapshot_before.manifests(table.io)
-    
+
     delete_manifest_path = None
     for m in manifests_before:
         if m.content == ManifestContent.DELETES:
@@ -442,7 +446,7 @@ def test_replace_passes_through_delete_manifests(catalog: Catalog) -> None:
             rewrite.append_data_file(file_b)
 
     # Verify the delete manifest was passed through unchanged
-    snapshot_after = table.current_snapshot()
+    snapshot_after = cast(Snapshot, table.current_snapshot())
     assert snapshot_after is not None
     manifests_after = snapshot_after.manifests(table.io)
     manifest_paths_after = [m.manifest_path for m in manifests_after]

--- a/tests/table/test_replace.py
+++ b/tests/table/test_replace.py
@@ -14,9 +14,16 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import pytest
 from pyiceberg.catalog import Catalog
-from pyiceberg.manifest import DataFile, DataFileContent, FileFormat, ManifestEntryStatus
-from pyiceberg.schema import Schema
+from pyiceberg.manifest import (
+    DataFile,
+    DataFileContent,
+    FileFormat,
+    ManifestContent,
+    ManifestEntry,
+    ManifestEntryStatus,
+)from pyiceberg.schema import Schema
 from pyiceberg.table.snapshots import Operation
 from pyiceberg.typedef import Record
 
@@ -204,6 +211,7 @@ def test_replace_reuses_unaffected_manifests(catalog: Catalog) -> None:
             rewrite.append_data_file(file_c)
 
     snapshot_after = table.current_snapshot()
+    assert snapshot_after is not None
     manifests_after = snapshot_after.manifests(table.io)
     
     # We expect 3 manifests: 
@@ -434,6 +442,7 @@ def test_replace_passes_through_delete_manifests(catalog: Catalog) -> None:
 
     # Verify the delete manifest was passed through unchanged
     snapshot_after = table.current_snapshot()
+    assert snapshot_after is not None
     manifests_after = snapshot_after.manifests(table.io)
     manifest_paths_after = [m.manifest_path for m in manifests_after]
 

--- a/tests/table/test_replace.py
+++ b/tests/table/test_replace.py
@@ -15,7 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 from typing import cast
+
 import pytest
+
 from pyiceberg.catalog import Catalog
 from pyiceberg.manifest import (
     DataFile,
@@ -93,20 +95,20 @@ def test_replace_internally(catalog: Catalog) -> None:
     # 1. Has a unique snapshot ID
     assert snapshot.snapshot_id is not None
     assert snapshot.snapshot_id != old_snapshot_id
-    
+
     # 2. Parent points to the previous snapshot
     assert snapshot.parent_snapshot_id == old_snapshot_id
-    
+
     # 3. Sequence number is exactly previous + 1
     assert snapshot.sequence_number == old_sequence_number + 1
-    
+
     # 4. Operation type is set to "replace"
     assert summary["operation"] == Operation.REPLACE
-    
+
     # 5. Manifest list path is correct (just verify it exists and is a string path)
     assert snapshot.manifest_list is not None
     assert isinstance(snapshot.manifest_list, str)
-    
+
     # 6. Summary counts are accurate
     assert summary["added-data-files"] == "1"
     assert summary["deleted-data-files"] == "1"
@@ -122,7 +124,7 @@ def test_replace_internally(catalog: Catalog) -> None:
 
     # We expect 3 entries: ADDED, DELETED, and EXISTING
     assert len(entries) == 3
-    
+
     # Check ADDED
     added_entries = [e for e in entries if e.status == ManifestEntryStatus.ADDED]
     assert len(added_entries) == 1
@@ -216,15 +218,15 @@ def test_replace_reuses_unaffected_manifests(catalog: Catalog) -> None:
     snapshot_after = cast(Snapshot, table.current_snapshot())
     assert snapshot_after is not None
     manifests_after = snapshot_after.manifests(table.io)
-    
-    # We expect 3 manifests: 
+
+    # We expect 3 manifests:
     # 1. The reused one for file B
     # 2. The newly rewritten one marking file A as DELETED
     # 3. The new one for file C (ADDED)
     assert len(manifests_after) == 3
-    
+
     manifest_paths_after = [m.manifest_path for m in manifests_after]
-    
+
     # ASSERTION 1: The untouched manifest is completely reused (the path matches exactly)
     assert manifest_b_path in manifest_paths_after
 
@@ -309,7 +311,7 @@ def test_replace_invariant_violation(catalog: Catalog) -> None:
         file_path="s3://bucket/test/data/too_many.parquet",
         file_format=FileFormat.PARQUET,
         partition=Record(),
-        record_count=101, 
+        record_count=101,
         file_size_in_bytes=1024,
         content=DataFileContent.DATA,
     )
@@ -352,7 +354,7 @@ def test_replace_allows_shrinking_for_soft_deletes(catalog: Catalog) -> None:
         file_path="s3://bucket/test/data/shrunk.parquet",
         file_format=FileFormat.PARQUET,
         partition=Record(),
-        record_count=90, 
+        record_count=90,
         file_size_in_bytes=900,
         content=DataFileContent.DATA,
     )
@@ -436,7 +438,7 @@ def test_replace_passes_through_delete_manifests(catalog: Catalog) -> None:
     for m in manifests_before:
         if m.content == ManifestContent.DELETES:
             delete_manifest_path = m.manifest_path
-            
+
     assert delete_manifest_path is not None
 
     # Commit 3: Replace data file A with data file B

--- a/tests/table/test_replace.py
+++ b/tests/table/test_replace.py
@@ -23,7 +23,6 @@ from pyiceberg.manifest import (
     DataFile,
     DataFileContent,
     FileFormat,
-    ManifestContent,
     ManifestEntry,
     ManifestEntryStatus,
 )
@@ -385,6 +384,7 @@ def test_replace_passes_through_delete_manifests(catalog: Catalog) -> None:
     table = catalog.create_table(
         identifier="default.test_replace_delete_manifests",
         schema=Schema(),
+        properties={"format-version": "2"},
     )
 
     # 1. Data file we will replace
@@ -436,8 +436,10 @@ def test_replace_passes_through_delete_manifests(catalog: Catalog) -> None:
 
     delete_manifest_path = None
     for m in manifests_before:
-        if m.content == ManifestContent.DELETES:
+        entries = m.fetch_manifest_entry(table.io, discard_deleted=False)
+        if any(e.data_file.file_path == file_a_deletes.file_path for e in entries):
             delete_manifest_path = m.manifest_path
+            break
 
     assert delete_manifest_path is not None
 

--- a/tests/table/test_replace.py
+++ b/tests/table/test_replace.py
@@ -23,7 +23,8 @@ from pyiceberg.manifest import (
     ManifestContent,
     ManifestEntry,
     ManifestEntryStatus,
-)from pyiceberg.schema import Schema
+)
+from pyiceberg.schema import Schema
 from pyiceberg.table.snapshots import Operation
 from pyiceberg.typedef import Record
 

--- a/tests/table/test_replace.py
+++ b/tests/table/test_replace.py
@@ -1,0 +1,942 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import cast
+
+import pytest
+
+from pyiceberg.catalog import Catalog
+from pyiceberg.exceptions import ValidationException
+from pyiceberg.manifest import (
+    DataFile,
+    DataFileContent,
+    FileFormat,
+    ManifestEntry,
+    ManifestEntryStatus,
+)
+from pyiceberg.schema import Schema
+from pyiceberg.table.snapshots import Operation, Snapshot, Summary
+from pyiceberg.typedef import Record
+
+
+def _create_dummy_data_file(
+    file_path: str,
+    record_count: int,
+    file_size_in_bytes: int = 1024,
+    content: DataFileContent = DataFileContent.DATA,
+    partition: Record | None = None,
+    spec_id: int = 0,
+) -> DataFile:
+    if partition is None:
+        partition = Record()
+    df = DataFile.from_args(
+        file_path=file_path,
+        file_format=FileFormat.PARQUET,
+        partition=partition,
+        record_count=record_count,
+        file_size_in_bytes=file_size_in_bytes,
+        content=content,
+    )
+    df.spec_id = spec_id
+    return df
+
+
+def test_replace_internally(catalog: Catalog) -> None:
+    catalog.create_namespace("default")
+    table = catalog.create_table(
+        identifier="default.test_replace",
+        schema=Schema(),
+    )
+
+    file_to_delete = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/deleted.parquet",
+        record_count=100,
+    )
+
+    file_to_keep = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/kept.parquet",
+        record_count=50,
+        file_size_in_bytes=512,
+    )
+
+    file_to_add = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/added.parquet",
+        record_count=100,
+    )
+
+    # Initially append both files
+    with table.transaction() as tx:
+        with tx.update_snapshot().fast_append() as append_snapshot:
+            append_snapshot.append_data_file(file_to_delete)
+            append_snapshot.append_data_file(file_to_keep)
+
+    old_snapshot = cast(Snapshot, table.current_snapshot())
+    old_snapshot_id = old_snapshot.snapshot_id
+    old_sequence_number = cast(int, old_snapshot.sequence_number)
+
+    # Call the replace API
+    with table.transaction() as tx:
+        with tx.update_snapshot().replace() as rewrite:
+            rewrite.delete_data_file(file_to_delete)
+            rewrite.append_data_file(file_to_add)
+
+    snapshot = cast(Snapshot, table.current_snapshot())
+    summary = cast(Summary, snapshot.summary)
+
+    assert snapshot.snapshot_id is not None
+    assert snapshot.snapshot_id != old_snapshot_id
+    assert snapshot.parent_snapshot_id == old_snapshot_id
+    assert snapshot.sequence_number == old_sequence_number + 1
+    assert summary["operation"] == Operation.REPLACE
+    assert snapshot.manifest_list is not None
+    assert isinstance(snapshot.manifest_list, str)
+
+    # Summary counts
+    assert summary["added-data-files"] == "1"
+    assert summary["deleted-data-files"] == "1"
+    assert summary["added-records"] == "100"
+    assert summary["deleted-records"] == "100"
+    assert summary["total-records"] == "150"
+
+    # Fetch all entries from the new manifests
+    manifest_files = snapshot.manifests(table.io)
+    entries: list[ManifestEntry] = []
+    for manifest in manifest_files:
+        entries.extend(manifest.fetch_manifest_entry(table.io, discard_deleted=False))
+
+    assert len(entries) == 3
+
+    added_entries = [e for e in entries if e.status == ManifestEntryStatus.ADDED]
+    assert len(added_entries) == 1
+    assert added_entries[0].data_file.file_path == file_to_add.file_path
+    assert added_entries[0].snapshot_id == snapshot.snapshot_id
+
+    deleted_entries = [e for e in entries if e.status == ManifestEntryStatus.DELETED]
+    assert len(deleted_entries) == 1
+    assert deleted_entries[0].data_file.file_path == file_to_delete.file_path
+    assert deleted_entries[0].snapshot_id == snapshot.snapshot_id
+
+    existing_entries = [e for e in entries if e.status == ManifestEntryStatus.EXISTING]
+    assert len(existing_entries) == 1
+    assert existing_entries[0].data_file.file_path == file_to_keep.file_path
+    assert existing_entries[0].snapshot_id == old_snapshot_id
+    assert existing_entries[0].sequence_number == old_sequence_number
+
+
+def test_replace_reuses_unaffected_manifests(catalog: Catalog) -> None:
+    # Setup a basic table
+    catalog.create_namespace("default")
+    table = catalog.create_table(
+        identifier="default.test_replace_reuse_manifest",
+        schema=Schema(),
+    )
+
+    file_a = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/a.parquet",
+        record_count=10,
+        file_size_in_bytes=100,
+    )
+
+    file_b = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/b.parquet",
+        record_count=10,
+        file_size_in_bytes=100,
+    )
+
+    file_c = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/c.parquet",
+        record_count=10,
+        file_size_in_bytes=100,
+    )
+
+    # Commit 1: Append file A (Creates Manifest 1)
+    with table.transaction() as tx:
+        with tx.update_snapshot().fast_append() as append_snapshot:
+            append_snapshot.append_data_file(file_a)
+
+    # Commit 2: Append file B (Creates Manifest 2)
+    with table.transaction() as tx:
+        with tx.update_snapshot().fast_append() as append_snapshot:
+            append_snapshot.append_data_file(file_b)
+
+    snapshot_before = cast(Snapshot, table.current_snapshot())
+    manifests_before = snapshot_before.manifests(table.io)
+    assert len(manifests_before) == 2
+
+    # Identify which manifest belongs to file_b and file_a
+    manifest_b_path = None
+    manifest_a_path = None
+    for m in manifests_before:
+        entries = m.fetch_manifest_entry(table.io, discard_deleted=False)
+        if any(e.data_file.file_path == file_b.file_path for e in entries):
+            manifest_b_path = m.manifest_path
+        if any(e.data_file.file_path == file_a.file_path for e in entries):
+            manifest_a_path = m.manifest_path
+
+    assert manifest_b_path is not None
+    assert manifest_a_path is not None
+
+    # Commit 3: Replace file A with file C
+    with table.transaction() as tx:
+        with tx.update_snapshot().replace() as rewrite:
+            rewrite.delete_data_file(file_a)
+            rewrite.append_data_file(file_c)
+
+    snapshot_after = cast(Snapshot, table.current_snapshot())
+    assert snapshot_after is not None
+    manifests_after = snapshot_after.manifests(table.io)
+
+    # We expect 3 manifests:
+    # 1. The reused one for file B
+    # 2. The newly rewritten one marking file A as DELETED
+    # 3. The new one for file C (ADDED)
+    assert len(manifests_after) == 3
+
+    manifest_paths_after = [m.manifest_path for m in manifests_after]
+
+    # ASSERTION 1: The untouched manifest is reused (path matches exactly)
+    assert manifest_b_path in manifest_paths_after
+
+    # ASSERTION 2: File A's manifest was rewritten
+    assert manifest_a_path not in manifest_paths_after
+
+
+def test_replace_empty_files(catalog: Catalog) -> None:
+    catalog.create_namespace("default")
+    table = catalog.create_table(
+        identifier="default.test_replace_empty",
+        schema=Schema(),
+    )
+
+    # No-op replace should not produce a snapshot
+    with table.transaction() as tx:
+        with tx.update_snapshot().replace():
+            pass
+
+    assert len(table.history()) == 0
+    assert table.current_snapshot() is None
+
+
+def test_replace_missing_file_abort(catalog: Catalog) -> None:
+    # Setup a basic table
+    catalog.create_namespace("default")
+    table = catalog.create_table(
+        identifier="default.test_replace_missing",
+        schema=Schema(),
+    )
+
+    fake_data_file = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/does_not_exist.parquet",
+        record_count=100,
+    )
+
+    new_data_file = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/new.parquet",
+        record_count=100,
+    )
+
+    # Ensure it aborts when trying to replace a file that isn't in the table
+    with pytest.raises(ValidationException, match="missing data files to be rewritten"):
+        with table.transaction() as tx:
+            with tx.update_snapshot().replace() as rewrite:
+                rewrite.delete_data_file(fake_data_file)
+                rewrite.append_data_file(new_data_file)
+
+
+def test_replace_invariant_violation(catalog: Catalog) -> None:
+    # Setup a basic table
+    catalog.create_namespace("default")
+    table = catalog.create_table(
+        identifier="default.test_replace_invariant",
+        schema=Schema(),
+    )
+
+    file_to_delete = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/deleted.parquet",
+        record_count=100,
+    )
+
+    # Create a new file with MORE records than the one we are deleting
+    too_many_records_file = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/too_many.parquet",
+        record_count=101,
+    )
+
+    # Initially append to have something to replace
+    with table.transaction() as tx:
+        with tx.update_snapshot().fast_append() as append_snapshot:
+            append_snapshot.append_data_file(file_to_delete)
+
+    # Ensure it enforces the invariant: records added <= records removed
+    with pytest.raises(ValidationException, match=r"Invalid replace: records added \(101\) exceeds records removed \(100\)"):
+        with table.transaction() as tx:
+            with tx.update_snapshot().replace() as rewrite:
+                rewrite.delete_data_file(file_to_delete)
+                rewrite.append_data_file(too_many_records_file)
+
+
+def test_replace_allows_shrinking_for_soft_deletes(catalog: Catalog) -> None:
+    # Setup a basic table
+    catalog.create_namespace("default")
+    table = catalog.create_table(
+        identifier="default.test_replace_shrink",
+        schema=Schema(),
+    )
+
+    # Old data file has 100 records
+    file_to_delete = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/deleted.parquet",
+        record_count=100,
+    )
+
+    # New data file only has 90 records (simulating 10 records were soft-deleted)
+    shrunk_file_to_add = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/shrunk.parquet",
+        record_count=90,
+        file_size_in_bytes=900,
+    )
+
+    # Initially append
+    with table.transaction() as tx:
+        with tx.update_snapshot().fast_append() as append_snapshot:
+            append_snapshot.append_data_file(file_to_delete)
+
+    # This should succeed without throwing an invariant violation
+    with table.transaction() as tx:
+        with tx.update_snapshot().replace() as rewrite:
+            rewrite.delete_data_file(file_to_delete)
+            rewrite.append_data_file(shrunk_file_to_add)
+
+    snapshot = cast(Snapshot, table.current_snapshot())
+    summary = cast(Summary, snapshot.summary)
+
+    assert summary["operation"] == Operation.REPLACE
+    assert summary["added-records"] == "90"
+    assert summary["deleted-records"] == "100"
+
+
+def test_replace_passes_through_delete_manifests(catalog: Catalog) -> None:
+    catalog.create_namespace("default")
+    table = catalog.create_table(
+        identifier="default.test_replace_delete_manifests",
+        schema=Schema(),
+        properties={"format-version": "2"},
+    )
+
+    file_a = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/a.parquet",
+        record_count=10,
+        file_size_in_bytes=100,
+    )
+
+    file_a_deletes = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/a_deletes.parquet",
+        record_count=2,
+        file_size_in_bytes=50,
+        content=DataFileContent.POSITION_DELETES,
+    )
+
+    file_b = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/b.parquet",
+        record_count=10,
+        file_size_in_bytes=100,
+    )
+
+    # Commit 1: Append the data file
+    with table.transaction() as tx:
+        with tx.update_snapshot().fast_append() as append_snapshot:
+            append_snapshot.append_data_file(file_a)
+
+    # Commit 2: Append the delete file
+    with table.transaction() as tx:
+        with tx.update_snapshot().fast_append() as append_snapshot:
+            append_snapshot.append_data_file(file_a_deletes)
+
+    # Find the path of the delete manifest so we can verify it survives
+    snapshot_before = cast(Snapshot, table.current_snapshot())
+    manifests_before = snapshot_before.manifests(table.io)
+
+    delete_manifest_path = None
+    for m in manifests_before:
+        entries = m.fetch_manifest_entry(table.io, discard_deleted=False)
+        if any(e.data_file.file_path == file_a_deletes.file_path for e in entries):
+            delete_manifest_path = m.manifest_path
+            break
+
+    assert delete_manifest_path is not None
+
+    # Commit 3: Replace data file A with data file B
+    with table.transaction() as tx:
+        with tx.update_snapshot().replace() as rewrite:
+            rewrite.delete_data_file(file_a)
+            rewrite.append_data_file(file_b)
+
+    # Verify the delete manifest was passed through unchanged
+    snapshot_after = cast(Snapshot, table.current_snapshot())
+    assert snapshot_after is not None
+    manifests_after = snapshot_after.manifests(table.io)
+    manifest_paths_after = [m.manifest_path for m in manifests_after]
+
+    assert delete_manifest_path in manifest_paths_after
+
+
+def test_replace_multiple_files(catalog: Catalog) -> None:
+    # Setup a basic table
+    catalog.create_namespace("default")
+    table = catalog.create_table(
+        identifier="default.test_replace_multiple",
+        schema=Schema(),
+    )
+
+    file_1 = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/1.parquet",
+        record_count=100,
+    )
+
+    file_2 = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/2.parquet",
+        record_count=100,
+    )
+
+    file_1_new = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/1_new.parquet",
+        record_count=50,
+        file_size_in_bytes=512,
+    )
+
+    file_2_new = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/2_new.parquet",
+        record_count=50,
+        file_size_in_bytes=512,
+    )
+
+    # Append initial files
+    with table.transaction() as tx:
+        with tx.update_snapshot().fast_append() as append_snapshot:
+            append_snapshot.append_data_file(file_1)
+            append_snapshot.append_data_file(file_2)
+
+    # Replace both files with new ones
+    with table.transaction() as tx:
+        with tx.update_snapshot().replace() as rewrite:
+            rewrite.delete_data_file(file_1)
+            rewrite.delete_data_file(file_2)
+            rewrite.append_data_file(file_1_new)
+            rewrite.append_data_file(file_2_new)
+
+    snapshot = cast(Snapshot, table.current_snapshot())
+    summary = cast(Summary, snapshot.summary)
+
+    assert summary["added-data-files"] == "2"
+    assert summary["deleted-data-files"] == "2"
+    assert summary["added-records"] == "100"
+    assert summary["deleted-records"] == "200"
+    assert summary["total-records"] == "100"
+
+
+def test_replace_partitioned_table(catalog: Catalog) -> None:
+    from pyiceberg.partitioning import PartitionField, PartitionSpec
+    from pyiceberg.transforms import IdentityTransform
+    from pyiceberg.types import IntegerType, NestedField, StringType
+
+    # Setup a partitioned table
+    catalog.create_namespace("default")
+    schema = Schema(
+        NestedField(field_id=1, name="id", field_type=IntegerType(), required=True),
+        NestedField(field_id=2, name="data", field_type=StringType(), required=True),
+    )
+    spec = PartitionSpec(PartitionField(source_id=1, field_id=1001, transform=IdentityTransform(), name="id"))
+    table = catalog.create_table(
+        identifier="default.test_replace_partitioned",
+        schema=schema,
+        partition_spec=spec,
+    )
+
+    # File in partition id=1
+    file_part1 = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/part1.parquet",
+        partition=Record(1),
+        record_count=100,
+        spec_id=table.spec().spec_id,
+    )
+
+    # File in partition id=2
+    file_part2 = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/part2.parquet",
+        partition=Record(2),
+        record_count=100,
+        spec_id=table.spec().spec_id,
+    )
+
+    # Add initial files
+    with table.transaction() as tx:
+        with tx.update_snapshot().fast_append() as append_snapshot:
+            append_snapshot.append_data_file(file_part1)
+            append_snapshot.append_data_file(file_part2)
+
+    # Replace file in partition 1
+    file_part1_new = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/part1_new.parquet",
+        partition=Record(1),
+        record_count=50,
+        file_size_in_bytes=512,
+        spec_id=table.spec().spec_id,
+    )
+
+    with table.transaction() as tx:
+        with tx.update_snapshot().replace() as rewrite:
+            rewrite.delete_data_file(file_part1)
+            rewrite.append_data_file(file_part1_new)
+
+    snapshot = cast(Snapshot, table.current_snapshot())
+    summary = cast(Summary, snapshot.summary)
+
+    assert summary["added-data-files"] == "1"
+    assert summary["deleted-data-files"] == "1"
+    assert summary["total-records"] == "150"
+
+
+def test_replace_no_op_on_non_empty_table(catalog: Catalog) -> None:
+    # Setup a basic table
+    catalog.create_namespace("default")
+    table = catalog.create_table(
+        identifier="default.test_replace_noop_nonempty",
+        schema=Schema(),
+    )
+
+    file_a = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/a.parquet",
+        record_count=10,
+        file_size_in_bytes=100,
+    )
+
+    # Commit 1: Append file A
+    with table.transaction() as tx:
+        with tx.update_snapshot().fast_append() as append_snapshot:
+            append_snapshot.append_data_file(file_a)
+
+    initial_snapshot = table.current_snapshot()
+    assert initial_snapshot is not None
+
+    # Perform a no-op replace
+    with table.transaction() as tx:
+        with tx.update_snapshot().replace():
+            pass
+
+    # Successive calls to current_snapshot() should yield the same snapshot
+    assert table.current_snapshot() == initial_snapshot
+    assert len(table.history()) == 1
+
+
+def test_replace_on_custom_branch(catalog: Catalog) -> None:
+    catalog.create_namespace("default")
+    table = catalog.create_table(
+        identifier="default.test_replace_branch",
+        schema=Schema(),
+    )
+
+    file_to_delete = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/deleted.parquet",
+        record_count=100,
+    )
+
+    file_to_add = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/added.parquet",
+        record_count=100,
+    )
+
+    # Initially append to have something to replace on main
+    with table.transaction() as tx:
+        with tx.update_snapshot().fast_append() as append_snapshot:
+            append_snapshot.append_data_file(file_to_delete)
+
+    initial_main_snapshot = cast(Snapshot, table.current_snapshot())
+    initial_main_snapshot_id = initial_main_snapshot.snapshot_id
+
+    # Create a new branch called "test-branch" pointing to the initial snapshot
+    table.manage_snapshots().create_branch(branch_name="test-branch", snapshot_id=initial_main_snapshot_id).commit()
+
+    # Perform a replace() operation explicitly targeting "test-branch"
+    with table.transaction() as tx:
+        with tx.update_snapshot(branch="test-branch").replace() as rewrite:
+            rewrite.delete_data_file(file_to_delete)
+            rewrite.append_data_file(file_to_add)
+
+    # Reload table to get updated refs
+    table = catalog.load_table("default.test_replace_branch")
+
+    test_branch_ref = table.metadata.refs["test-branch"]
+    main_branch_ref = table.metadata.refs["main"]
+
+    # Assert that the operation was successful on test-branch
+    assert test_branch_ref.snapshot_id != initial_main_snapshot_id
+
+    # Assert that the "test-branch" reference now points to a REPLACE snapshot
+    new_snapshot = table.snapshot_by_id(test_branch_ref.snapshot_id)
+    assert new_snapshot is not None
+    summary = cast(Summary, new_snapshot.summary)
+    assert summary["operation"] == Operation.REPLACE
+
+    # Assert that the "main" branch reference was completely untouched
+    assert main_branch_ref.snapshot_id == initial_main_snapshot_id
+
+
+def test_replace_retries_on_concurrent_append(catalog: Catalog) -> None:
+    """Replace should succeed via retry when a concurrent append lands in a different partition."""
+    from pyiceberg.partitioning import PartitionField, PartitionSpec
+    from pyiceberg.transforms import IdentityTransform
+    from pyiceberg.types import IntegerType, NestedField, StringType
+
+    catalog.create_namespace("default")
+    schema = Schema(
+        NestedField(field_id=1, name="id", field_type=IntegerType(), required=True),
+        NestedField(field_id=2, name="data", field_type=StringType(), required=True),
+    )
+    spec = PartitionSpec(PartitionField(source_id=1, field_id=1001, transform=IdentityTransform(), name="id"))
+    table = catalog.create_table(
+        identifier="default.test_replace_retry_append",
+        schema=schema,
+        partition_spec=spec,
+    )
+
+    # File in partition id=1
+    file_a = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/a.parquet",
+        record_count=100,
+        partition=Record(1),
+        spec_id=table.spec().spec_id,
+    )
+
+    # Append file_a to partition 1
+    with table.transaction() as tx:
+        with tx.update_snapshot().fast_append() as append_snapshot:
+            append_snapshot.append_data_file(file_a)
+
+    # Load two references to simulate concurrent access
+    tbl1 = catalog.load_table("default.test_replace_retry_append")
+    tbl2 = catalog.load_table("default.test_replace_retry_append")
+
+    # tbl1 appends a new file to a DIFFERENT partition (non-conflicting)
+    unrelated_file = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/unrelated.parquet",
+        record_count=50,
+        partition=Record(2),
+        spec_id=table.spec().spec_id,
+    )
+    with tbl1.transaction() as tx:
+        with tx.update_snapshot().fast_append() as append_snapshot:
+            append_snapshot.append_data_file(unrelated_file)
+
+    # tbl2 replaces file_a with file_b in partition 1 — should succeed via retry
+    file_b = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/b.parquet",
+        record_count=100,
+        partition=Record(1),
+        spec_id=table.spec().spec_id,
+    )
+    with tbl2.transaction() as tx:
+        with tx.update_snapshot().replace() as rewrite:
+            rewrite.delete_data_file(file_a)
+            rewrite.append_data_file(file_b)
+
+    refreshed = catalog.load_table("default.test_replace_retry_append")
+    snapshot = cast(Snapshot, refreshed.current_snapshot())
+    summary = cast(Summary, snapshot.summary)
+
+    # The replace landed successfully after retry
+    assert summary["operation"] == Operation.REPLACE
+
+
+def test_replace_raises_on_concurrent_delete_of_same_file(catalog: Catalog) -> None:
+    """Replace should raise ValidationException when a concurrent commit deletes the same file."""
+    catalog.create_namespace("default")
+    table = catalog.create_table(
+        identifier="default.test_replace_conflict",
+        schema=Schema(),
+    )
+
+    file_a = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/a.parquet",
+        record_count=100,
+    )
+
+    # Append file_a
+    with table.transaction() as tx:
+        with tx.update_snapshot().fast_append() as append_snapshot:
+            append_snapshot.append_data_file(file_a)
+
+    # Load two references
+    tbl1 = catalog.load_table("default.test_replace_conflict")
+    tbl2 = catalog.load_table("default.test_replace_conflict")
+
+    # tbl1 replaces file_a first
+    file_b = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/b.parquet",
+        record_count=100,
+    )
+    with tbl1.transaction() as tx:
+        with tx.update_snapshot().replace() as rewrite:
+            rewrite.delete_data_file(file_a)
+            rewrite.append_data_file(file_b)
+
+    # tbl2 tries to replace the same file_a — should fail
+    file_c = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/c.parquet",
+        record_count=100,
+    )
+    with pytest.raises(ValidationException):
+        with tbl2.transaction() as tx:
+            with tx.update_snapshot().replace() as rewrite:
+                rewrite.delete_data_file(file_a)
+                rewrite.append_data_file(file_c)
+
+
+def test_replace_refresh_for_retry_clears_cached_entries(catalog: Catalog) -> None:
+    """Verify that _refresh_for_retry clears the cached deleted entries."""
+    catalog.create_namespace("default")
+    table = catalog.create_table(
+        identifier="default.test_replace_refresh",
+        schema=Schema(),
+    )
+
+    from pyiceberg.table import Transaction
+    from pyiceberg.table.update.snapshot import _RewriteFiles
+
+    file_a = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/a.parquet",
+        record_count=100,
+    )
+
+    # Append file_a
+    with table.transaction() as tx:
+        with tx.update_snapshot().fast_append() as append_snapshot:
+            append_snapshot.append_data_file(file_a)
+
+    tx = Transaction(table, autocommit=False)
+    producer = _RewriteFiles(
+        operation=Operation.REPLACE,
+        transaction=tx,
+        io=table.io,
+    )
+    producer.delete_data_file(file_a)
+
+    # Force computation of the cached property
+    entries = producer._cached_deleted_entries
+    assert len(entries) == 1
+    assert "_cached_deleted_entries" in producer.__dict__
+
+    # Simulate retry
+    producer._refresh_for_retry()
+
+    # The cached property should be cleared
+    assert "_cached_deleted_entries" not in producer.__dict__
+
+
+def test_replace_concurrent_replace_different_files_retries_successfully(catalog: Catalog) -> None:
+    """Two concurrent replaces on different files should both succeed (second via retry)."""
+    from pyiceberg.partitioning import PartitionField, PartitionSpec
+    from pyiceberg.transforms import IdentityTransform
+    from pyiceberg.types import IntegerType, NestedField, StringType
+
+    catalog.create_namespace("default")
+    schema = Schema(
+        NestedField(field_id=1, name="id", field_type=IntegerType(), required=True),
+        NestedField(field_id=2, name="data", field_type=StringType(), required=True),
+    )
+    spec = PartitionSpec(PartitionField(source_id=1, field_id=1001, transform=IdentityTransform(), name="id"))
+    table = catalog.create_table(
+        identifier="default.test_replace_diff_files",
+        schema=schema,
+        partition_spec=spec,
+    )
+
+    file_part1 = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/part1.parquet",
+        record_count=100,
+        partition=Record(1),
+        spec_id=table.spec().spec_id,
+    )
+    file_part2 = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/part2.parquet",
+        record_count=100,
+        partition=Record(2),
+        spec_id=table.spec().spec_id,
+    )
+
+    # Append both files
+    with table.transaction() as tx:
+        with tx.update_snapshot().fast_append() as append_snapshot:
+            append_snapshot.append_data_file(file_part1)
+            append_snapshot.append_data_file(file_part2)
+
+    tbl1 = catalog.load_table("default.test_replace_diff_files")
+    tbl2 = catalog.load_table("default.test_replace_diff_files")
+
+    # tbl1 replaces file in partition 1
+    new_part1 = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/part1_new.parquet",
+        record_count=100,
+        partition=Record(1),
+        spec_id=table.spec().spec_id,
+    )
+    with tbl1.transaction() as tx:
+        with tx.update_snapshot().replace() as rewrite:
+            rewrite.delete_data_file(file_part1)
+            rewrite.append_data_file(new_part1)
+
+    # tbl2 replaces file in partition 2 — different partition, should succeed via retry
+    new_part2 = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/part2_new.parquet",
+        record_count=100,
+        partition=Record(2),
+        spec_id=table.spec().spec_id,
+    )
+    with tbl2.transaction() as tx:
+        with tx.update_snapshot().replace() as rewrite:
+            rewrite.delete_data_file(file_part2)
+            rewrite.append_data_file(new_part2)
+
+    refreshed = catalog.load_table("default.test_replace_diff_files")
+    snapshot = cast(Snapshot, refreshed.current_snapshot())
+    summary = cast(Summary, snapshot.summary)
+    assert summary["operation"] == Operation.REPLACE
+
+    # Both replaces landed — all entries should reference the new files
+    entries: list[ManifestEntry] = []
+    for m in snapshot.manifests(refreshed.io):
+        entries.extend(m.fetch_manifest_entry(refreshed.io, discard_deleted=True))
+    file_paths = {e.data_file.file_path for e in entries}
+    assert "s3://bucket/test/data/part1_new.parquet" in file_paths
+    assert "s3://bucket/test/data/part2_new.parquet" in file_paths
+    assert "s3://bucket/test/data/part1.parquet" not in file_paths
+    assert "s3://bucket/test/data/part2.parquet" not in file_paths
+
+
+def test_replace_does_not_conflict_with_same_partition_append(catalog: Catalog) -> None:
+    """Replace should NOT conflict with a concurrent append to the same partition.
+
+    This validates the key behavioral difference from the base _validate_concurrency:
+    Java's BaseRewriteFiles does not call validateAddedDataFiles, so concurrent appends
+    (even to the same partition) are not conflicts for a replace operation.
+    """
+    catalog.create_namespace("default")
+    table = catalog.create_table(
+        identifier="default.test_replace_no_append_conflict",
+        schema=Schema(),
+    )
+
+    file_a = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/a.parquet",
+        record_count=100,
+    )
+
+    # Append file_a
+    with table.transaction() as tx:
+        with tx.update_snapshot().fast_append() as append_snapshot:
+            append_snapshot.append_data_file(file_a)
+
+    tbl1 = catalog.load_table("default.test_replace_no_append_conflict")
+    tbl2 = catalog.load_table("default.test_replace_no_append_conflict")
+
+    # tbl1 appends to the SAME (unpartitioned) table — this is NOT a conflict for replace
+    appended_file = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/appended.parquet",
+        record_count=50,
+    )
+    with tbl1.transaction() as tx:
+        with tx.update_snapshot().fast_append() as append_snapshot:
+            append_snapshot.append_data_file(appended_file)
+
+    # tbl2 replaces file_a — should succeed even though the append was to the same table
+    file_b = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/b.parquet",
+        record_count=100,
+    )
+    with tbl2.transaction() as tx:
+        with tx.update_snapshot().replace() as rewrite:
+            rewrite.delete_data_file(file_a)
+            rewrite.append_data_file(file_b)
+
+    refreshed = catalog.load_table("default.test_replace_no_append_conflict")
+    snapshot = cast(Snapshot, refreshed.current_snapshot())
+    summary = cast(Summary, snapshot.summary)
+    assert summary["operation"] == Operation.REPLACE
+
+    # All three files should be live: appended + replacement
+    entries: list[ManifestEntry] = []
+    for m in snapshot.manifests(refreshed.io):
+        entries.extend(m.fetch_manifest_entry(refreshed.io, discard_deleted=True))
+    file_paths = {e.data_file.file_path for e in entries}
+    assert "s3://bucket/test/data/b.parquet" in file_paths
+    assert "s3://bucket/test/data/appended.parquet" in file_paths
+    assert "s3://bucket/test/data/a.parquet" not in file_paths
+
+
+def test_replace_only_deletes_without_adds(catalog: Catalog) -> None:
+    """Replace with files_to_delete but no files_to_add should succeed (pure compaction removal)."""
+    catalog.create_namespace("default")
+    table = catalog.create_table(
+        identifier="default.test_replace_delete_only",
+        schema=Schema(),
+    )
+
+    file_a = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/a.parquet",
+        record_count=100,
+    )
+
+    with table.transaction() as tx:
+        with tx.update_snapshot().fast_append() as append_snapshot:
+            append_snapshot.append_data_file(file_a)
+
+    # Delete file_a without adding anything (records go from 100 to 0 — added <= deleted)
+    with table.transaction() as tx:
+        with tx.update_snapshot().replace() as rewrite:
+            rewrite.delete_data_file(file_a)
+
+    snapshot = cast(Snapshot, table.current_snapshot())
+    summary = cast(Summary, snapshot.summary)
+    assert summary["operation"] == Operation.REPLACE
+    assert summary["deleted-data-files"] == "1"
+    assert summary["deleted-records"] == "100"
+    assert summary["total-records"] == "0"
+
+
+def test_replace_only_adds_raises_without_deletes(catalog: Catalog) -> None:
+    """Replace with files_to_add but no files_to_delete should still commit.
+
+    Unlike Java (which requires files-to-delete to be non-empty), PyIceberg's
+    _RewriteFiles allows add-only commits. This is a deliberate simplification
+    — the added_records <= deleted_records check will catch truly invalid cases.
+    An add-only replace with 0 deleted records means added_records > 0 > 0 which
+    would violate the invariant and raise.
+    """
+    catalog.create_namespace("default")
+    table = catalog.create_table(
+        identifier="default.test_replace_add_only",
+        schema=Schema(),
+    )
+
+    new_file = _create_dummy_data_file(
+        file_path="s3://bucket/test/data/new.parquet",
+        record_count=100,
+    )
+
+    # Adding without deleting: added_records (100) > deleted_records (0) → should raise
+    with pytest.raises(ValidationException, match="Invalid replace"):
+        with table.transaction() as tx:
+            with tx.update_snapshot().replace() as rewrite:
+                rewrite.append_data_file(new_file)

--- a/tests/table/test_snapshots.py
+++ b/tests/table/test_snapshots.py
@@ -398,7 +398,7 @@ def test_merge_snapshot_summaries_overwrite_summary() -> None:
 
 def test_invalid_operation() -> None:
     with pytest.raises(ValueError) as e:
-        update_snapshot_summaries(summary=Summary(Operation("invalid")))  # type: ignore
+        update_snapshot_summaries(summary=Summary(Operation("invalid")))
     assert "Operation not implemented: Operation" in str(e.value)
 
 

--- a/tests/table/test_snapshots.py
+++ b/tests/table/test_snapshots.py
@@ -398,8 +398,8 @@ def test_merge_snapshot_summaries_overwrite_summary() -> None:
 
 def test_invalid_operation() -> None:
     with pytest.raises(ValueError) as e:
-        update_snapshot_summaries(summary=Summary(Operation("invalid")))
-    assert "Operation not implemented: Operation" in str(e.value)
+        update_snapshot_summaries(summary=Summary.model_construct(operation="unknown_operation"))
+    assert "Operation not implemented: unknown_operation" in str(e.value)
 
 
 def test_invalid_type() -> None:

--- a/tests/table/test_snapshots.py
+++ b/tests/table/test_snapshots.py
@@ -398,8 +398,8 @@ def test_merge_snapshot_summaries_overwrite_summary() -> None:
 
 def test_invalid_operation() -> None:
     with pytest.raises(ValueError) as e:
-        update_snapshot_summaries(summary=Summary(Operation.REPLACE))
-    assert "Operation not implemented: Operation.REPLACE" in str(e.value)
+        update_snapshot_summaries(summary=Summary(Operation("invalid")))  # type: ignore
+    assert "Operation not implemented: Operation" in str(e.value)
 
 
 def test_invalid_type() -> None:

--- a/tests/table/test_snapshots.py
+++ b/tests/table/test_snapshots.py
@@ -409,8 +409,8 @@ def test_merge_snapshot_summaries_overwrite_summary() -> None:
 
 def test_invalid_operation() -> None:
     with pytest.raises(ValueError) as e:
-        update_snapshot_summaries(summary=Summary(Operation.REPLACE))
-    assert "Operation not implemented: Operation.REPLACE" in str(e.value)
+        update_snapshot_summaries(summary=Summary.model_construct(operation="unknown_operation"))
+    assert "Operation not implemented: unknown_operation" in str(e.value)
 
 
 def test_invalid_type() -> None:


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
Closes #3130

# Rationale for this change
In a current PR (#3124, part of #1092), the proposed `replace()` API accepts a PyArrow dataframe (`pa.Table`), forcing the table engine to physically serialize data during a metadata transaction commit. This couples execution with the catalog, diverges from Java Iceberg's native `RewriteFiles` builder behavior, and fails to register under `Operation.REPLACE`. 

This PR redesigns `table.replace()` and `transaction.replace()` to accept `Iterable[DataFile]` inputs. By externalizing physical data writing (e.g., compaction via Ray), the new explicit metadata-only `_RewriteFiles` SnapshotProducer can natively swap snapshot pointers in the manifests, perfectly inheriting ancestral sequence numbers for `DELETED` entries to ensure time-travel equivalence.

## Are these changes tested?
**Yes.**

Fully exhaustive test coverage has been added to `tests/table/test_replace.py`. The suite validates:
1. Context manager executions tracking valid history growth (`len(table.history())`).
2. Snapshot summary bindings asserting strict `Operation.REPLACE` tags.
3. Accurate evaluation of delta-metrics (added/deleted files and records tracking perfectly).
4. **Low-level serialization:** Bypassed high-level discard filters on `manifest.fetch_manifest_entry(discard_deleted=False)` to natively assert that `status=DELETED` overrides are accurately preserving avro sequence numbers.
5. Idempotent edge cases where `replace([], [])` successfully short-circuits the commit loop without mutating history.

## Are there any user-facing changes?
**Yes.**

The method signature for `Table.replace()` and `Transaction.replace()` has been updated from the original PR #3124. 
It no longer accepts a PyArrow DataFrame (`df: pa.Table`). Instead, it now requests two arguments:
`files_to_delete: Iterable[DataFile]` and `files_to_add: Iterable[DataFile]`, following the convention seen in the Java implementation.

<!-- In the case of user-facing changes, please add the changelog label. -->
*(Please add the `changelog` label)*

## AI Disclosure
AI was used to help understand the code base and draft code changes. All code changes have been thoroughly reviewed, ensuring that the code changes are in line with a broader understanding of the codebase.

- Worth deeper review after AI-assistance:
- The `test_invalid_operation()` in `tests/table/test_snapshots.py` previously used `Operation.REPLACE` as a value to test invalid operations, but with this change `Operation.REPLACE` becomes valid. In place I just put a dummy Operation.
- The `_RewriteFiles` in `pyiceberg/table/update/snapshot.py` overrides the `_deleted_entries` and `_existing_manifests` functions. I sought to test this thoroughly that it was done correctly. I am thinking it's possible to improve the test suite to make this more rigorous. I am open to suggestions on how that could be done.