### PR TITLE
docs: clarify table write API docstrings

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -1378,7 +1378,7 @@ class Table:
         Shorthand API for appending a PyArrow table to the table.
 
         Args:
-            df: The Arrow dataframe that will be appended to overwrite the table
+            df: The Arrow dataframe that will be appended to the table
             snapshot_properties: Custom properties to be added to the snapshot summary
             branch: Branch Reference to run the append operation
         """
@@ -1466,6 +1466,9 @@ class Table:
 
         Args:
             file_paths: The list of full file paths to be added as data files to the table
+            snapshot_properties: Custom properties to be added to the snapshot summary
+            check_duplicate_files: Whether to check if the files are already present in the table
+            branch: Branch Reference to run the add-files operation
 
         Raises:
             FileNotFoundError: If the file does not exist.
@@ -1479,6 +1482,11 @@ class Table:
             )
 
     def update_spec(self, case_sensitive: bool = True) -> UpdateSpec:
+        """Create a new UpdateSpec to update the partitioning of the table.
+
+        Args:
+            case_sensitive: Whether column name matching should be case-sensitive.
+        """
         return UpdateSpec(Transaction(self, autocommit=True), case_sensitive=case_sensitive)
 
     def refs(self) -> dict[str, SnapshotRef]:


### PR DESCRIPTION
<!-- Closes #1056 -->

# Rationale for this change

Issue #1056 tracks missing or incomplete docstrings in PyIceberg public APIs. While reviewing the table write helpers, I noticed a few small gaps in the `Table` API docs:

- `append` described the input dataframe as overwriting the table, although the method appends rows.
- `add_files` documented only `file_paths`, even though the public method also accepts snapshot properties, duplicate-file checking, and branch selection.
- `update_spec` did not have a public docstring, unlike the surrounding table update helpers.

# What changes are included in this PR?

This PR makes a small documentation-only update to `pyiceberg/table/__init__.py`:

- clarifies the `append` argument description
- adds missing `add_files` argument descriptions
- adds a short `update_spec` docstring with its `case_sensitive` argument

## Are these changes tested?

Yes. I ran the following local checks:

- `uv tool run ruff@0.14.3 check --config pyproject.toml pyiceberg/table/__init__.py`
  - Result: `All checks passed!`
- `uv tool run pydocstyle@6.3.0 --ignore=D100,D102,D101,D103,D104,D107,D203,D212,D213,D404,D405,D406,D407,D411,D413,D415,D417 pyiceberg/table/__init__.py`
  - Result: passed with no output
- `git diff --check`
  - Result: passed with no whitespace errors

## Are there any user-facing changes?

Yes, documentation-only. The public API docs are clearer, but runtime behavior is unchanged.

## LLM-generated code disclosure

This documentation update was prepared with assistance from OpenAI Codex and manually reviewed before submission.
