### PR TITLE
Fix ManifestEntry.snapshot_id setter writing to wrong index

### DIFF
--- a/pyiceberg/manifest.py
+++ b/pyiceberg/manifest.py
@@ -614,7 +614,7 @@ class ManifestEntry(Record):
 
     @snapshot_id.setter
     def snapshot_id(self, value: int) -> None:
-        self._data[0] = value
+        self._data[1] = value
 
     @property
     def sequence_number(self) -> int | None:

--- a/tests/utils/test_manifest.py
+++ b/tests/utils/test_manifest.py
@@ -32,6 +32,7 @@ from pyiceberg.manifest import (
     ManifestEntryStatus,
     ManifestFile,
     PartitionFieldSummary,
+    _inherit_from_manifest,
     _manifest_cache,
     _manifests,
     read_manifest_list,
@@ -932,3 +933,43 @@ def test_manifest_writer_tell(format_version: TableVersion) -> None:
             after_entry_bytes = writer.tell()
 
             assert after_entry_bytes > initial_bytes, "Bytes should increase after adding entry"
+
+
+def test_inherit_from_manifest_snapshot_id() -> None:
+    entry = ManifestEntry.from_args(
+        status=ManifestEntryStatus.ADDED,
+        snapshot_id=None,
+        sequence_number=None,
+        file_sequence_number=None,
+        data_file=DataFile.from_args(
+            content=DataFileContent.DATA,
+            file_path="s3://bucket/data/file.parquet",
+            file_format="PARQUET",
+            partition={},
+            record_count=100,
+            file_size_in_bytes=1024,
+        ),
+    )
+
+    manifest = ManifestFile.from_args(
+        manifest_path="s3://bucket/metadata/manifest.avro",
+        manifest_length=1000,
+        partition_spec_id=0,
+        content=ManifestContent.DATA,
+        sequence_number=1,
+        min_sequence_number=1,
+        added_snapshot_id=3051729675574597004,
+        added_files_count=1,
+        existing_files_count=0,
+        deleted_files_count=0,
+        added_rows_count=100,
+        existing_rows_count=0,
+        deleted_rows_count=0,
+    )
+
+    result = _inherit_from_manifest(entry, manifest)
+
+    assert result.status == ManifestEntryStatus.ADDED
+    assert result.snapshot_id == 3051729675574597004
+    assert result.sequence_number == 1
+    assert result.file_sequence_number == 1

--- a/tests/utils/test_manifest.py
+++ b/tests/utils/test_manifest.py
@@ -944,8 +944,8 @@ def test_inherit_from_manifest_snapshot_id() -> None:
         data_file=DataFile.from_args(
             content=DataFileContent.DATA,
             file_path="s3://bucket/data/file.parquet",
-            file_format="PARQUET",
-            partition={},
+            file_format=FileFormat.PARQUET,
+            partition=Record(),
             record_count=100,
             file_size_in_bytes=1024,
         ),


### PR DESCRIPTION
Closes #3256

# Rationale for this change
The `snapshot_id` property setter on `ManifestEntry` writes to `self._data[0]` (the `status` field) instead of `self._data[1]` (the `snapshot_id` field). This means that when `_inherit_from_manifest()` assigns a null `snapshot_id` from the manifest's `added_snapshot_id`, the entry's `status` is corrupted and `snapshot_id` remains `None`.

## Are these changes tested?
Yes. Added `test_inherit_from_manifest_snapshot_id` to verify that `_inherit_from_manifest()` correctly inherits `snapshot_id` without corrupting the `status` field.

## Are there any user-facing changes?
N/A