### PR TITLE
fix(tests): isolate state in test_write_optional_list

### DIFF
--- a/tests/integration/test_writes/test_writes.py
+++ b/tests/integration/test_writes/test_writes.py
@@ -2027,7 +2027,7 @@ def test_write_optional_list(session_catalog: Catalog) -> None:
             required=False,
         ),
     )
-    session_catalog.create_table_if_not_exists(identifier, schema)
+    _create_table(session_catalog, identifier, schema=schema)
 
     df_1 = pa.Table.from_pylist(
         [


### PR DESCRIPTION
# Rationale for this change

`test_write_optional_list` uses `create_table_if_not_exists` and then asserts exact row counts (2 after the first append, 4 after the second). The table is reused across runs, so a second invocation against the same docker-compose stack accumulates rows — counts become 6, 10, 14, … and the asserts fail.

CI hides this because it spins up a fresh `docker-compose-integration` stack for every job. Locally it bites anyone who runs `make test-integration-exec` twice without `make test-integration-cleanup` in between.

Fix: drop the table at the start so the test always starts from a clean slate, matching the `drop-then-create` pattern used by `_create_table()` for every other write test in this module.

# Are these changes tested?

Yes — verified locally that the test now passes when run twice back-to-back without resetting the docker stack:

```bash
docker compose -f dev/docker-compose-integration.yml up -d --wait
uv run python dev/provision.py
uv run python -m pytest tests/integration/test_writes/test_writes.py::test_write_optional_list -m integration  # PASS
uv run python -m pytest tests/integration/test_writes/test_writes.py::test_write_optional_list -m integration  # PASS (was previously: 8 == 2)
```

Full `tests/integration/test_writes/test_writes.py` suite: 122 passed, 1 skipped.

# Are there any user-facing changes?

No.

---

Noticed while preparing the PR for #2152 (`RecordBatchReader` streaming append).