### PR TITLE
fix zizmor ci issue by bumping codeql-action to v4.35.2

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,11 +46,11 @@ jobs:
         persist-credentials: false
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+      uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
       with:
         languages: actions
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+      uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
       with:
         category: "/language:actions"


### PR DESCRIPTION
# Rationale for this change

The zizmor workflow is currently failing on all PRs due to a ref version mismatch. The pinned SHAs were pointing to v4.35.1, but the comment referenced the major version (#v4). When v4.35.2 was released, the v4 tag moved to the new commit, causing a mismatch between the pinned SHA and the tag in the comment. Updated the SHAs to v4.35.2 and switched the comments to use the fully qualified version so that Dependabot will bump both the SHA and comment together in the future!

## Are these changes tested?

ci run

## Are there any user-facing changes?

no
