### PR TITLE
fix: SaslServer busy-loop causes process hang after test suite

### DIFF
--- a/tests/catalog/test_hive.py
+++ b/tests/catalog/test_hive.py
@@ -234,10 +234,16 @@ class SaslServer(threading.Thread):
         return self._port
 
     def close(self) -> None:
-        self._socket.close()
+        try:
+            self._socket.close()
+        except Exception:
+            pass
         self.join(timeout=5)
         for client in self._clients:
-            client.close()
+            try:
+                client.close()
+            except Exception:
+                pass
 
 
 @pytest.fixture(scope="session")

--- a/tests/catalog/test_hive.py
+++ b/tests/catalog/test_hive.py
@@ -226,7 +226,7 @@ class SaslServer(threading.Thread):
                     client.write(self._response)
                     client.flush()
             except Exception:
-                pass
+                break
 
     @property
     def port(self) -> int | None:
@@ -234,13 +234,10 @@ class SaslServer(threading.Thread):
         return self._port
 
     def close(self) -> None:
-        # Close all client connections first
-        for client in self._clients:
-            try:
-                client.close()
-            except Exception:
-                pass
         self._socket.close()
+        self.join(timeout=5)
+        for client in self._clients:
+            client.close()
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

## Rationale for this change

`PYTHON=3.13 make test` hangs after all tests pass. 

The `SaslServer` test helper has `except Exception: pass` in its accept loop. After `close()` is called, `accept()` raises on every iteration but the exception is swallowed, creating a tight busy-loop that holds the GIL and prevents the process from exiting.

This is particularly severe on CPython 3.13+ on macOS, where GIL fairness changes make the main thread unable to make progress against the spinning daemon thread.

## Changes

- `except Exception: pass` -> `except Exception: break` to exit the loop when the socket is closed
- Reorder `close()`: close the server socket first (unblocks `accept()`), then `join()` the thread (ensures no more client appends), then close tracked clients

## Are these changes tested?

`PYTHON=3.13 make test` passes with clean exit.

## Are there any user-facing changes?

No.