### PR TITLE
fix(rest): skip Hadoop-only vended storage credentials during resolution

### DIFF
--- a/pyiceberg/catalog/rest/__init__.py
+++ b/pyiceberg/catalog/rest/__init__.py
@@ -374,6 +374,11 @@ class ListViewsResponse(IcebergBaseModel):
 _PLANNING_RESPONSE_ADAPTER = TypeAdapter(PlanningResponse)
 
 
+def _is_hadoop_only_config(config: Properties) -> bool:
+    """Return True if every key is a Hadoop ``fs.*`` key — pyiceberg has no HadoopFileIO to consume them."""
+    return bool(config) and all(k.startswith("fs.") for k in config)
+
+
 class RestCatalog(Catalog):
     uri: str
     _session: Session
@@ -440,21 +445,29 @@ class RestCatalog(Catalog):
 
     @staticmethod
     def _resolve_storage_credentials(storage_credentials: list[StorageCredential], location: str | None) -> Properties:
-        """Resolve the best-matching storage credential by longest prefix match.
+        """Pick the longest-prefix storage credential for ``location``.
 
-        Mirrors the Java implementation in S3FileIO.clientForStoragePath() which iterates
-        over storage credential prefixes and selects the one with the longest match.
-
-        See: https://github.com/apache/iceberg/blob/main/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+        Mirrors Java ``S3FileIO.clientForStoragePath``. Hadoop-only (``fs.*``)
+        credentials are filtered out since pyiceberg has no HadoopFileIO to
+        consume them — otherwise a catalog vending both ``fs.*`` and ``s3.*``
+        bundles per location could strand the FileIO with unusable keys.
         """
         if not storage_credentials or not location:
             return {}
 
+        consumable = [c for c in storage_credentials if not _is_hadoop_only_config(c.config)]
+
         best_match: StorageCredential | None = None
-        for cred in storage_credentials:
+        for cred in consumable:
             if location.startswith(cred.prefix):
                 if best_match is None or len(cred.prefix) > len(best_match.prefix):
                     best_match = cred
+
+        # Java S3FileIO falls back to the "s3" ROOT_PREFIX credential; scope
+        # it to schemes pyarrow's S3FileSystem handles so gs:///abfs:// don't
+        # get handed s3.* keys.
+        if best_match is None and location.startswith(("s3://", "s3a://", "s3n://", "oss://")):
+            best_match = next((c for c in consumable if c.prefix == "s3"), None)
 
         return best_match.config if best_match else {}
 

--- a/pyiceberg/catalog/rest/__init__.py
+++ b/pyiceberg/catalog/rest/__init__.py
@@ -396,6 +396,11 @@ class ListViewsResponse(IcebergBaseModel):
 _PLANNING_RESPONSE_ADAPTER = TypeAdapter(PlanningResponse)
 
 
+def _is_hadoop_only_config(config: Properties) -> bool:
+    """Return True if every key is a Hadoop ``fs.*`` key — pyiceberg has no HadoopFileIO to consume them."""
+    return bool(config) and all(k.startswith("fs.") for k in config)
+
+
 class RestCatalog(Catalog):
     uri: str
     _session: Session
@@ -462,21 +467,31 @@ class RestCatalog(Catalog):
 
     @staticmethod
     def _resolve_storage_credentials(storage_credentials: list[StorageCredential], location: str | None) -> Properties:
-        """Resolve the best-matching storage credential by longest prefix match.
+        """Pick the longest-prefix storage credential for ``location``.
 
-        Mirrors the Java implementation in S3FileIO.clientForStoragePath() which iterates
-        over storage credential prefixes and selects the one with the longest match.
+        Mirrors Java ``S3FileIO.clientForStoragePath``. Hadoop-only (``fs.*``)
+        credentials are filtered out since pyiceberg has no HadoopFileIO to
+        consume them — otherwise a catalog vending both ``fs.*`` and ``s3.*``
+        bundles per location could strand the FileIO with unusable keys.
 
         See: https://github.com/apache/iceberg/blob/main/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
         """
         if not storage_credentials or not location:
             return {}
 
+        consumable = [c for c in storage_credentials if not _is_hadoop_only_config(c.config)]
+
         best_match: StorageCredential | None = None
-        for cred in storage_credentials:
+        for cred in consumable:
             if location.startswith(cred.prefix):
                 if best_match is None or len(cred.prefix) > len(best_match.prefix):
                     best_match = cred
+
+        # Java S3FileIO falls back to the "s3" ROOT_PREFIX credential; scope it to
+        # schemes pyarrow's S3FileSystem handles so non-S3 schemes (gs://, abfs://,
+        # etc.) don't get handed s3.* keys.
+        if best_match is None and location.startswith(("s3://", "s3a://", "s3n://", "oss://")):
+            best_match = next((c for c in consumable if c.prefix == "s3"), None)
 
         return best_match.config if best_match else {}
 

--- a/pyiceberg/catalog/rest/__init__.py
+++ b/pyiceberg/catalog/rest/__init__.py
@@ -396,7 +396,7 @@ class ListViewsResponse(IcebergBaseModel):
 _PLANNING_RESPONSE_ADAPTER = TypeAdapter(PlanningResponse)
 
 
-def _is_hadoop_only_config(config: Properties) -> bool:
+def _is_hadoop_only_config(config: dict[str, str]) -> bool:
     """Return True if every key is a Hadoop ``fs.*`` key — pyiceberg has no HadoopFileIO to consume them."""
     return bool(config) and all(k.startswith("fs.") for k in config)
 
@@ -487,10 +487,9 @@ class RestCatalog(Catalog):
                 if best_match is None or len(cred.prefix) > len(best_match.prefix):
                     best_match = cred
 
-        # Java S3FileIO falls back to the "s3" ROOT_PREFIX credential; scope it to
-        # schemes pyarrow's S3FileSystem handles so non-S3 schemes (gs://, abfs://,
-        # etc.) don't get handed s3.* keys.
-        if best_match is None and location.startswith(("s3://", "s3a://", "s3n://", "oss://")):
+        # Java S3FileIO ROOT_PREFIX fallback. Only oss:// needs it — s3/s3a/s3n
+        # already match the "s3" credential via startswith in the loop above.
+        if best_match is None and location.startswith("oss://"):
             best_match = next((c for c in consumable if c.prefix == "s3"), None)
 
         return best_match.config if best_match else {}

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -2600,6 +2600,67 @@ def test_resolve_storage_credentials_empty() -> None:
     assert RestCatalog._resolve_storage_credentials([], None) == {}
 
 
+def test_resolve_storage_credentials_skips_hadoop_only() -> None:
+    from pyiceberg.catalog.rest.scan_planning import StorageCredential
+
+    # The longer fs.* prefix would win a blind longest-match; the filter drops it.
+    credentials = [
+        StorageCredential(prefix="s3://warehouse/jindo", config={"fs.s3.access-key": "hadoop-k"}),
+        StorageCredential(prefix="s3://warehouse", config={"s3.access-key-id": "native-k"}),
+    ]
+    result = RestCatalog._resolve_storage_credentials(credentials, "s3://warehouse/jindo/table/data")
+    assert result == {"s3.access-key-id": "native-k"}
+
+
+def test_resolve_storage_credentials_mixed_prefix_namespaces_preserved() -> None:
+    from pyiceberg.catalog.rest.scan_planning import StorageCredential
+
+    credentials = [
+        StorageCredential(prefix="gs", config={"gs.oauth2.token": "tok"}),
+        StorageCredential(prefix="s3", config={"s3.access-key-id": "native-k"}),
+    ]
+    result = RestCatalog._resolve_storage_credentials(credentials, "gs://bucket/path")
+    assert result == {"gs.oauth2.token": "tok"}
+
+
+def test_resolve_storage_credentials_all_hadoop_only_returns_empty() -> None:
+    from pyiceberg.catalog.rest.scan_planning import StorageCredential
+
+    credentials = [
+        StorageCredential(prefix="custom", config={"fs.custom.access-key": "hadoop-k"}),
+    ]
+    assert RestCatalog._resolve_storage_credentials(credentials, "custom://bucket/path") == {}
+
+
+def test_resolve_storage_credentials_root_prefix_fallback_for_s3_compatible_scheme() -> None:
+    from pyiceberg.catalog.rest.scan_planning import StorageCredential
+
+    # oss:// is routed through pyarrow's S3FileSystem, so ROOT_PREFIX "s3" applies.
+    credentials = [
+        StorageCredential(prefix="s3", config={"s3.access-key-id": "native-k"}),
+    ]
+    result = RestCatalog._resolve_storage_credentials(credentials, "oss://bucket/path")
+    assert result == {"s3.access-key-id": "native-k"}
+
+
+def test_resolve_storage_credentials_root_prefix_fallback_respects_consumable() -> None:
+    from pyiceberg.catalog.rest.scan_planning import StorageCredential
+
+    credentials = [
+        StorageCredential(prefix="s3", config={"fs.s3.access-key": "hadoop-k"}),
+    ]
+    assert RestCatalog._resolve_storage_credentials(credentials, "s3://bucket/path") == {}
+
+
+def test_resolve_storage_credentials_fallback_skipped_for_non_s3_scheme() -> None:
+    from pyiceberg.catalog.rest.scan_planning import StorageCredential
+
+    credentials = [
+        StorageCredential(prefix="s3", config={"s3.access-key-id": "native-k"}),
+    ]
+    assert RestCatalog._resolve_storage_credentials(credentials, "gs://bucket/path") == {}
+
+
 def test_load_table_with_storage_credentials(rest_mock: Mocker, example_table_metadata_with_snapshot_v1: dict[str, Any]) -> None:
     metadata_location = "s3://warehouse/database/table/metadata/00001.metadata.json"
     rest_mock.get(

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -3112,7 +3112,6 @@ def test_resolve_storage_credentials_empty() -> None:
 def test_resolve_storage_credentials_skips_hadoop_only() -> None:
     from pyiceberg.catalog.rest.scan_planning import StorageCredential
 
-    # The longer fs.* prefix would win a blind longest-match; the filter drops it.
     credentials = [
         StorageCredential(prefix="s3://warehouse/jindo", config={"fs.s3.access-key": "hadoop-k"}),
         StorageCredential(prefix="s3://warehouse", config={"s3.access-key-id": "native-k"}),
@@ -3141,10 +3140,20 @@ def test_resolve_storage_credentials_all_hadoop_only_returns_empty() -> None:
     assert RestCatalog._resolve_storage_credentials(credentials, "custom://bucket/path") == {}
 
 
-def test_resolve_storage_credentials_root_prefix_fallback_for_s3_compatible_scheme() -> None:
+def test_resolve_storage_credentials_s3a_s3n_match_root_prefix_directly() -> None:
     from pyiceberg.catalog.rest.scan_planning import StorageCredential
 
-    # oss:// is routed through pyarrow's S3FileSystem, so ROOT_PREFIX "s3" applies.
+    credentials = [
+        StorageCredential(prefix="s3", config={"s3.access-key-id": "native-k"}),
+    ]
+    for scheme in ("s3a", "s3n"):
+        result = RestCatalog._resolve_storage_credentials(credentials, f"{scheme}://bucket/path")
+        assert result == {"s3.access-key-id": "native-k"}, f"{scheme}:// should match prefix='s3' directly"
+
+
+def test_resolve_storage_credentials_root_prefix_fallback_for_oss() -> None:
+    from pyiceberg.catalog.rest.scan_planning import StorageCredential
+
     credentials = [
         StorageCredential(prefix="s3", config={"s3.access-key-id": "native-k"}),
     ]

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -3109,6 +3109,67 @@ def test_resolve_storage_credentials_empty() -> None:
     assert RestCatalog._resolve_storage_credentials([], None) == {}
 
 
+def test_resolve_storage_credentials_skips_hadoop_only() -> None:
+    from pyiceberg.catalog.rest.scan_planning import StorageCredential
+
+    # The longer fs.* prefix would win a blind longest-match; the filter drops it.
+    credentials = [
+        StorageCredential(prefix="s3://warehouse/jindo", config={"fs.s3.access-key": "hadoop-k"}),
+        StorageCredential(prefix="s3://warehouse", config={"s3.access-key-id": "native-k"}),
+    ]
+    result = RestCatalog._resolve_storage_credentials(credentials, "s3://warehouse/jindo/table/data")
+    assert result == {"s3.access-key-id": "native-k"}
+
+
+def test_resolve_storage_credentials_mixed_prefix_namespaces_preserved() -> None:
+    from pyiceberg.catalog.rest.scan_planning import StorageCredential
+
+    credentials = [
+        StorageCredential(prefix="gs", config={"gs.oauth2.token": "tok"}),
+        StorageCredential(prefix="s3", config={"s3.access-key-id": "native-k"}),
+    ]
+    result = RestCatalog._resolve_storage_credentials(credentials, "gs://bucket/path")
+    assert result == {"gs.oauth2.token": "tok"}
+
+
+def test_resolve_storage_credentials_all_hadoop_only_returns_empty() -> None:
+    from pyiceberg.catalog.rest.scan_planning import StorageCredential
+
+    credentials = [
+        StorageCredential(prefix="custom", config={"fs.custom.access-key": "hadoop-k"}),
+    ]
+    assert RestCatalog._resolve_storage_credentials(credentials, "custom://bucket/path") == {}
+
+
+def test_resolve_storage_credentials_root_prefix_fallback_for_s3_compatible_scheme() -> None:
+    from pyiceberg.catalog.rest.scan_planning import StorageCredential
+
+    # oss:// is routed through pyarrow's S3FileSystem, so ROOT_PREFIX "s3" applies.
+    credentials = [
+        StorageCredential(prefix="s3", config={"s3.access-key-id": "native-k"}),
+    ]
+    result = RestCatalog._resolve_storage_credentials(credentials, "oss://bucket/path")
+    assert result == {"s3.access-key-id": "native-k"}
+
+
+def test_resolve_storage_credentials_root_prefix_fallback_respects_consumable() -> None:
+    from pyiceberg.catalog.rest.scan_planning import StorageCredential
+
+    credentials = [
+        StorageCredential(prefix="s3", config={"fs.s3.access-key": "hadoop-k"}),
+    ]
+    assert RestCatalog._resolve_storage_credentials(credentials, "s3://bucket/path") == {}
+
+
+def test_resolve_storage_credentials_fallback_skipped_for_non_s3_scheme() -> None:
+    from pyiceberg.catalog.rest.scan_planning import StorageCredential
+
+    credentials = [
+        StorageCredential(prefix="s3", config={"s3.access-key-id": "native-k"}),
+    ]
+    assert RestCatalog._resolve_storage_credentials(credentials, "gs://bucket/path") == {}
+
+
 def test_load_table_with_storage_credentials(rest_mock: Mocker, example_table_metadata_with_snapshot_v1: dict[str, Any]) -> None:
     metadata_location = "s3://warehouse/database/table/metadata/00001.metadata.json"
     rest_mock.get(


### PR DESCRIPTION
# Rationale for this change
REST catalogs can return multiple StorageCredential entries per table to serve different client runtimes. A common pattern is one entry with Hadoop-style fs.* keys alongside a second entry with canonical s3.* / gs.* keys consumed by the cloud-native SDKs).
Java's FileIO implementations each filter vended credentials down to their own key namespace. S3FileIO.clientForStoragePath() only consumes entries with an s3-prefixed label ([S3FileIO.java:413-414](https://github.com/apache/iceberg/blob/main/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java#L413)) and, when no URI prefix matches the storage path, falls back to the client keyed at the root "s3" prefix. pyiceberg has no HadoopFileIO, so Hadoop-style credential bundles have no consumer on the Python side; but _resolve_storage_credentials did a blind longest-prefix URI match across the full credential list, so when a Hadoop-style entry happened to be the longest URI-prefix match for a given location the Python FileIO ended up with fs.* keys it cannot use, and silently fell through to unauthenticated access.