### PR TITLE
Fix pa.Schema type annotations in schema_to_pyarrow

### DIFF
--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -690,7 +690,7 @@ def schema_to_pyarrow(
     metadata: dict[bytes, bytes] = EMPTY_DICT,
     include_field_ids: bool = True,
     file_format: FileFormat = FileFormat.PARQUET,
-) -> pa.schema:
+) -> pa.Schema:
     return visit(schema, _ConvertToArrowSchema(metadata, include_field_ids, file_format))
 
 
@@ -704,7 +704,7 @@ class _ConvertToArrowSchema(SchemaVisitorPerPrimitiveType[pa.DataType]):
         self._include_field_ids = include_field_ids
         self._file_format = file_format
 
-    def schema(self, _: Schema, struct_result: pa.StructType) -> pa.schema:
+    def schema(self, _: Schema, struct_result: pa.StructType) -> pa.Schema:
         return pa.schema(list(struct_result), metadata=self._metadata)
 
     def struct(self, _: StructType, field_results: builtins.list[pa.DataType]) -> pa.DataType:


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
The `schema_for_pyarrow` return type is `pa.schema` but should be `pa.Schema`. `pa.schema` is the factory method ([pyarrow docs](https://arrow.apache.org/docs/python/generated/pyarrow.schema.html#pyarrow.schema)) whereas `pa.Schema` is the class it constructs ([pyarrow docs](https://arrow.apache.org/docs/python/generated/pyarrow.Schema.html)).

## Are these changes tested?
Just a type change. `make lint` passes.

## Are there any user-facing changes?
No

<!-- In the case of user-facing changes, please add the changelog label. -->
