### PR TITLE
CI: Lock REST Fixture to 1.10.1

### DIFF
--- a/dev/docker-compose-integration.yml
+++ b/dev/docker-compose-integration.yml
@@ -44,7 +44,7 @@ services:
       retries: 5
       start_period: 90s
   rest:
-    image: apache/iceberg-rest-fixture
+    image: apache/iceberg-rest-fixture:1.10.1
     container_name: pyiceberg-rest
     networks:
       iceberg_net:

--- a/tests/integration/test_catalog.py
+++ b/tests/integration/test_catalog.py
@@ -618,6 +618,7 @@ def test_register_table_existing(test_catalog: Catalog, table_schema_nested: Sch
 
 
 @pytest.mark.integration
+@pytest.mark.skip(reason="Requires Iceberg REST Fixtures 1.11.x")
 def test_rest_custom_namespace_separator(rest_catalog: RestCatalog, table_schema_simple: Schema) -> None:
     """
     Tests that the REST catalog correctly picks up the namespace-separator from the config endpoint.


### PR DESCRIPTION
With the new Jetty upgrade in https://github.com/apache/iceberg/pull/10837 we're running into the following:

Failing CI: https://github.com/apache/iceberg-python/actions/runs/24416422109/job/71326697962

```json
Malformed request: {
"message":"Suspicious Path Character",
"url":"http://rest:8181/v1/namespaces/default%1Ftest_positional_mor_deletes_v2/tables/branch_without_5?snapshots=all",
"status":"400"
}
```

The `namespace-seperator` has been introduced afther the 1.10.x branch (https://github.com/apache/iceberg-python/pull/2826), so it isn't out in public, meaning the Spark integration tests are not respecting this config. This requires us to downgrade for now.

I think disallowing the default (`%1F`) separator is problematic, since it might break compatibility.

<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

## Are these changes tested?

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
