### PR TITLE
Merge scan options into FileIO at TableScan.__init__ time

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -1713,7 +1713,7 @@ class TableScan(ABC):
         table_identifier: Identifier | None = None,
     ):
         self.table_metadata = table_metadata
-        self.io = io
+        self.io = load_file_io({**io.properties, **options}, self.table_metadata.location) if options else io
         self.row_filter = _parse_row_filter(row_filter)
         self.selected_fields = selected_fields
         self.case_sensitive = case_sensitive
@@ -1961,13 +1961,11 @@ class DataScan(TableScan):
         # The lambda created here is run in multiple threads.
         # So we avoid creating _EvaluatorExpression methods bound to a single
         # shared instance across multiple threads.
-        return lambda datafile: (
-            residual_evaluator_of(
-                spec=spec,
-                expr=self.row_filter,
-                case_sensitive=self.case_sensitive,
-                schema=self.table_metadata.schema(),
-            )
+        return lambda datafile: residual_evaluator_of(
+            spec=spec,
+            expr=self.row_filter,
+            case_sensitive=self.case_sensitive,
+            schema=self.table_metadata.schema(),
         )
 
     @staticmethod

--- a/tests/table/test_init.py
+++ b/tests/table/test_init.py
@@ -336,6 +336,25 @@ def test_table_scan_projection_unknown_column(table_v2: Table) -> None:
     assert "Could not find column: 'a'" in str(exc_info.value)
 
 
+def test_table_scan_options_merged_with_existing_io_properties(table_v2: Table) -> None:
+    table = Table(
+        identifier=table_v2._identifier,
+        metadata=table_v2.metadata,
+        metadata_location=table_v2.metadata_location,
+        io=load_file_io({"s3.region": "us-east-1", "s3.connect-timeout": "10"}),
+        catalog=table_v2.catalog,
+    )
+    scan = table.scan(options={"s3.connect-timeout": "60", "s3.endpoint": "https://custom.endpoint"})
+    assert scan.io.properties["s3.region"] == "us-east-1"
+    assert scan.io.properties["s3.connect-timeout"] == "60"
+    assert scan.io.properties["s3.endpoint"] == "https://custom.endpoint"
+
+
+def test_table_scan_empty_options_reuses_file_io(table_v2: Table) -> None:
+    scan = table_v2.scan()
+    assert scan.io is table_v2.io
+
+
 def test_static_table_same_as_table(table_v2: Table, metadata_location: str) -> None:
     static_table = StaticTable.from_metadata(metadata_location)
     assert isinstance(static_table, Table)


### PR DESCRIPTION
Closes #3166

# Rationale for this change

The `Table.scan(..)` method accepts a parameter `options: Properties`; this parameter is not actually threaded into the FileIO instance used in the DataScan class which scans the data. Instead, the internal callers were using a FileIO instance with only the basic catalog-level parameters set and were not respecting the user-specified options.

This is resolved by merging scan `options` into the FileIO at `TableScan.__init__` time, using the existing `load_file_io` method. This means that if the user provides new parameters to `scan`, a new FileIO instance must be created with the merged properties. FileIO properties are immutable after construction, and the cached filesystem objects are built from those properties at first access, so a new instance is required.

If the `options` are empty or if the key:value pairs are all present in the existing FileIO options, you can use the existing FileIO instance. 

I wanted to fix the problem at initialization, rather than at the various callsites, because `self.io` is also used in `scan_plan_helper()` for manifest reads, not just in `to_arrow()` for data reads. Fixing at init time covers both.

## Are these changes tested?

I added tests to confirm that the __init__ method has the expected behavior. 

## Are there any user-facing changes?

Yes. Scan-level options passed to Table.scan(options=...) are now respected by the underlying FileIO during data and manifest reads. Previously these options were silently ignored.   
