### PR TITLE
Fixed ray session fixture for uv run

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3030,13 +3030,19 @@ def pyarrow_table_with_promoted_types(pyarrow_schema_with_promoted_types: "pa.Sc
 
 
 @pytest.fixture(scope="session")
-def ray_session() -> Generator[Any, None, None]:
+def ray_session(tmp_path_factory: pytest.TempPathFactory) -> Generator[Any, None, None]:
     """Fixture to manage Ray initialization and shutdown for tests."""
+    os.environ["RAY_ENABLE_UV_RUN_RUNTIME_ENV"] = (
+        "0"  # Disable Ray's uv-run runtime env propagation to keep test workers isolated.
+    )
+
     import ray
+
+    working_dir = str(tmp_path_factory.mktemp("ray-working-dir"))
 
     ray.init(
         ignore_reinit_error=True,
-        runtime_env={"working_dir": None},  # Prevent Ray from serializing the working directory to workers
+        runtime_env={"working_dir": working_dir},  # Prevent Ray from serializing the working directory to workers
     )
     yield ray
     ray.shutdown()


### PR DESCRIPTION
## Summary
Closes #3318. (cc. @Fokko)

- use a temporary working directory for the session-scoped Ray fixture
- disable Ray's uv runtime-env hook before importing Ray in `ray_session`



## Testing
- `uv run pytest tests/integration/test_reads.py -m integration -k 'test_ray_' -vv`


before upgrading
```shell
❯ uv run pytest tests/integration/test_reads.py -m integration -k 'test_ray_'; uv pip list | grep ray
===================================================================== test session starts ======================================================================
platform darwin -- Python 3.10.19, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/jj/workspace/opensource/iceberg-python
configfile: pyproject.toml
plugins: mock-3.15.1, anyio-4.11.0, lazy-fixtures-1.4.0, checkdocs-2.14.0, requests-mock-1.12.1
collected 109 items / 101 deselected / 8 selected

tests/integration/test_reads.py ....ss..                                                                                                                 [100%]

======================================================== 6 passed, 2 skipped, 101 deselected in 15.67s =========================================================
aws-xray-sdk                  2.15.0
ray                           2.54.1
```

after,
```shell
❯ uv run pytest tests/integration/test_reads.py -m integration -k 'test_ray_'; uv pip list | grep ray
===================================================================== test session starts ======================================================================
platform darwin -- Python 3.10.19, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/jj/workspace/opensource/iceberg-python
configfile: pyproject.toml
plugins: mock-3.15.1, anyio-4.11.0, lazy-fixtures-1.4.0, checkdocs-2.14.0, requests-mock-1.12.1
collected 109 items / 101 deselected / 8 selected

tests/integration/test_reads.py ....ss..                                                                                                                 [100%]

======================================================== 6 passed, 2 skipped, 101 deselected in 15.01s =========================================================
aws-xray-sdk                  2.15.0
ray                           2.55.1
```