### PR TITLE
fix: add iceberg_type column for SqlCatalog

### DIFF
--- a/pyiceberg/catalog/sql.py
+++ b/pyiceberg/catalog/sql.py
@@ -27,6 +27,7 @@ from sqlalchemy import (
     delete,
     insert,
     select,
+    text,
     union,
     update,
 )
@@ -92,6 +93,7 @@ class IcebergTables(SqlCatalogBaseTable):
     table_name: Mapped[str] = mapped_column(String(255), nullable=False, primary_key=True)
     metadata_location: Mapped[str | None] = mapped_column(String(1000), nullable=True)
     previous_metadata_location: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+    iceberg_type: Mapped[str | None] = mapped_column(String(5), nullable=True, default="TABLE")
 
 
 class IcebergNamespaceProperties(SqlCatalogBaseTable):
@@ -133,6 +135,8 @@ class SqlCatalog(MetastoreCatalog):
         if init_catalog_tables:
             self._ensure_tables_exist()
 
+        self._update_tables_if_required()
+
     def _ensure_tables_exist(self) -> None:
         with Session(self.engine) as session:
             for table in [IcebergTables, IcebergNamespaceProperties]:
@@ -145,6 +149,15 @@ class SqlCatalog(MetastoreCatalog):
                 ):  # sqlalchemy returns OperationalError in case of sqlite and ProgrammingError with postgres.
                     self.create_tables()
                     return
+
+    def _update_tables_if_required(self) -> None:
+        with Session(self.engine) as session:
+            stmt = f"ALTER TABLE {IcebergTables.__tablename__} ADD COLUMN iceberg_type VARCHAR(5)"
+            try:
+                session.execute(text(stmt))
+                session.commit()
+            except (OperationalError, ProgrammingError):
+                session.rollback()
 
     def create_tables(self) -> None:
         SqlCatalogBaseTable.metadata.create_all(self.engine)

--- a/pyiceberg/catalog/sql.py
+++ b/pyiceberg/catalog/sql.py
@@ -613,7 +613,11 @@ class SqlCatalog(MetastoreCatalog):
             raise NoSuchNamespaceError(f"Namespace does not exist: {namespace}")
 
         namespace = Catalog.namespace_to_string(namespace)
-        stmt = select(IcebergTables).where(IcebergTables.catalog_name == self.name, IcebergTables.table_namespace == namespace)
+        stmt = select(IcebergTables).where(
+            IcebergTables.catalog_name == self.name,
+            IcebergTables.table_namespace == namespace,
+            (IcebergTables.iceberg_type == "TABLE") | (IcebergTables.iceberg_type.is_(None)),
+        )
         with Session(self.engine) as session:
             result = session.scalars(stmt)
             return [(Catalog.identifier_to_tuple(table.table_namespace) + (table.table_name,)) for table in result]

--- a/pyiceberg/catalog/sql.py
+++ b/pyiceberg/catalog/sql.py
@@ -17,8 +17,10 @@
 
 from __future__ import annotations
 
+import logging
 from typing import (
     TYPE_CHECKING,
+    Any,
 )
 
 from sqlalchemy import (
@@ -76,6 +78,8 @@ from pyiceberg.view.metadata import ViewVersion
 if TYPE_CHECKING:
     import pyarrow as pa
 
+logger = logging.getLogger(__name__)
+
 DEFAULT_ECHO_VALUE = "false"
 DEFAULT_POOL_PRE_PING_VALUE = "false"
 DEFAULT_INIT_CATALOG_TABLES = "true"
@@ -93,7 +97,7 @@ class IcebergTables(SqlCatalogBaseTable):
     table_name: Mapped[str] = mapped_column(String(255), nullable=False, primary_key=True)
     metadata_location: Mapped[str | None] = mapped_column(String(1000), nullable=True)
     previous_metadata_location: Mapped[str | None] = mapped_column(String(1000), nullable=True)
-    iceberg_type: Mapped[str | None] = mapped_column(String(5), nullable=True, default="TABLE")
+    iceberg_type: Mapped[str | None] = mapped_column(String(5), nullable=True, deferred=True, init=False, default=None)
 
 
 class IcebergNamespaceProperties(SqlCatalogBaseTable):
@@ -128,42 +132,84 @@ class SqlCatalog(MetastoreCatalog):
         echo_str = str(self.properties.get("echo", DEFAULT_ECHO_VALUE)).lower()
         echo = strtobool(echo_str) if echo_str != "debug" else "debug"
         pool_pre_ping = strtobool(self.properties.get("pool_pre_ping", DEFAULT_POOL_PRE_PING_VALUE))
-        init_catalog_tables = strtobool(self.properties.get("init_catalog_tables", DEFAULT_INIT_CATALOG_TABLES))
 
         self.engine = create_engine(uri_prop, echo=echo, pool_pre_ping=pool_pre_ping)
+        self._init_catalog()
 
-        if init_catalog_tables:
-            self._ensure_tables_exist()
+    def _init_catalog(self) -> None:
+        """Detect schema state, create tables if absent, and migrate V0 to V1 when requested.
 
-        self._update_tables_if_required()
+        Rules:
+            - New catalogs always get v1 schema with view support.
+            - Existing v0 catalogs are not migrated unless schema_version='v1' is explicitly set.
+        """
+        # Get schema version from properties, ok if None
+        schema_version_prop = self.properties.get("schema_version", "v0")
+        if schema_version_prop not in ("v0", "v1"):
+            raise ValueError(f"Invalid schema_version property: '{schema_version_prop}'. Must be 'v0' or 'v1'.")
 
-    def _ensure_tables_exist(self) -> None:
+        # Determine if catalog tables should be created if absent
+        init_catalog_tables = strtobool(self.properties.get("init_catalog_tables", DEFAULT_INIT_CATALOG_TABLES))
+
         with Session(self.engine) as session:
-            for table in [IcebergTables, IcebergNamespaceProperties]:
-                stmt = select(1).select_from(table)
+            # 1. Check if catalog tables exist; create if absent
+            tables_absent = False
+            for tbl in [IcebergTables, IcebergNamespaceProperties]:
                 try:
-                    session.scalar(stmt)
-                except (
-                    OperationalError,
-                    ProgrammingError,
-                ):  # sqlalchemy returns OperationalError in case of sqlite and ProgrammingError with postgres.
+                    session.execute(select(1).select_from(tbl))
+                except (OperationalError, ProgrammingError):
+                    session.rollback()
+                    tables_absent = True
+                    break
+            # Tables are created with the v1 schema.
+            if tables_absent:
+                if init_catalog_tables:
                     self.create_tables()
-                    return
+                self._schema_version = "v1"
+                return
 
-    def _update_tables_if_required(self) -> None:
-        with Session(self.engine) as session:
-            stmt = f"ALTER TABLE {IcebergTables.__tablename__} ADD COLUMN iceberg_type VARCHAR(5)"
+            # 2. Tables exist at this point, so detect the schema version with a probe.
             try:
-                session.execute(text(stmt))
-                session.commit()
+                stmt = text("SELECT iceberg_type FROM iceberg_tables LIMIT 0")
+                session.execute(stmt)
+                self._schema_version = "v1"
+                return
             except (OperationalError, ProgrammingError):
                 session.rollback()
+
+            # 3. We only get here if tables exist and iceberg_type column is missing.
+            if schema_version_prop == "v1":
+                try:
+                    stmt = text(f"ALTER TABLE {IcebergTables.__tablename__} ADD COLUMN iceberg_type VARCHAR(5)")
+                    session.execute(stmt)
+                    session.commit()
+                except (OperationalError, ProgrammingError):
+                    session.rollback()
+                self._schema_version = "v1"
+            else:
+                logger.warning(
+                    "SqlCatalog detected a v0 schema (iceberg_type column missing). "
+                    "The catalog will operate in v0 mode. To migrate, set schema_version='v1'."
+                )
+                self._schema_version = "v0"
 
     def create_tables(self) -> None:
         SqlCatalogBaseTable.metadata.create_all(self.engine)
 
     def destroy_tables(self) -> None:
         SqlCatalogBaseTable.metadata.drop_all(self.engine)
+
+    def _create_table_row(self, namespace: str, table_name: str, metadata_location: str | None) -> dict[str, Any]:
+        row: dict[str, Any] = {
+            "catalog_name": self.name,
+            "table_namespace": namespace,
+            "table_name": table_name,
+            "metadata_location": metadata_location,
+            "previous_metadata_location": None,
+        }
+        if self._schema_version == "v1":
+            row["iceberg_type"] = "TABLE"
+        return row
 
     def _convert_orm_to_iceberg(self, orm_table: IcebergTables) -> Table:
         # Check for expected properties.
@@ -235,15 +281,7 @@ class SqlCatalog(MetastoreCatalog):
 
         with Session(self.engine) as session:
             try:
-                session.add(
-                    IcebergTables(
-                        catalog_name=self.name,
-                        table_namespace=namespace,
-                        table_name=table_name,
-                        metadata_location=metadata_location,
-                        previous_metadata_location=None,
-                    )
-                )
+                session.execute(insert(IcebergTables).values(**self._create_table_row(namespace, table_name, metadata_location)))
                 session.commit()
             except IntegrityError as e:
                 raise TableAlreadyExistsError(f"Table {namespace}.{table_name} already exists") from e
@@ -272,15 +310,7 @@ class SqlCatalog(MetastoreCatalog):
 
         with Session(self.engine) as session:
             try:
-                session.add(
-                    IcebergTables(
-                        catalog_name=self.name,
-                        table_namespace=namespace,
-                        table_name=table_name,
-                        metadata_location=metadata_location,
-                        previous_metadata_location=None,
-                    )
-                )
+                session.execute(insert(IcebergTables).values(**self._create_table_row(namespace, table_name, metadata_location)))
                 session.commit()
             except IntegrityError as e:
                 raise TableAlreadyExistsError(f"Table {namespace}.{table_name} already exists") from e
@@ -494,15 +524,8 @@ class SqlCatalog(MetastoreCatalog):
             else:
                 # table does not exist, create it
                 try:
-                    session.add(
-                        IcebergTables(
-                            catalog_name=self.name,
-                            table_namespace=namespace,
-                            table_name=table_name,
-                            metadata_location=updated_staged_table.metadata_location,
-                            previous_metadata_location=None,
-                        )
-                    )
+                    row = self._create_table_row(namespace, table_name, updated_staged_table.metadata_location)
+                    session.execute(insert(IcebergTables).values(**row))
                     session.commit()
                 except IntegrityError as e:
                     raise TableAlreadyExistsError(f"Table {namespace}.{table_name} already exists") from e
@@ -616,8 +639,12 @@ class SqlCatalog(MetastoreCatalog):
         stmt = select(IcebergTables).where(
             IcebergTables.catalog_name == self.name,
             IcebergTables.table_namespace == namespace,
-            (IcebergTables.iceberg_type == "TABLE") | (IcebergTables.iceberg_type.is_(None)),
         )
+
+        # Filter out views only if schema_version is v1
+        if self._schema_version == "v1":
+            stmt = stmt.where((IcebergTables.iceberg_type == "TABLE") | (IcebergTables.iceberg_type.is_(None)))
+
         with Session(self.engine) as session:
             result = session.scalars(stmt)
             return [(Catalog.identifier_to_tuple(table.table_namespace) + (table.table_name,)) for table in result]

--- a/tests/catalog/test_sql.py
+++ b/tests/catalog/test_sql.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import cast
 
 import pytest
-from sqlalchemy import Engine, create_engine, inspect
+from sqlalchemy import Engine, create_engine, inspect, text
 from sqlalchemy.exc import ArgumentError
 
 from pyiceberg.catalog import load_catalog
@@ -261,3 +261,83 @@ class TestSqlCatalogClose:
 
         # Second close should not raise an exception
         catalog_sqlite.close()
+
+
+def _create_pre_migration_schema_tables(engine: Engine) -> None:
+    with engine.connect() as conn:
+        conn.execute(
+            text(
+                "CREATE TABLE iceberg_tables ("
+                "  catalog_name VARCHAR(255) NOT NULL,"
+                "  table_namespace VARCHAR(255) NOT NULL,"
+                "  table_name VARCHAR(255) NOT NULL,"
+                "  metadata_location VARCHAR(1000),"
+                "  previous_metadata_location VARCHAR(1000),"
+                "  PRIMARY KEY (catalog_name, table_namespace, table_name)"
+                ")"
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE TABLE iceberg_namespace_properties ("
+                "  catalog_name VARCHAR(255) NOT NULL,"
+                "  namespace VARCHAR(255) NOT NULL,"
+                "  property_key VARCHAR(255) NOT NULL,"
+                "  property_value VARCHAR(1000) NOT NULL,"
+                "  PRIMARY KEY (catalog_name, namespace, property_key)"
+                ")"
+            )
+        )
+        conn.commit()
+
+
+def get_columns(engine: Engine) -> set[str]:
+    return {c["name"] for c in inspect(engine).get_columns("iceberg_tables")}
+
+
+def test_adds_iceberg_type_column_to_old_schema(warehouse: Path) -> None:
+    # Create the old schema tables
+    uri = f"sqlite:////{warehouse}/test-migration-add-col"
+    engine = create_engine(uri)
+    with engine.connect() as conn:
+        conn.execute(
+            text(
+                "CREATE TABLE iceberg_tables ("
+                "  catalog_name VARCHAR(255) NOT NULL,"
+                "  table_namespace VARCHAR(255) NOT NULL,"
+                "  table_name VARCHAR(255) NOT NULL,"
+                "  metadata_location VARCHAR(1000),"
+                "  previous_metadata_location VARCHAR(1000),"
+                "  PRIMARY KEY (catalog_name, table_namespace, table_name)"
+                ")"
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE TABLE iceberg_namespace_properties ("
+                "  catalog_name VARCHAR(255) NOT NULL,"
+                "  namespace VARCHAR(255) NOT NULL,"
+                "  property_key VARCHAR(255) NOT NULL,"
+                "  property_value VARCHAR(1000) NOT NULL,"
+                "  PRIMARY KEY (catalog_name, namespace, property_key)"
+                ")"
+            )
+        )
+        conn.commit()
+
+    # Verify the column does not exist in the old schema
+    assert "iceberg_type" not in get_columns(engine)
+
+    # Load the catalog and verify the column exists
+    catalog = SqlCatalog("test", uri=uri, warehouse=f"file://{warehouse}", init_catalog_tables="false")
+    assert "iceberg_type" in get_columns(catalog.engine)
+
+
+def test_idempotent_when_column_already_exists(warehouse: Path) -> None:
+    # Verify the column was created by the init_tables call
+    catalog = SqlCatalog("test", uri="sqlite:///:memory:", warehouse=f"file://{warehouse}")
+    assert "iceberg_type" in get_columns(catalog.engine)
+
+    # Verify the method is idempotent by calling it again
+    catalog._update_tables_if_required()
+    assert "iceberg_type" in get_columns(catalog.engine)

--- a/tests/catalog/test_sql.py
+++ b/tests/catalog/test_sql.py
@@ -263,34 +263,6 @@ class TestSqlCatalogClose:
         catalog_sqlite.close()
 
 
-def _create_pre_migration_schema_tables(engine: Engine) -> None:
-    with engine.connect() as conn:
-        conn.execute(
-            text(
-                "CREATE TABLE iceberg_tables ("
-                "  catalog_name VARCHAR(255) NOT NULL,"
-                "  table_namespace VARCHAR(255) NOT NULL,"
-                "  table_name VARCHAR(255) NOT NULL,"
-                "  metadata_location VARCHAR(1000),"
-                "  previous_metadata_location VARCHAR(1000),"
-                "  PRIMARY KEY (catalog_name, table_namespace, table_name)"
-                ")"
-            )
-        )
-        conn.execute(
-            text(
-                "CREATE TABLE iceberg_namespace_properties ("
-                "  catalog_name VARCHAR(255) NOT NULL,"
-                "  namespace VARCHAR(255) NOT NULL,"
-                "  property_key VARCHAR(255) NOT NULL,"
-                "  property_value VARCHAR(1000) NOT NULL,"
-                "  PRIMARY KEY (catalog_name, namespace, property_key)"
-                ")"
-            )
-        )
-        conn.commit()
-
-
 def get_columns(engine: Engine) -> set[str]:
     return {c["name"] for c in inspect(engine).get_columns("iceberg_tables")}
 
@@ -341,3 +313,34 @@ def test_idempotent_when_column_already_exists(warehouse: Path) -> None:
     # Verify the method is idempotent by calling it again
     catalog._update_tables_if_required()
     assert "iceberg_type" in get_columns(catalog.engine)
+
+
+def test_list_tables_filters_by_iceberg_type(warehouse: Path) -> None:
+    catalog = SqlCatalog("test", uri="sqlite:///:memory:", warehouse=f"file://{warehouse}")
+    catalog.create_namespace("ns")
+    schema = Schema(NestedField(1, "id", StringType(), required=True))
+    catalog.create_table(("ns", "table_V1"), schema)
+
+    # Insert a legac-schema row (iceberg_type IS NULL), so itshould appear in list_tables
+    with catalog.engine.connect() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO iceberg_tables "
+                "(catalog_name, table_namespace, table_name, metadata_location, previous_metadata_location, iceberg_type) "
+                "VALUES ('test', 'ns', 'table_V0', NULL, NULL, NULL)"
+            )
+        )
+        # Insert a non-TABLE row — should NOT appear in list_tables
+        conn.execute(
+            text(
+                "INSERT INTO iceberg_tables "
+                "(catalog_name, table_namespace, table_name, metadata_location, previous_metadata_location, iceberg_type) "
+                "VALUES ('test', 'ns', 'some_view', NULL, NULL, 'VIEW')"
+            )
+        )
+        conn.commit()
+
+    tables = [t[-1] for t in catalog.list_tables("ns")]
+    assert "table_V1" in tables
+    assert "table_V0" in tables
+    assert "some_view" not in tables

--- a/tests/catalog/test_sql.py
+++ b/tests/catalog/test_sql.py
@@ -268,8 +268,143 @@ def get_columns(engine: Engine) -> set[str]:
 
 
 def test_adds_iceberg_type_column_to_old_schema(warehouse: Path) -> None:
-    # Create the old schema tables
     uri = f"sqlite:////{warehouse}/test-migration-add-col"
+    engine = _create_v0_db(uri)
+
+    # Verify the column does not exist in the old schema
+    assert "iceberg_type" not in get_columns(engine)
+
+    # Load the catalog with schema_version='v1' to trigger migration
+    catalog = SqlCatalog(
+        name="test",
+        uri=uri,
+        warehouse=f"file://{warehouse}",
+        init_catalog_tables="false",
+        schema_version="v1",
+    )
+    assert "iceberg_type" in get_columns(catalog.engine)
+
+
+def test_idempotent_when_column_already_exists(warehouse: Path) -> None:
+    catalog = SqlCatalog(
+        name="test",
+        uri="sqlite:///:memory:",
+        warehouse=f"file://{warehouse}",
+    )
+    assert "iceberg_type" in get_columns(catalog.engine)
+
+    # Verify initialization is idempotent when column already exists
+    catalog._init_catalog()
+    assert "iceberg_type" in get_columns(catalog.engine)
+
+
+def test_list_tables_filters_by_iceberg_type(warehouse: Path) -> None:
+    catalog = SqlCatalog(
+        name="test",
+        uri="sqlite:///:memory:",
+        warehouse=f"file://{warehouse}",
+    )
+    catalog.create_namespace("ns")
+    schema = Schema(NestedField(1, "id", StringType(), required=True))
+    catalog.create_table(("ns", "table_V1"), schema)
+
+    # Insert a legacy-schema row (iceberg_type IS NULL); should appear in list_tables.
+    with catalog.engine.connect() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO iceberg_tables "
+                "(catalog_name, table_namespace, table_name, metadata_location, previous_metadata_location, iceberg_type) "
+                "VALUES ('test', 'ns', 'table_V0', NULL, NULL, NULL)"
+            )
+        )
+        # Insert a non-TABLE row; should NOT appear in list_tables.
+        conn.execute(
+            text(
+                "INSERT INTO iceberg_tables "
+                "(catalog_name, table_namespace, table_name, metadata_location, previous_metadata_location, iceberg_type) "
+                "VALUES ('test', 'ns', 'some_view', NULL, NULL, 'VIEW')"
+            )
+        )
+        conn.commit()
+
+    tables = [t[-1] for t in catalog.list_tables("ns")]
+    assert "table_V1" in tables
+    assert "table_V0" in tables
+    assert "some_view" not in tables
+
+
+def test_migration_to_v1_with_property_set(warehouse: Path) -> None:
+    uri = f"sqlite:////{warehouse}/test-v1-migrate"
+    engine = _create_v0_db(uri)
+
+    assert "iceberg_type" not in get_columns(engine)
+
+    catalog = SqlCatalog(
+        name="test",
+        uri=uri,
+        warehouse=f"file://{warehouse}",
+        init_catalog_tables="false",
+        schema_version="v1",
+    )
+    assert "iceberg_type" in get_columns(catalog.engine)
+
+
+def test_invalid_schema_version_raises(warehouse: Path) -> None:
+    with pytest.raises(ValueError, match="Invalid schema_version"):
+        SqlCatalog(
+            name="test",
+            uri="sqlite:///:memory:",
+            warehouse=f"file://{warehouse}",
+            schema_version="invalid",
+        )
+
+
+def test_list_tables_works_on_v0_schema(warehouse: Path) -> None:
+    """list_tables should work on V0 schemas without iceberg_type column."""
+    uri = f"sqlite:////{warehouse}/test-v0-list"
+    _create_v0_db(uri)
+
+    catalog = SqlCatalog(
+        name="test",
+        uri=uri,
+        warehouse=f"file://{warehouse}",
+        init_catalog_tables="false",
+    )
+
+    # Create namespace directly
+    with catalog.engine.connect() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO iceberg_namespace_properties "
+                "(catalog_name, namespace, property_key, property_value) "
+                "VALUES ('test', 'ns', 'exists', 'true')"
+            )
+        )
+        # Insert rows (all are tables on V0, no iceberg_type column to distinguish)
+        conn.execute(
+            text(
+                "INSERT INTO iceberg_tables "
+                "(catalog_name, table_namespace, table_name, metadata_location, previous_metadata_location) "
+                "VALUES ('test', 'ns', 'table1', 'loc1', NULL)"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO iceberg_tables "
+                "(catalog_name, table_namespace, table_name, metadata_location, previous_metadata_location) "
+                "VALUES ('test', 'ns', 'table2', 'loc2', NULL)"
+            )
+        )
+        conn.commit()
+
+    # list_tables should work on V0 (no iceberg_type filtering)
+    tables = [t[-1] for t in catalog.list_tables("ns")]
+    assert "table1" in tables
+    assert "table2" in tables
+
+
+def _create_v0_db(uri: str) -> Engine:
+    """Create a SQLite DB with V0 schema (no iceberg_type column). Returns the engine."""
     engine = create_engine(uri)
     with engine.connect() as conn:
         conn.execute(
@@ -296,51 +431,33 @@ def test_adds_iceberg_type_column_to_old_schema(warehouse: Path) -> None:
             )
         )
         conn.commit()
-
-    # Verify the column does not exist in the old schema
-    assert "iceberg_type" not in get_columns(engine)
-
-    # Load the catalog and verify the column exists
-    catalog = SqlCatalog("test", uri=uri, warehouse=f"file://{warehouse}", init_catalog_tables="false")
-    assert "iceberg_type" in get_columns(catalog.engine)
+    return engine
 
 
-def test_idempotent_when_column_already_exists(warehouse: Path) -> None:
-    # Verify the column was created by the init_tables call
-    catalog = SqlCatalog("test", uri="sqlite:///:memory:", warehouse=f"file://{warehouse}")
-    assert "iceberg_type" in get_columns(catalog.engine)
-
-    # Verify the method is idempotent by calling it again
-    catalog._update_tables_if_required()
-    assert "iceberg_type" in get_columns(catalog.engine)
+def _make_v0_catalog(uri: str, warehouse: Path) -> SqlCatalog:
+    _create_v0_db(uri)
+    return SqlCatalog("test", uri=uri, warehouse=f"file://{warehouse}", init_catalog_tables="false")
 
 
-def test_list_tables_filters_by_iceberg_type(warehouse: Path) -> None:
-    catalog = SqlCatalog("test", uri="sqlite:///:memory:", warehouse=f"file://{warehouse}")
+def test_namespace_exists_on_v0_schema(warehouse: Path) -> None:
+    """namespace_exists should not fail on V0 schema (no iceberg_type column)."""
+    catalog = _make_v0_catalog(f"sqlite:////{warehouse}/test-v0-ns-exists", warehouse)
+    catalog.create_namespace("ns")
+    assert catalog.namespace_exists("ns")
+    assert not catalog.namespace_exists("missing")
+
+
+def test_create_and_load_table_on_v0_schema(warehouse: Path) -> None:
+    """create_table and load_table should work on V0 schema without iceberg_type column."""
+    catalog = _make_v0_catalog(f"sqlite:////{warehouse}/test-v0-create", warehouse)
     catalog.create_namespace("ns")
     schema = Schema(NestedField(1, "id", StringType(), required=True))
-    catalog.create_table(("ns", "table_V1"), schema)
+    tbl = catalog.create_table(("ns", "tbl"), schema)
+    assert tbl.name() == ("ns", "tbl")
 
-    # Insert a legac-schema row (iceberg_type IS NULL), so itshould appear in list_tables
-    with catalog.engine.connect() as conn:
-        conn.execute(
-            text(
-                "INSERT INTO iceberg_tables "
-                "(catalog_name, table_namespace, table_name, metadata_location, previous_metadata_location, iceberg_type) "
-                "VALUES ('test', 'ns', 'table_V0', NULL, NULL, NULL)"
-            )
-        )
-        # Insert a non-TABLE row — should NOT appear in list_tables
-        conn.execute(
-            text(
-                "INSERT INTO iceberg_tables "
-                "(catalog_name, table_namespace, table_name, metadata_location, previous_metadata_location, iceberg_type) "
-                "VALUES ('test', 'ns', 'some_view', NULL, NULL, 'VIEW')"
-            )
-        )
-        conn.commit()
+    # load_table must work without iceberg_type in the SELECT
+    loaded = catalog.load_table(("ns", "tbl"))
+    assert loaded.name() == ("ns", "tbl")
 
-    tables = [t[-1] for t in catalog.list_tables("ns")]
-    assert "table_V1" in tables
-    assert "table_V0" in tables
-    assert "some_view" not in tables
+    # iceberg_type column must still be absent from the DB (no migration occurred)
+    assert "iceberg_type" not in get_columns(catalog.engine)


### PR DESCRIPTION
# Rationale for this change

Pyiceberg currently does not include the `iceberg_type` column in the `iceberg_tables`  table for SQL-based catalogs. This caused an error when reading a SQL-based Catalog from iceberg-rust, which expected this column. I will also update iceberg-rust to be more defensive like this PR.

The fix here is done exactly how iceberg-java handles this. We do an idempotent `ALTER TABLE iceberg_tables ADD COLUMN iceberg_type` after ensuring `iceberg_tables` exists. We explicitly use the try/catch to make it idempotent because older sqlite versions do not support `IF NOT EXISTS` for column creation. For newly created tables, the addition to the sqlalchemy table will create the column. For existing tables, this backwards-compatible schema update will hit.

- https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java#L227
- https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/jdbc/JdbcUtil.java#L150
- https://github.com/apache/iceberg/blob/main/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcUtil.java#L58

## Are these changes tested?

**Unit Testing**

1. Unit test for the migration case
2. Unit test for new table creation and idempotency

**End-to-end Testing**

```sh
# Case 1. New Catalog

# Catalog definition
$ cat ~/.pyiceberg.yaml | yq .catalog.tmp
type: sql
uri: sqlite:////tmp/pyiceberg.db

# Trigger initialization of catalog tables
$ pyiceberg --catalog tmp list

# Verify Schema
sqlite> .schema iceberg_tables
CREATE TABLE iceberg_tables (
        catalog_name VARCHAR(255) NOT NULL, 
        table_namespace VARCHAR(255) NOT NULL, 
        table_name VARCHAR(255) NOT NULL, 
        metadata_location VARCHAR(1000), 
        previous_metadata_location VARCHAR(1000), 
 ---->  iceberg_type VARCHAR(5), 
        PRIMARY KEY (catalog_name, table_namespace, table_name)
);

# Case 2. Existing Catalog (before fix)

# This catalog was created without the fix
sqlite> .schema iceberg_tables
CREATE TABLE iceberg_tables (
        catalog_name VARCHAR(255) NOT NULL, 
        table_namespace VARCHAR(255) NOT NULL, 
        table_name VARCHAR(255) NOT NULL, 
        metadata_location VARCHAR(1000), 
        previous_metadata_location VARCHAR(1000), 
        PRIMARY KEY (catalog_name, table_namespace, table_name)
);

# Fix is now applied
# ...

# Trigger update by loading this catalog with these changes in pyiceberg
sqlite> .schema iceberg_tables
CREATE TABLE iceberg_tables (
        catalog_name VARCHAR(255) NOT NULL, 
        table_namespace VARCHAR(255) NOT NULL, 
        table_name VARCHAR(255) NOT NULL, 
        metadata_location VARCHAR(1000), 
        previous_metadata_location VARCHAR(1000),
 ---->  iceberg_type VARCHAR(5),
        PRIMARY KEY (catalog_name, table_namespace, table_name)
);
```

## Are there any user-facing changes?

No
