### PR TITLE
bug: NoopCatalog should return False, not throw error

### DIFF
--- a/pyiceberg/catalog/noop.py
+++ b/pyiceberg/catalog/noop.py
@@ -89,7 +89,7 @@ class NoopCatalog(Catalog):
         raise NotImplementedError
 
     def supports_server_side_planning(self) -> bool:
-        raise NotImplementedError
+        return False
 
     def purge_table(self, identifier: str | Identifier) -> None:
         raise NotImplementedError


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
This is a little niche. 

StaticTable uses NoopCatalog under the hood. If you attempt to call `plan_files`, it'll try to call `NoopCatalog.should_use_server_side_planning` ...which immediately throws an error.

Intuitively, this fix should make sense. Why would I throw an error when I can just return False? NoopCatalog does not support server side planning!

## Are these changes tested?
Tests should still pass.

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
