### PR TITLE
Remove _ENV_CONFIG and cached env config to config.py

### DIFF
--- a/pyiceberg/catalog/__init__.py
+++ b/pyiceberg/catalog/__init__.py
@@ -226,7 +226,7 @@ def _check_required_catalog_properties(name: str, catalog_type: CatalogType, con
         )
 
 
-def load_catalog(name: str | None = None, config: Config | None = None, **properties: str | None) -> Catalog:
+def load_catalog(name: str | None = None, **properties: str | None) -> Catalog:
     """Load the catalog based on the properties.
 
     Will look up the properties from the config, based on the name.
@@ -242,7 +242,7 @@ def load_catalog(name: str | None = None, config: Config | None = None, **proper
         ValueError: Raises a ValueError in case properties are missing or malformed,
             or if it could not determine the catalog based on the properties.
     """
-    config = config or get_env_config()
+    config = get_env_config()
     if name is None:
         name = config.get_default_catalog_name()
 

--- a/pyiceberg/catalog/__init__.py
+++ b/pyiceberg/catalog/__init__.py
@@ -66,7 +66,7 @@ from pyiceberg.typedef import (
     RecursiveDict,
     TableVersion,
 )
-from pyiceberg.utils.config import Config, merge_config
+from pyiceberg.utils.config import Config, get_env_config, merge_config
 from pyiceberg.utils.properties import property_as_bool
 from pyiceberg.view import View
 from pyiceberg.view.metadata import ViewVersion
@@ -75,8 +75,6 @@ if TYPE_CHECKING:
     import pyarrow as pa
 
 logger = logging.getLogger(__name__)
-
-_ENV_CONFIG = Config()
 
 TOKEN = "token"
 TYPE = "type"
@@ -228,7 +226,7 @@ def _check_required_catalog_properties(name: str, catalog_type: CatalogType, con
         )
 
 
-def load_catalog(name: str | None = None, **properties: str | None) -> Catalog:
+def load_catalog(name: str | None = None, config: Config | None = None, **properties: str | None) -> Catalog:
     """Load the catalog based on the properties.
 
     Will look up the properties from the config, based on the name.
@@ -244,10 +242,11 @@ def load_catalog(name: str | None = None, **properties: str | None) -> Catalog:
         ValueError: Raises a ValueError in case properties are missing or malformed,
             or if it could not determine the catalog based on the properties.
     """
+    config = config or get_env_config()
     if name is None:
-        name = _ENV_CONFIG.get_default_catalog_name()
+        name = config.get_default_catalog_name()
 
-    env = _ENV_CONFIG.get_catalog_config(name)
+    env = config.get_catalog_config(name)
     conf: RecursiveDict = merge_config(env or {}, cast(RecursiveDict, properties))
 
     catalog_type: CatalogType | None
@@ -279,8 +278,8 @@ def load_catalog(name: str | None = None, **properties: str | None) -> Catalog:
     raise ValueError(f"Could not initialize catalog with the following properties: {properties}")
 
 
-def list_catalogs() -> list[str]:
-    return _ENV_CONFIG.get_known_catalogs()
+def list_catalogs(config: Config) -> list[str]:
+    return config.get_known_catalogs()
 
 
 def delete_files(io: FileIO, files_to_delete: set[str], file_type: str) -> None:

--- a/pyiceberg/utils/config.py
+++ b/pyiceberg/utils/config.py
@@ -16,6 +16,7 @@
 # under the License.
 import logging
 import os
+from functools import lru_cache
 
 import strictyaml
 
@@ -179,3 +180,8 @@ class Config:
             except ValueError as err:
                 raise ValueError(f"{key} should be a boolean or left unset. Current value: {val}") from err
         return None
+
+
+@lru_cache(maxsize=1)
+def get_env_config() -> Config:
+    return Config()

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -2036,8 +2036,8 @@ def test_catalog_from_environment_variables(catalog_config_mock: mock.Mock, rest
 
 
 @mock.patch.dict(os.environ, EXAMPLE_ENV)
-@mock.patch("pyiceberg.catalog._ENV_CONFIG.get_catalog_config")
-def test_catalog_from_environment_variables_override(catalog_config_mock: mock.Mock, rest_mock: Mocker) -> None:
+@mock.patch("pyiceberg.catalog.get_env_config")
+def test_catalog_from_environment_variables_override(get_env_config_mock: mock.Mock, rest_mock: Mocker) -> None:
     rest_mock.get(
         "https://other-service.io/api/v1/config",
         json={"defaults": {}, "overrides": {}},
@@ -2045,7 +2045,9 @@ def test_catalog_from_environment_variables_override(catalog_config_mock: mock.M
     )
     env_config: RecursiveDict = Config._from_environment_variables({})
 
-    catalog_config_mock.return_value = cast(RecursiveDict, env_config.get("catalog")).get("production")
+    mock_env_config = mock.Mock()
+    mock_env_config.get_catalog_config.return_value = cast(RecursiveDict, env_config.get("catalog")).get("production")
+    get_env_config_mock.return_value = mock_env_config
     catalog = cast(RestCatalog, load_catalog("production", uri="https://other-service.io/api"))
     assert catalog.uri == "https://other-service.io/api"
 

--- a/tests/cli/test_console.py
+++ b/tests/cli/test_console.py
@@ -34,19 +34,17 @@ from pyiceberg.schema import Schema
 from pyiceberg.transforms import IdentityTransform
 from pyiceberg.typedef import Properties
 from pyiceberg.types import LongType, NestedField
-from pyiceberg.utils.config import Config
 
 
 def test_missing_uri(mocker: MockFixture, empty_home_dir_path: str) -> None:
     # mock to prevent parsing ~/.pyiceberg.yaml or {PYICEBERG_HOME}/.pyiceberg.yaml
     mocker.patch.dict(os.environ, values={"HOME": empty_home_dir_path, "PYICEBERG_HOME": empty_home_dir_path})
-    mocker.patch("pyiceberg.catalog._ENV_CONFIG", return_value=Config())
 
     runner = CliRunner()
     result = runner.invoke(run, ["list"])
 
     assert result.exit_code == 1
-    assert result.output == "Could not initialize catalog with the following properties: {}\n"
+    assert "URI missing" in result.output
 
 
 def test_hive_catalog_missing_uri_shows_helpful_error(mocker: MockFixture) -> None:

--- a/tests/cli/test_console.py
+++ b/tests/cli/test_console.py
@@ -50,7 +50,7 @@ def test_missing_uri(mocker: MockFixture, empty_home_dir_path: str) -> None:
 def test_hive_catalog_missing_uri_shows_helpful_error(mocker: MockFixture) -> None:
     mock_env_config = mocker.MagicMock()
     mock_env_config.get_catalog_config.return_value = {"type": "hive"}
-    mocker.patch("pyiceberg.catalog._ENV_CONFIG", mock_env_config)
+    mocker.patch("pyiceberg.catalog.get_env_config", return_value=mock_env_config)
 
     runner = CliRunner()
     result = runner.invoke(run, ["--catalog", "my_hive_catalog", "list"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
 )
-from unittest import mock
 
 import boto3
 import pytest
@@ -109,20 +108,6 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     for item in items:
         if not any(item.iter_markers()):
             item.add_marker("unmarked")
-
-
-@pytest.fixture(autouse=True, scope="session")
-def _isolate_pyiceberg_config() -> None:
-    """Make test runs ignore your local PyIceberg config.
-
-    Without this, tests will attempt to resolve a local ~/.pyiceberg.yaml while running pytest.
-    This replaces the global catalog config once at session start with an env-only config.
-    """
-    import pyiceberg.catalog as _catalog_module
-    from pyiceberg.utils.config import Config
-
-    with mock.patch.object(Config, "_from_configuration_files", return_value=None):
-        _catalog_module._ENV_CONFIG = Config()
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -71,7 +71,8 @@ def test_from_configuration_files(tmp_path_factory: pytest.TempPathFactory) -> N
         file.write(yaml_str)
 
     os.environ["PYICEBERG_HOME"] = config_path
-    assert Config().get_catalog_config("production") == {"uri": "https://service.io/api"}
+    config = Config()
+    assert config.get_catalog_config("production") == {"uri": "https://service.io/api"}
 
 
 def test_lowercase_dictionary_keys() -> None:


### PR DESCRIPTION
Related #3028
and Related #3083 

# Rationale for this change

Move the cached environment config out of `pyiceberg.catalog` into `pyiceberg.utils.config` so catalog loading no longer depends on a module-level mutable global and tests can patch config access more cleanly.

## Are these changes tested?

Yes, updated the affected catalog, CLI, and config tests.

## Are there any user-facing changes?

No.
