### PR TITLE
Skip catalog loading for the version command

### DIFF
--- a/pyiceberg/cli/console.py
+++ b/pyiceberg/cli/console.py
@@ -101,6 +101,9 @@ def run(
     else:
         ctx.obj["output"] = JsonOutput(verbose=verbose)
 
+    if ctx.invoked_subcommand == "version":
+        return
+
     try:
         ctx.obj["catalog"] = load_catalog(catalog, **properties)
     except Exception as e:

--- a/tests/cli/test_console.py
+++ b/tests/cli/test_console.py
@@ -25,6 +25,7 @@ import pytest
 from click.testing import CliRunner
 from pytest_mock import MockFixture
 
+from pyiceberg import __version__
 from pyiceberg.catalog.memory import InMemoryCatalog
 from pyiceberg.cli.console import run
 from pyiceberg.io import WAREHOUSE
@@ -59,6 +60,17 @@ def test_hive_catalog_missing_uri_shows_helpful_error(mocker: MockFixture) -> No
     assert result.exit_code == 1
     assert "URI missing, please provide using --uri" in result.output
     assert "'uri'" not in result.output
+
+
+def test_version_does_not_load_catalog(mocker: MockFixture) -> None:
+    mock_load_catalog = mocker.patch("pyiceberg.cli.console.load_catalog", side_effect=Exception("should not be called"))
+
+    runner = CliRunner()
+    result = runner.invoke(run, ["version"])
+
+    assert result.exit_code == 0
+    assert result.output == f"{__version__}\n"
+    mock_load_catalog.assert_not_called()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
  # Rationale for this change

  `pyiceberg version` should print the installed PyIceberg version even when `.pyiceberg.yaml` or catalog-related environment variables are invalid. CLI group callback eagerly loads the catalog for every subcommand, so `version` can fail before it prints anything.

This change skips catalog loading for the `version` subcommand and adds a regression test for that behavior.

  ## Are these changes tested?

  Yes.

  - Added `test_version_does_not_load_catalog` in `tests/cli/test_console.py`

  ## Are there any user-facing changes?

  Yes.

  - `pyiceberg version` now prints the version without requiring valid catalog configuration.