### PR TITLE
fix: avoid TSaslClientTransport reuse to eliminate server-side SASL noise

### DIFF
--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -142,9 +142,17 @@ logger = logging.getLogger(__name__)
 
 
 class _HiveClient:
-    """Helper class to nicely open and close the transport."""
+    """Helper class to nicely open and close the transport.
 
-    _transport: TTransport
+    ``TSaslClientTransport`` instances are single-use: ``close()`` disposes
+    the SASL session and the same instance cannot be reopened. The
+    transport is therefore created lazily in ``__enter__`` rather than held
+    on the class, which lets the ``_HiveClient`` itself live for the
+    duration of a ``HiveCatalog`` while still honouring the SASL transport
+    lifecycle.
+    """
+
+    _transport: "TTransport | None"
     _ugi: list[str] | None
 
     def __init__(
@@ -158,7 +166,7 @@ class _HiveClient:
         self._kerberos_auth = kerberos_auth
         self._kerberos_service_name = kerberos_service_name
         self._ugi = ugi.split(":") if ugi else None
-        self._transport = self._init_thrift_transport()
+        self._transport = None
 
     def _init_thrift_transport(self) -> TTransport:
         url_parts = urlparse(self._uri)
@@ -169,6 +177,7 @@ class _HiveClient:
             return TTransport.TSaslClientTransport(socket, host=url_parts.hostname, service=self._kerberos_service_name)
 
     def _client(self) -> Client:
+        assert self._transport is not None  # set by __enter__
         protocol = TBinaryProtocol.TBinaryProtocol(self._transport)
         client = Client(protocol)
         if self._ugi:
@@ -176,24 +185,20 @@ class _HiveClient:
         return client
 
     def __enter__(self) -> Client:
-        """Make sure the transport is initialized and open."""
-        if not self._transport.isOpen():
-            try:
-                self._transport.open()
-            except (TypeError, TTransport.TTransportException):
-                # Close the old transport before reinitializing to prevent resource leaks
-                try:
-                    self._transport.close()
-                except Exception:
-                    pass
-                # reinitialize _transport
-                self._transport = self._init_thrift_transport()
-                self._transport.open()
-        return self._client()  # recreate the client
+        """Initialize and open a fresh transport for this entry.
+
+        A new ``TSaslClientTransport`` is created on every entry because
+        the underlying SASL session cannot be reused after ``close()``.
+        Reusing a closed transport would leave a half-opened TCP socket
+        and SASL handshake EOF noise on the server.
+        """
+        self._transport = self._init_thrift_transport()
+        self._transport.open()
+        return self._client()
 
     def __exit__(self, exctype: type[BaseException] | None, excinst: BaseException | None, exctb: TracebackType | None) -> None:
         """Close transport if it was opened."""
-        if self._transport.isOpen():
+        if self._transport is not None and self._transport.isOpen():
             self._transport.close()
 
 

--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -142,18 +142,11 @@ logger = logging.getLogger(__name__)
 
 
 class _HiveClient:
-    """Helper class to nicely open and close the transport.
+    """Helper class to nicely open and close the transport."""
 
-    ``TSaslClientTransport`` instances are single-use: ``close()`` disposes
-    the SASL session and the same instance cannot be reopened. The
-    transport is therefore created lazily in ``__enter__`` rather than held
-    on the class, which lets the ``_HiveClient`` itself live for the
-    duration of a ``HiveCatalog`` while still honouring the SASL transport
-    lifecycle.
-    """
-
-    _transport: "TTransport | None"
+    _transport: TTransport
     _ugi: list[str] | None
+    _was_opened: bool
 
     def __init__(
         self,
@@ -166,7 +159,8 @@ class _HiveClient:
         self._kerberos_auth = kerberos_auth
         self._kerberos_service_name = kerberos_service_name
         self._ugi = ugi.split(":") if ugi else None
-        self._transport = None
+        self._transport = self._init_thrift_transport()
+        self._was_opened = False
 
     def _init_thrift_transport(self) -> TTransport:
         url_parts = urlparse(self._uri)
@@ -177,7 +171,6 @@ class _HiveClient:
             return TTransport.TSaslClientTransport(socket, host=url_parts.hostname, service=self._kerberos_service_name)
 
     def _client(self) -> Client:
-        assert self._transport is not None  # set by __enter__
         protocol = TBinaryProtocol.TBinaryProtocol(self._transport)
         client = Client(protocol)
         if self._ugi:
@@ -185,20 +178,16 @@ class _HiveClient:
         return client
 
     def __enter__(self) -> Client:
-        """Initialize and open a fresh transport for this entry.
-
-        A new ``TSaslClientTransport`` is created on every entry because
-        the underlying SASL session cannot be reused after ``close()``.
-        Reusing a closed transport would leave a half-opened TCP socket
-        and SASL handshake EOF noise on the server.
-        """
-        self._transport = self._init_thrift_transport()
+        """Make sure the transport is initialized and open."""
+        if self._was_opened:
+            self._transport = self._init_thrift_transport()
         self._transport.open()
+        self._was_opened = True
         return self._client()
 
     def __exit__(self, exctype: type[BaseException] | None, excinst: BaseException | None, exctb: TracebackType | None) -> None:
         """Close transport if it was opened."""
-        if self._transport is not None and self._transport.isOpen():
+        if self._transport.isOpen():
             self._transport.close()
 
 

--- a/tests/catalog/test_hive.py
+++ b/tests/catalog/test_hive.py
@@ -1410,3 +1410,42 @@ def test_create_hive_client_with_kerberos_using_context_manager(
         # closing and re-opening work as expected.
         with client as open_client:
             assert open_client._iprot.trans.isOpen()
+
+
+def test_kerberized_client_uses_fresh_transport_per_entry(
+    kerberized_hive_metastore_fake_url: str,
+) -> None:
+    """TSaslClientTransport is single-use — each entry must create a new one.
+
+    The underlying SASL session cannot be reused after close(). Each
+    context-manager entry must therefore produce a fresh transport
+    instance rather than reopening the previous one (which would leave
+    a half-opened TCP socket and SASL handshake EOF noise on the server).
+    """
+    client = _HiveClient(
+        uri=kerberized_hive_metastore_fake_url,
+        kerberos_auth=True,
+    )
+    # No transport should exist until the context manager is entered.
+    assert client._transport is None
+    with (
+        patch(
+            "puresasl.mechanisms.kerberos.authGSSClientStep",
+            return_value=None,
+        ),
+        patch(
+            "puresasl.mechanisms.kerberos.authGSSClientResponse",
+            return_value=base64.b64encode(b"Some Response"),
+        ),
+        patch(
+            "puresasl.mechanisms.GSSAPIMechanism.complete",
+            return_value=True,
+        ),
+    ):
+        with client:
+            first_transport_id = id(client._transport)
+
+        with client:
+            second_transport_id = id(client._transport)
+
+        assert first_transport_id != second_transport_id

--- a/tests/catalog/test_hive.py
+++ b/tests/catalog/test_hive.py
@@ -1412,22 +1412,14 @@ def test_create_hive_client_with_kerberos_using_context_manager(
             assert open_client._iprot.trans.isOpen()
 
 
-def test_kerberized_client_uses_fresh_transport_per_entry(
+def test_kerberized_client_uses_fresh_transport_on_reuse(
     kerberized_hive_metastore_fake_url: str,
 ) -> None:
-    """TSaslClientTransport is single-use — each entry must create a new one.
-
-    The underlying SASL session cannot be reused after close(). Each
-    context-manager entry must therefore produce a fresh transport
-    instance rather than reopening the previous one (which would leave
-    a half-opened TCP socket and SASL handshake EOF noise on the server).
-    """
+    """Reusing the context manager must reinitialize the transport."""
     client = _HiveClient(
         uri=kerberized_hive_metastore_fake_url,
         kerberos_auth=True,
     )
-    # No transport should exist until the context manager is entered.
-    assert client._transport is None
     with (
         patch(
             "puresasl.mechanisms.kerberos.authGSSClientStep",


### PR DESCRIPTION
Related: #1744, #1747, #1941

# Rationale for this change

#1747 / #1941 caught the `TSaslClientTransport` reopen failure on the client side, but the doomed `open()` attempt still completes a TCP handshake before aborting, which leaves a `TTransportException` event in the HMS server log per `_HiveClient` re-entry. In production this produces a steady stream of server-side error events matched by HMS alert filters.

`TSaslClientTransport` is single-use by design: its `SASLClient` is disposed on `close()` and there is no API to reset it. Reusing the same transport across context-manager entries was the original misuse. This PR keeps the existing `_HiveClient.__init__` setup intact — the transport is still created in `__init__` so `_HiveClient` can be used without a context manager (per @kevinjqliu's note in #1747) — and reinitializes the transport before `open()` whenever the client has been used before:

```python
def __enter__(self) -> Client:
    if self._was_opened:
        self._transport = self._init_thrift_transport()
    self._transport.open()
    self._was_opened = True
    return self._client()
```

The `try/except` retry from #1747 / #1941 is removed because the failure mode it covered (reopening a disposed SASL session) cannot occur on a fresh transport.

The public behaviour of `_HiveClient` (`with hive_client as c:` returns a working `Client`, `__exit__` closes it) is unchanged.

# Are these changes tested?

- New unit test `test_kerberized_client_uses_fresh_transport_on_reuse` asserts that the transport instance differs between two consecutive context-manager entries
- Existing `test_create_hive_client_with_kerberos_using_context_manager` continues to pass

# Are there any user-facing changes?

No.
