### PR TITLE
REST: Add pagination support for list_views

### DIFF
--- a/pyiceberg/catalog/rest/__init__.py
+++ b/pyiceberg/catalog/rest/__init__.py
@@ -370,6 +370,7 @@ class ListTablesResponse(IcebergBaseModel):
 
 class ListViewsResponse(IcebergBaseModel):
     identifiers: list[ListViewResponseEntry] = Field()
+    next_page_token: str | None = Field(default=None, alias="next-page-token")
 
 
 _PLANNING_RESPONSE_ADAPTER = TypeAdapter(PlanningResponse)
@@ -1102,12 +1103,31 @@ class RestCatalog(Catalog):
             return []
         namespace_tuple = self._check_valid_namespace_identifier(namespace)
         namespace_concat = self._encode_namespace_path(namespace_tuple)
-        response = self._session.get(self.url(Endpoints.list_views, namespace=namespace_concat))
-        try:
-            response.raise_for_status()
-        except HTTPError as exc:
-            _handle_non_200_response(exc, {404: NoSuchNamespaceError})
-        return [(*view.namespace, view.name) for view in ListViewsResponse.model_validate_json(response.text).identifiers]
+
+        all_identifiers: list[Identifier] = []
+        page_token: str | None = None
+
+        while True:
+            # Build URL with pagination params
+            url = self.url(Endpoints.list_views, namespace=namespace_concat)
+            if page_token:
+                url = f"{url}?pageToken={page_token}"
+
+            response = self._session.get(url)
+            try:
+                response.raise_for_status()
+            except HTTPError as exc:
+                _handle_non_200_response(exc, {404: NoSuchNamespaceError})
+
+            parsed = ListViewsResponse.model_validate_json(response.text)
+            all_identifiers.extend([(*view.namespace, view.name) for view in parsed.identifiers])
+
+            # Check if more pages exist
+            if not parsed.next_page_token:
+                break
+            page_token = parsed.next_page_token
+
+        return all_identifiers
 
     @retry(**_RETRY_ARGS)
     def commit_table(

--- a/pyiceberg/catalog/rest/__init__.py
+++ b/pyiceberg/catalog/rest/__init__.py
@@ -1103,31 +1103,27 @@ class RestCatalog(Catalog):
             return []
         namespace_tuple = self._check_valid_namespace_identifier(namespace)
         namespace_concat = self._encode_namespace_path(namespace_tuple)
+        url = self.url(Endpoints.list_views, namespace=namespace_concat)
 
-        all_identifiers: list[Identifier] = []
+        views: list[Identifier] = []
         page_token: str | None = None
 
         while True:
-            # Build URL with pagination params
-            url = self.url(Endpoints.list_views, namespace=namespace_concat)
-            if page_token:
-                url = f"{url}?pageToken={page_token}"
-
-            response = self._session.get(url)
+            params = {"pageToken": page_token} if page_token else None
+            response = self._session.get(url, params=params)
             try:
                 response.raise_for_status()
             except HTTPError as exc:
                 _handle_non_200_response(exc, {404: NoSuchNamespaceError})
 
             parsed = ListViewsResponse.model_validate_json(response.text)
-            all_identifiers.extend([(*view.namespace, view.name) for view in parsed.identifiers])
+            views.extend([(*view.namespace, view.name) for view in parsed.identifiers])
 
-            # Check if more pages exist
             if not parsed.next_page_token:
                 break
             page_token = parsed.next_page_token
 
-        return all_identifiers
+        return views
 
     @retry(**_RETRY_ARGS)
     def commit_table(

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -687,6 +687,42 @@ def test_list_views_paginated_200(rest_mock: Mocker) -> None:
     ]
 
 
+def test_list_views_paginated_200_none_next_page_token(rest_mock: Mocker) -> None:
+    namespace = "examples"
+    # First page with next-page-token
+    rest_mock.get(
+        f"{TEST_URI}v1/namespaces/{namespace}/views",
+        json={
+            "identifiers": [
+                {"namespace": ["examples"], "name": "view1"},
+                {"namespace": ["examples"], "name": "view2"},
+            ],
+            "next-page-token": "page2token",
+        },
+        status_code=200,
+        request_headers=TEST_HEADERS,
+    )
+    # The last page with NONE next-page-token
+    rest_mock.get(
+        f"{TEST_URI}v1/namespaces/{namespace}/views?pageToken=page2token",
+        json={
+            "identifiers": [
+                {"namespace": ["examples"], "name": "view3"},
+            ],
+            "next-page-token": None,
+        },
+        status_code=200,
+        request_headers=TEST_HEADERS,
+    )
+
+    result = RestCatalog("rest", uri=TEST_URI, token=TEST_TOKEN).list_views(namespace)
+    assert result == [
+        ("examples", "view1"),
+        ("examples", "view2"),
+        ("examples", "view3"),
+    ]
+
+
 def test_list_views_200_sigv4(rest_mock: Mocker) -> None:
     namespace = "examples"
     rest_mock.get(

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -639,6 +639,54 @@ def test_list_views_200(rest_mock: Mocker) -> None:
     assert RestCatalog("rest", uri=TEST_URI, token=TEST_TOKEN).list_views(namespace) == [("examples", "fooshare")]
 
 
+def test_list_views_paginated_200(rest_mock: Mocker) -> None:
+    namespace = "examples"
+    # First page with next-page-token
+    rest_mock.get(
+        f"{TEST_URI}v1/namespaces/{namespace}/views",
+        json={
+            "identifiers": [
+                {"namespace": ["examples"], "name": "view1"},
+                {"namespace": ["examples"], "name": "view2"},
+            ],
+            "next-page-token": "page2token",
+        },
+        status_code=200,
+        request_headers=TEST_HEADERS,
+    )
+    # Second page with next-page-token
+    rest_mock.get(
+        f"{TEST_URI}v1/namespaces/{namespace}/views?pageToken=page2token",
+        json={
+            "identifiers": [
+                {"namespace": ["examples"], "name": "view3"},
+            ],
+            "next-page-token": "page3token",
+        },
+        status_code=200,
+        request_headers=TEST_HEADERS,
+    )
+    # Third page without next-page-token (last page)
+    rest_mock.get(
+        f"{TEST_URI}v1/namespaces/{namespace}/views?pageToken=page3token",
+        json={
+            "identifiers": [
+                {"namespace": ["examples"], "name": "view4"},
+            ],
+        },
+        status_code=200,
+        request_headers=TEST_HEADERS,
+    )
+
+    result = RestCatalog("rest", uri=TEST_URI, token=TEST_TOKEN).list_views(namespace)
+    assert result == [
+        ("examples", "view1"),
+        ("examples", "view2"),
+        ("examples", "view3"),
+        ("examples", "view4"),
+    ]
+
+
 def test_list_views_200_sigv4(rest_mock: Mocker) -> None:
     namespace = "examples"
     rest_mock.get(


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

Follows REST catalog spec: 

- /v1/{prefix}/views: https://github.com/apache/iceberg/blob/e7a5a87f26f9de5b200254155aa037368b13a29c/open-api/rest-catalog-open-api.yaml#L1525-L1562
- ListTablesResponse: https://github.com/apache/iceberg/blob/e7a5a87f26f9de5b200254155aa037368b13a29c/open-api/rest-catalog-open-api.yaml#L4210-L4219
- PageToken: https://github.com/apache/iceberg/blob/e7a5a87f26f9de5b200254155aa037368b13a29c/open-api/rest-catalog-open-api.yaml#L2233-L2256

## Are these changes tested?

Yes, includes unit tests for paginated cases.

## Are there any user-facing changes?

- Before: returned incomplete view list when server paginated (only first page)
- After: returns complete view list (fetches all pages)

<!-- In the case of user-facing changes, please add the changelog label. -->
