### PR TITLE
Add labels support to LoadTableResponse and Table

### DIFF
--- a/pyiceberg/catalog/rest/__init__.py
+++ b/pyiceberg/catalog/rest/__init__.py
@@ -278,6 +278,7 @@ class TableResponse(IcebergBaseModel):
     metadata: TableMetadata
     config: Properties = Field(default_factory=dict)
     storage_credentials: list[StorageCredential] = Field(alias="storage-credentials", default_factory=list)
+    labels: dict[str, Any] = Field(default_factory=dict)
 
 
 class ViewResponse(IcebergBaseModel):
@@ -805,6 +806,7 @@ class RestCatalog(Catalog):
             ),
             catalog=self,
             config=table_response.config,
+            labels=table_response.labels,
         )
 
     def _response_to_staged_table(self, identifier_tuple: tuple[str, ...], table_response: TableResponse) -> StagedTable:

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -1049,6 +1049,7 @@ class Table:
     io: FileIO
     catalog: Catalog
     config: dict[str, str]
+    labels: dict[str, Any]
 
     def __init__(
         self,
@@ -1058,6 +1059,7 @@ class Table:
         io: FileIO,
         catalog: Catalog,
         config: dict[str, str] = EMPTY_DICT,
+        labels: dict[str, Any] | None = None,
     ) -> None:
         self._identifier = identifier
         self.metadata = metadata
@@ -1065,6 +1067,24 @@ class Table:
         self.io = io
         self.catalog = catalog
         self.config = config
+        self.labels = labels or {}
+
+    @property
+    def table_labels(self) -> dict[str, str]:
+        """Table-level labels from catalog enrichment."""
+        return self.labels.get("table", {})
+
+    @property
+    def column_labels(self) -> list[dict[str, Any]]:
+        """Column-level labels from catalog enrichment."""
+        return self.labels.get("columns", [])
+
+    def get_column_label(self, field_id: int) -> dict[str, str]:
+        """Get labels for a specific column by field-id."""
+        for col in self.column_labels:
+            if col.get("field-id") == field_id:
+                return col.get("labels", {})
+        return {}
 
     def transaction(self) -> Transaction:
         """Create a new transaction object to first stage the changes, and then commit them to the catalog.


### PR DESCRIPTION
Adds optional labels field to IRC LoadTableResponse, parsed by the REST catalog client and exposed on Table objects.

- TableResponse: new labels dict field (default empty, backward compatible)
- Table: labels property + table_labels, column_labels, get_column_label()
- Column labels keyed by field-id for stability across schema evolution

Proof-of-concept for the IRC Labels proposal: https://github.com/apache/iceberg/issues/15521.

<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

## Are these changes tested?

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
