### PR TITLE
feat(cli): deprecate version command in favor of --version flag

### DIFF
--- a/pyiceberg/cli/console.py
+++ b/pyiceberg/cli/console.py
@@ -236,7 +236,7 @@ def location(ctx: Context, identifier: str) -> None:
 @click.pass_context
 @catch_exception()
 def version(ctx: Context) -> None:
-    """Print the installed pyiceberg package number (deprecated, use --version instead)."""
+    """Print the installed pyiceberg package version. Deprecated: use --version instead."""
     click.echo(
         "Deprecation warning: the `version` command is deprecated and will be removed in 0.13.0. "
         "Please use `pyiceberg --version` instead.",

--- a/pyiceberg/cli/console.py
+++ b/pyiceberg/cli/console.py
@@ -33,7 +33,6 @@ from pyiceberg.exceptions import NoSuchNamespaceError, NoSuchPropertyException, 
 from pyiceberg.io import WAREHOUSE
 from pyiceberg.table import TableProperties
 from pyiceberg.table.refs import SnapshotRef, SnapshotRefType
-from pyiceberg.utils.deprecated import deprecation_message
 from pyiceberg.utils.properties import property_as_int
 
 
@@ -237,14 +236,9 @@ def location(ctx: Context, identifier: str) -> None:
 @click.pass_context
 @catch_exception()
 def version(ctx: Context) -> None:
-    """Print pyiceberg's installed package number (deprecated, use ``--version`` instead)."""
-    deprecation_message(
-        deprecated_in="0.11.0",
-        removed_in="1.0.0",
-        help_message="Please use `pyiceberg --version` instead of `pyiceberg version`",
-    )
+    """Print the installed pyiceberg package number (deprecated, use --version instead)."""
     click.echo(
-        "Deprecation warning: the `version` command is deprecated and will be removed in 1.0.0. "
+        "Deprecation warning: the `version` command is deprecated and will be removed in 0.13.0. "
         "Please use `pyiceberg --version` instead.",
         err=True,
     )

--- a/pyiceberg/cli/console.py
+++ b/pyiceberg/cli/console.py
@@ -33,6 +33,7 @@ from pyiceberg.exceptions import NoSuchNamespaceError, NoSuchPropertyException, 
 from pyiceberg.io import WAREHOUSE
 from pyiceberg.table import TableProperties
 from pyiceberg.table.refs import SnapshotRef, SnapshotRefType
+from pyiceberg.utils.deprecated import deprecation_message
 from pyiceberg.utils.properties import property_as_int
 
 
@@ -54,6 +55,7 @@ def catch_exception() -> Callable:  # type: ignore
 
 
 @click.group()
+@click.version_option(__version__, message="%(version)s")
 @click.option("--catalog")
 @click.option("--verbose", type=click.BOOL)
 @click.option("--output", type=click.Choice(["text", "json"]), default="text")
@@ -235,7 +237,17 @@ def location(ctx: Context, identifier: str) -> None:
 @click.pass_context
 @catch_exception()
 def version(ctx: Context) -> None:
-    """Print pyiceberg version."""
+    """Print pyiceberg's installed package number (deprecated, use ``--version`` instead)."""
+    deprecation_message(
+        deprecated_in="0.11.0",
+        removed_in="1.0.0",
+        help_message="Please use `pyiceberg --version` instead of `pyiceberg version`",
+    )
+    click.echo(
+        "Deprecation warning: the `version` command is deprecated and will be removed in 1.0.0. "
+        "Please use `pyiceberg --version` instead.",
+        err=True,
+    )
     ctx.obj["output"].version(__version__)
 
 

--- a/tests/cli/test_console.py
+++ b/tests/cli/test_console.py
@@ -62,6 +62,10 @@ def test_hive_catalog_missing_uri_shows_helpful_error(mocker: MockFixture) -> No
     assert "'uri'" not in result.output
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Deprecated in 0.11.0, will be removed in 1.0.0. "
+    "Please use `pyiceberg --version` instead of `pyiceberg version`:DeprecationWarning"
+)
 def test_version_does_not_load_catalog(mocker: MockFixture) -> None:
     mock_load_catalog = mocker.patch("pyiceberg.cli.console.load_catalog", side_effect=Exception("should not be called"))
 
@@ -69,8 +73,28 @@ def test_version_does_not_load_catalog(mocker: MockFixture) -> None:
     result = runner.invoke(run, ["version"])
 
     assert result.exit_code == 0
-    assert result.output == f"{__version__}\n"
+    assert __version__ in result.output
     mock_load_catalog.assert_not_called()
+
+
+def test_version_flag() -> None:
+    runner = CliRunner()
+    result = runner.invoke(run, ["--version"])
+
+    assert result.exit_code == 0
+    assert result.output == f"{__version__}\n"
+
+
+def test_version_command_emits_deprecation_warning(mocker: MockFixture) -> None:
+    mocker.patch("pyiceberg.cli.console.load_catalog")
+
+    runner = CliRunner()
+    with pytest.warns(DeprecationWarning, match="Please use `pyiceberg --version` instead of `pyiceberg version`"):
+        result = runner.invoke(run, ["version"])
+
+    assert result.exit_code == 0
+    assert "deprecated" in result.output.lower()
+    assert "pyiceberg --version" in result.output
 
 
 @pytest.fixture(autouse=True)

--- a/tests/cli/test_console.py
+++ b/tests/cli/test_console.py
@@ -62,10 +62,6 @@ def test_hive_catalog_missing_uri_shows_helpful_error(mocker: MockFixture) -> No
     assert "'uri'" not in result.output
 
 
-@pytest.mark.filterwarnings(
-    "ignore:Deprecated in 0.11.0, will be removed in 1.0.0. "
-    "Please use `pyiceberg --version` instead of `pyiceberg version`:DeprecationWarning"
-)
 def test_version_does_not_load_catalog(mocker: MockFixture) -> None:
     mock_load_catalog = mocker.patch("pyiceberg.cli.console.load_catalog", side_effect=Exception("should not be called"))
 
@@ -73,7 +69,7 @@ def test_version_does_not_load_catalog(mocker: MockFixture) -> None:
     result = runner.invoke(run, ["version"])
 
     assert result.exit_code == 0
-    assert __version__ in result.output
+    assert result.stdout == f"{__version__}\n"
     mock_load_catalog.assert_not_called()
 
 
@@ -85,14 +81,12 @@ def test_version_flag() -> None:
     assert result.output == f"{__version__}\n"
 
 
-def test_version_command_emits_deprecation_warning(mocker: MockFixture) -> None:
-    mocker.patch("pyiceberg.cli.console.load_catalog")
-
+def test_version_command_emits_deprecation_warning() -> None:
     runner = CliRunner()
-    with pytest.warns(DeprecationWarning, match="Please use `pyiceberg --version` instead of `pyiceberg version`"):
-        result = runner.invoke(run, ["version"])
+    result = runner.invoke(run, ["version"])
 
     assert result.exit_code == 0
+    assert __version__ in result.output
     assert "deprecated" in result.output.lower()
     assert "pyiceberg --version" in result.output
 

--- a/tests/cli/test_console.py
+++ b/tests/cli/test_console.py
@@ -86,9 +86,9 @@ def test_version_command_emits_deprecation_warning() -> None:
     result = runner.invoke(run, ["version"])
 
     assert result.exit_code == 0
-    assert __version__ in result.output
-    assert "deprecated" in result.output.lower()
-    assert "pyiceberg --version" in result.output
+    assert result.stdout == f"{__version__}\n"
+    assert "deprecated" in result.stderr.lower()
+    assert "pyiceberg --version" in result.stderr
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Closes #3160

<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

The `pyiceberg version` subcommand is non-standard. Most CLI tools use `--version` instead.
This PR adds `--version` via Click's built-in `click.version_option()` and deprecates the
old `version` subcommand with a visible warning message, following the project's deprecation
conventions.

Note: I chose `removed_in="1.0.0"` to match the existing deprecation in the REST catalog 
(see `pyiceberg/catalog/rest/__init__.py`), but happy to adjust if a different version is preferred.  

## Are these changes tested?

Yes. Added two new tests:
- `test_version_flag` — verifies `pyiceberg --version` works correctly
- `test_version_command_emits_deprecation_warning` — verifies the old command still works but emits a `DeprecationWarning` and prints a visible deprecation notice to stderr

Updated the existing `test_version_does_not_load_catalog` to account for the deprecation warning.
<img width="884" height="116" alt="Screenshot 2026-03-29 at 11 47 37 pm" src="https://github.com/user-attachments/assets/cb4fe218-3671-41a3-83db-e90933271bb1" />

<img width="884" height="116" alt="Screenshot 2026-03-29 at 11 59 54 pm" src="https://github.com/user-attachments/assets/10bafeaa-9bea-4d81-b7e1-0ec2abce571e" />


## Are there any user-facing changes?

Yes:
- `pyiceberg --version` is now available
- `pyiceberg version` still works but prints a deprecation warning
- Help text updated to reflect the deprecation
<!-- In the case of user-facing changes, please add the changelog label. -->
