### PR TITLE
Document TableAlreadyExistsError in catalog.rename_table

### DIFF
--- a/pyiceberg/catalog/__init__.py
+++ b/pyiceberg/catalog/__init__.py
@@ -544,6 +544,7 @@ class Catalog(ABC):
 
         Raises:
             NoSuchTableError: If a table with the name does not exist.
+            TableAlreadyExistsError: If the target table already exists.
         """
 
     @abstractmethod


### PR DESCRIPTION
# Rationale for this change

Add a missing exception to `catalog.rename_table` method. 

## Are these changes tested?

No

## Are there any user-facing changes?

No

<!-- In the case of user-facing changes, please add the changelog label. -->
