### PR TITLE
Remove Orphan Files

### DIFF
--- a/pyiceberg/io/__init__.py
+++ b/pyiceberg/io/__init__.py
@@ -29,6 +29,9 @@ import importlib
 import logging
 import warnings
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import datetime
 from io import SEEK_SET
 from types import TracebackType
 from typing import (
@@ -254,6 +257,15 @@ class OutputFile(ABC):
         """
 
 
+@dataclass(frozen=True)
+class FileEntry:
+    """Metadata only for a single file."""
+
+    location: str
+    size: int
+    last_modified: datetime | None = None
+
+
 class FileIO(ABC):
     """A base class for FileIO implementations."""
 
@@ -290,6 +302,20 @@ class FileIO(ABC):
             PermissionError: If the file at location cannot be accessed due to a permission error.
             FileNotFoundError: When the file at the provided location does not exist.
         """
+
+    def list_prefix(self, location: str) -> Iterator[FileEntry]:
+        """Recursively list every file under the given location.
+
+        Returns metadata-only FileEntry objects.
+
+
+        Args:
+            location (str): A URI or path to recursively list.
+
+        Raises:
+            NotImplementedError: If the FileIO implementation does not support listing.
+        """
+        raise NotImplementedError(f"{type(self).__name__} does not support list_prefix")
 
 
 LOCATION = "location"

--- a/pyiceberg/io/fsspec.py
+++ b/pyiceberg/io/fsspec.py
@@ -22,8 +22,9 @@ import json
 import logging
 import os
 import threading
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from copy import copy
+from datetime import datetime, timezone
 from functools import lru_cache
 from typing import (
     TYPE_CHECKING,
@@ -83,6 +84,7 @@ from pyiceberg.io import (
     S3_SIGNER_ENDPOINT,
     S3_SIGNER_ENDPOINT_DEFAULT,
     S3_SIGNER_URI,
+    FileEntry,
     FileIO,
     InputFile,
     InputStream,
@@ -466,6 +468,30 @@ class FsspecFileIO(FileIO):
         uri = urlparse(str_location)
         fs = self._get_fs_from_uri(uri)
         fs.rm(str_location)
+
+    def list_prefix(self, location: str) -> Iterator[FileEntry]:
+        """Recursively list every file under the given location."""
+        uri = urlparse(location)
+        fs = self._get_fs_from_uri(uri)
+
+        for path, info in fs.find(location, detail=True).items():
+            if info.get("type") not in (None, "file"):
+                continue
+
+            mtime = info.get("mtime") or info.get("LastModified") or info.get("last_modified")
+            last_modified: datetime | None
+            if isinstance(mtime, datetime):
+                last_modified = mtime
+            elif isinstance(mtime, (int, float)):
+                last_modified = datetime.fromtimestamp(mtime, tz=timezone.utc)
+            else:
+                last_modified = None
+
+            yield FileEntry(
+                location=path if uri.scheme in ("", "file") else f"{uri.scheme}://{path}",
+                size=int(info.get("size") or 0),
+                last_modified=last_modified,
+            )
 
     def _get_fs_from_uri(self, uri: "ParseResult") -> AbstractFileSystem:
         """Get a filesystem from a parsed URI, using hostname for ADLS account resolution."""

--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -60,6 +60,7 @@ from pyarrow import ChunkedArray
 from pyarrow._s3fs import S3RetryStrategy
 from pyarrow.fs import (
     FileInfo,
+    FileSelector,
     FileSystem,
     FileType,
 )
@@ -114,6 +115,7 @@ from pyiceberg.io import (
     S3_ROLE_SESSION_NAME,
     S3_SECRET_ACCESS_KEY,
     S3_SESSION_TOKEN,
+    FileEntry,
     FileIO,
     InputFile,
     InputStream,
@@ -673,6 +675,36 @@ class PyArrowFileIO(FileIO):
             elif e.errno == 13 or "AWS Error [code 15]" in str(e):
                 raise PermissionError(f"Cannot delete file, access denied: {location}") from e
             raise  # pragma: no cover - If some other kind of OSError, raise the raw error
+
+    def list_prefix(self, location: str) -> Iterator[FileEntry]:
+        """Recursively list every file under the given location."""
+        original = urlparse(location)
+        scheme, netloc, path = self.parse_location(location, self.properties)
+        fs = self.fs_by_scheme(scheme, netloc)
+        selector = FileSelector(path, recursive=True, allow_not_found=True)
+
+        if original.scheme in ("hdfs", "viewfs"):
+            uri_prefix = f"{original.scheme}://{netloc}"
+            ensure_leading_slash = True
+        elif original.scheme:
+            # Cloud filesystem paths from pyarrow already start with the bucket/container.
+            uri_prefix = f"{original.scheme}://"
+            ensure_leading_slash = False
+        else:
+            uri_prefix = ""
+            ensure_leading_slash = False
+
+        for info in fs.get_file_info(selector):
+            if info.type != FileType.File:
+                continue
+            info_path = info.path
+            if ensure_leading_slash and not info_path.startswith("/"):
+                info_path = "/" + info_path
+            yield FileEntry(
+                location=f"{uri_prefix}{info_path}",
+                size=info.size or 0,
+                last_modified=info.mtime,
+            )
 
     def __getstate__(self) -> dict[str, Any]:
         """Create a dictionary of the PyArrowFileIO fields used when pickling."""

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -205,6 +205,9 @@ class TableProperties:
     MIN_SNAPSHOTS_TO_KEEP = "history.expire.min-snapshots-to-keep"
     MIN_SNAPSHOTS_TO_KEEP_DEFAULT = 1
 
+    GC_ENABLED = "gc.enabled"
+    GC_ENABLED_DEFAULT = True
+
 
 class Transaction:
     _table: Table

--- a/pyiceberg/table/maintenance/__init__.py
+++ b/pyiceberg/table/maintenance/__init__.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from pyiceberg.table import Table
+    from pyiceberg.table.maintenance.orphan_files import RemoveOrphanFiles
     from pyiceberg.table.update.snapshot import ExpireSnapshots
 
 
@@ -43,3 +44,13 @@ class MaintenanceTable:
         from pyiceberg.table.update.snapshot import ExpireSnapshots
 
         return ExpireSnapshots(transaction=Transaction(self.tbl, autocommit=True))
+
+    def remove_orphan_files(self) -> RemoveOrphanFiles:
+        """Return a RemoveOrphanFiles builder for removing files unreachable from the table.
+
+        Returns:
+            RemoveOrphanFiles builder for configuring and executing orphan file removal.
+        """
+        from pyiceberg.table.maintenance.orphan_files import RemoveOrphanFiles
+
+        return RemoveOrphanFiles(self.tbl)

--- a/pyiceberg/table/maintenance/orphan_files.py
+++ b/pyiceberg/table/maintenance/orphan_files.py
@@ -1,0 +1,414 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Action that removes files from storage that are not reachable from table metadata.
+
+Lists the table's storage location, computes the set of files referenced by any valid
+snapshot or metadata file, and deletes the difference.
+
+Only acts on files older than 3 days by default.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Callable, Iterable
+from concurrent.futures import as_completed
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+from pyiceberg.utils.concurrent import ExecutorFactory
+from pyiceberg.utils.properties import property_as_bool
+
+if TYPE_CHECKING:
+    from pyiceberg.io import FileEntry
+    from pyiceberg.table import Table
+
+logger = logging.getLogger(__name__)
+
+
+class PrefixMismatchMode(str, Enum):
+    """How to treat listed files whose URI scheme or authority differs from the referenced file.
+
+    Files may match a referenced path component-for-component but be served through a different
+    scheme (s3 vs s3a) or endpoint authority. Use ``equal_schemes`` / ``equal_authorities`` to
+    declare equivalences; this mode chooses what to do with anything that remains ambiguous.
+    """
+
+    ERROR = "ERROR"
+    IGNORE = "IGNORE"
+    DELETE = "DELETE"
+
+
+@dataclass(frozen=True)
+class RemoveOrphanFilesResult:
+    """Outcome of a RemoveOrphanFiles execution."""
+
+    orphan_file_locations: list[str] = field(default_factory=list)
+    deleted_files: list[str] = field(default_factory=list)
+    failed_to_delete: list[str] = field(default_factory=list)
+    total_bytes: int = 0
+
+
+_DEFAULT_OLDER_THAN = timedelta(days=3)
+_DEFAULT_EQUAL_SCHEMES = {"s3a": "s3", "s3n": "s3"}
+
+
+class RemoveOrphanFiles:
+    r"""Builder for the remove-orphan-files action.
+
+    Usage::
+
+        result = table.maintenance.remove_orphan_files() \
+            .older_than(datetime.now(tz=timezone.utc) - timedelta(days=7)) \
+            .execute()
+    """
+
+    _table: Table
+    _location: str | None
+    _older_than_ms: int
+    _dry_run: bool
+    _delete_with: Callable[[str], None] | None
+    _max_concurrency: int | None
+    _prefix_mismatch_mode: PrefixMismatchMode
+    _equal_schemes: dict[str, str]
+    _equal_authorities: dict[str, str]
+    _compare_to_file_list: Iterable[tuple[str, datetime]] | None
+
+    def __init__(self, table: Table) -> None:
+        self._table = table
+        self._location = None
+        self._older_than_ms = _now_ms() - int(_DEFAULT_OLDER_THAN.total_seconds() * 1000)
+        self._dry_run = False
+        self._delete_with = None
+        self._max_concurrency = None
+        self._prefix_mismatch_mode = PrefixMismatchMode.ERROR
+        self._equal_schemes = dict(_DEFAULT_EQUAL_SCHEMES)
+        self._equal_authorities = {}
+        self._compare_to_file_list = None
+
+    def location(self, location: str) -> RemoveOrphanFiles:
+        """Restrict the scan to a specific location. Defaults to the table's root location."""
+        self._location = location
+        return self
+
+    def older_than(self, value: datetime | timedelta) -> RemoveOrphanFiles:
+        """Only consider files modified strictly before this point.
+
+        Accepts either an absolute datetime or a timedelta interpreted as "files older
+        than this much" relative to now. Defaults to 3 days ago.
+        """
+        if isinstance(value, timedelta):
+            self._older_than_ms = _now_ms() - int(value.total_seconds() * 1000)
+        else:
+            if value.tzinfo is None:
+                value = value.replace(tzinfo=timezone.utc)
+            self._older_than_ms = int(value.timestamp() * 1000)
+        return self
+
+    def dry_run(self, enabled: bool = True) -> RemoveOrphanFiles:
+        """When enabled, identify orphans but do not delete them."""
+        self._dry_run = enabled
+        return self
+
+    def delete_with(self, delete_func: Callable[[str], None]) -> RemoveOrphanFiles:
+        """Use a custom deleter instead of FileIO.delete.
+
+        Useful for dry runs that collect orphans, or for routing deletes through a
+        different sink.
+        """
+        self._delete_with = delete_func
+        return self
+
+    def max_concurrency(self, max_workers: int) -> RemoveOrphanFiles:
+        """Override the worker count for manifest reads and deletes."""
+        if max_workers <= 0:
+            raise ValueError(f"max_concurrency must be positive, got {max_workers}")
+        self._max_concurrency = max_workers
+        return self
+
+    def prefix_mismatch_mode(self, mode: PrefixMismatchMode) -> RemoveOrphanFiles:
+        """Set how to handle scheme/authority mismatches between listed and referenced files."""
+        self._prefix_mismatch_mode = mode
+        return self
+
+    def equal_schemes(self, schemes: dict[str, str]) -> RemoveOrphanFiles:
+        """Declare schemes that should be considered equivalent.
+
+        Keys may be comma-separated lists of schemes that map to the canonical value, e.g.
+        ``{"s3a,s3n": "s3"}``. Extends (not replaces) the default mapping.
+        """
+        self._equal_schemes = dict(_DEFAULT_EQUAL_SCHEMES)
+        self._equal_schemes.update(_flatten_mapping(schemes))
+        return self
+
+    def equal_authorities(self, authorities: dict[str, str]) -> RemoveOrphanFiles:
+        """Declare authorities (host[:port]) that should be considered equivalent.
+
+        Keys may be comma-separated lists.
+        """
+        self._equal_authorities = _flatten_mapping(authorities)
+        return self
+
+    def compare_to_file_list(self, files: Iterable[tuple[str, datetime]]) -> RemoveOrphanFiles:
+        """Skip the storage listing step and use the provided ``(path, last_modified)`` pairs.
+
+        Useful when a caller has already enumerated storage (e.g. from an external inventory).
+        The same ``location`` and ``older_than`` filters still apply.
+        """
+        self._compare_to_file_list = files
+        return self
+
+    def execute(self) -> RemoveOrphanFilesResult:
+        """Run the action and return the result."""
+        properties = self._table.metadata.properties
+        if not property_as_bool(properties, "gc.enabled", True):
+            raise ValueError(
+                "Cannot remove orphan files: gc.enabled is false on this table "
+                "(deleting files may corrupt other tables that reference them)"
+            )
+
+        scan_location = self._location or self._table.metadata.location
+
+        referenced = self._collect_referenced_files()
+
+        candidates = self._collect_candidate_files(scan_location)
+        orphans, conflicts = _find_orphans(
+            candidates,
+            referenced,
+            self._equal_schemes,
+            self._equal_authorities,
+            self._prefix_mismatch_mode,
+        )
+
+        if conflicts and self._prefix_mismatch_mode == PrefixMismatchMode.ERROR:
+            raise ValueError(
+                "Unable to determine whether certain files are orphan. Metadata references "
+                "files that match listed files except for authority/scheme. Resolve by passing "
+                "equal_schemes() / equal_authorities(), or set prefix_mismatch_mode to IGNORE or "
+                f"DELETE. Conflicting prefixes: {sorted(conflicts)}"
+            )
+
+        total_bytes = sum(size for _, size in orphans)
+        orphan_locations = [path for path, _ in orphans]
+
+        if self._dry_run:
+            return RemoveOrphanFilesResult(
+                orphan_file_locations=orphan_locations,
+                deleted_files=[],
+                failed_to_delete=[],
+                total_bytes=total_bytes,
+            )
+
+        deleted, failed = self._delete_files(orphan_locations)
+        return RemoveOrphanFilesResult(
+            orphan_file_locations=orphan_locations,
+            deleted_files=deleted,
+            failed_to_delete=failed,
+            total_bytes=total_bytes,
+        )
+
+    def _collect_referenced_files(self) -> set[str]:
+        """Build the full set of file paths reachable from the table's current metadata."""
+        table = self._table
+        metadata = table.metadata
+        io = table.io
+
+        referenced: set[str] = set()
+        referenced.add(table.metadata_location)
+        for entry in metadata.metadata_log:
+            referenced.add(entry.metadata_file)
+        for stat in metadata.statistics:
+            referenced.add(stat.statistics_path)
+        for pstat in metadata.partition_statistics:
+            referenced.add(pstat.statistics_path)
+
+        snapshots = list(metadata.snapshots)
+        if not snapshots:
+            return referenced
+
+        executor = ExecutorFactory.get_or_create()
+
+        for snapshot in snapshots:
+            if snapshot.manifest_list:
+                referenced.add(snapshot.manifest_list)
+
+        manifest_lists = list(executor.map(lambda s: s.manifests(io), snapshots))
+        unique_manifests = {m.manifest_path: m for ms in manifest_lists for m in ms}
+        for path in unique_manifests:
+            referenced.add(path)
+
+        entries_iter = executor.map(
+            lambda m: m.fetch_manifest_entry(io=io, discard_deleted=False),
+            list(unique_manifests.values()),
+        )
+        for entries in entries_iter:
+            for entry in entries:
+                referenced.add(entry.data_file.file_path)
+
+        return referenced
+
+    def _collect_candidate_files(self, scan_location: str) -> list[tuple[str, int]]:
+        """List files to consider for deletion, applying the ``older_than`` filter."""
+        location_prefix = self._location
+        cutoff_ms = self._older_than_ms
+
+        def keep(path: str, last_modified_ms: int | None) -> bool:
+            if location_prefix is not None and not path.startswith(location_prefix):
+                return False
+            if last_modified_ms is None:
+                return True
+            return last_modified_ms < cutoff_ms
+
+        results: list[tuple[str, int]] = []
+
+        if self._compare_to_file_list is not None:
+            for path, ts in self._compare_to_file_list:
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=timezone.utc)
+                if keep(path, int(ts.timestamp() * 1000)):
+                    results.append((path, 0))
+            return results
+
+        for entry in self._iter_listing(scan_location):
+            entry_ts_ms = int(entry.last_modified.timestamp() * 1000) if entry.last_modified else None
+            if keep(entry.location, entry_ts_ms):
+                results.append((entry.location, entry.size))
+        return results
+
+    def _iter_listing(self, scan_location: str) -> Iterable[FileEntry]:
+        try:
+            return self._table.io.list_prefix(scan_location)
+        except NotImplementedError as e:
+            raise NotImplementedError(
+                f"FileIO {type(self._table.io).__name__} does not implement list_prefix; "
+                "pass compare_to_file_list() or use a FileIO that supports listing."
+            ) from e
+
+    def _delete_files(self, orphan_paths: list[str]) -> tuple[list[str], list[str]]:
+        if not orphan_paths:
+            return [], []
+
+        deleter = self._delete_with or self._table.io.delete
+
+        if self._max_concurrency == 1 or len(orphan_paths) == 1:
+            deleted: list[str] = []
+            failed: list[str] = []
+            for path in orphan_paths:
+                try:
+                    deleter(path)
+                    deleted.append(path)
+                except Exception as e:
+                    logger.warning("Failed to delete orphan file %s: %s", path, e)
+                    failed.append(path)
+            return deleted, failed
+
+        executor = ExecutorFactory.get_or_create()
+        futures = {executor.submit(deleter, path): path for path in orphan_paths}
+        deleted = []
+        failed = []
+        for fut in as_completed(futures):
+            path = futures[fut]
+            try:
+                fut.result()
+                deleted.append(path)
+            except Exception as e:
+                logger.warning("Failed to delete orphan file %s: %s", path, e)
+                failed.append(path)
+        return deleted, failed
+
+
+def _now_ms() -> int:
+    return int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+
+
+def _flatten_mapping(mapping: dict[str, str]) -> dict[str, str]:
+    """Expand comma-separated keys, e.g. ``{"s3a,s3n": "s3"}`` → ``{"s3a": "s3", "s3n": "s3"}``."""
+    out: dict[str, str] = {}
+    for keys, value in mapping.items():
+        for key in keys.split(","):
+            key = key.strip()
+            if key:
+                out[key] = value.strip()
+    return out
+
+
+def _find_orphans(
+    candidates: list[tuple[str, int]],
+    referenced: Iterable[str],
+    equal_schemes: dict[str, str],
+    equal_authorities: dict[str, str],
+    mode: PrefixMismatchMode,
+) -> tuple[list[tuple[str, int]], set[tuple[str, str]]]:
+    """Return (orphans, prefix-mismatch conflicts) for the given candidate/referenced sets."""
+    referenced_set = referenced if isinstance(referenced, set) else set(referenced)
+    normalized_referenced = {_normalize(p, equal_schemes, equal_authorities): p for p in referenced_set}
+
+    orphans: list[tuple[str, int]] = []
+    conflicts: set[tuple[str, str]] = set()
+    for path, size in candidates:
+        if path in referenced_set:
+            continue
+        normalized = _normalize(path, equal_schemes, equal_authorities)
+        if normalized in normalized_referenced:
+            referenced_original = normalized_referenced[normalized]
+            conflict = _conflict(referenced_original, path, equal_schemes, equal_authorities)
+            if conflict is not None:
+                if mode == PrefixMismatchMode.DELETE:
+                    orphans.append((path, size))
+                else:
+                    conflicts.add(conflict)
+            continue
+        orphans.append((path, size))
+    return orphans, conflicts
+
+
+_REPEATED_SLASH = re.compile(r"/+")
+
+
+def _normalize(path: str, equal_schemes: dict[str, str], equal_authorities: dict[str, str]) -> str:
+    """Reduce a path to its canonical form for set membership comparisons.
+
+    Drops scheme and authority so two references pointing at the same logical object
+    (e.g. ``s3://b/x`` vs ``s3a://b/x``) compare equal. Collapses runs of slashes so
+    ``file:///a///b`` matches ``file:///a/b``. Scheme/authority mismatches are surfaced
+    separately by ``_conflict`` so the caller can report what differed.
+    """
+    parsed = urlparse(path)
+    body = parsed.path if parsed.scheme else path
+    return _REPEATED_SLASH.sub("/", body) if body else path
+
+
+def _conflict(
+    referenced_path: str,
+    candidate_path: str,
+    equal_schemes: dict[str, str],
+    equal_authorities: dict[str, str],
+) -> tuple[str, str] | None:
+    """Return a (referenced_prefix, candidate_prefix) pair if their scheme or authority differs."""
+    ref = urlparse(referenced_path)
+    cand = urlparse(candidate_path)
+    ref_scheme = equal_schemes.get(ref.scheme, ref.scheme)
+    cand_scheme = equal_schemes.get(cand.scheme, cand.scheme)
+    ref_auth = equal_authorities.get(ref.netloc, ref.netloc)
+    cand_auth = equal_authorities.get(cand.netloc, cand.netloc)
+    if ref_scheme == cand_scheme and ref_auth == cand_auth:
+        return None
+    return (f"{ref_scheme}://{ref_auth}", f"{cand_scheme}://{cand_auth}")

--- a/tests/table/test_remove_orphan_files.py
+++ b/tests/table/test_remove_orphan_files.py
@@ -1,0 +1,399 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for the RemoveOrphanFiles maintenance action."""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pyarrow as pa
+import pytest
+
+from pyiceberg.catalog import Catalog
+from pyiceberg.catalog.memory import InMemoryCatalog
+from pyiceberg.schema import Schema
+from pyiceberg.table import Table
+from pyiceberg.table.maintenance.orphan_files import (
+    _DEFAULT_EQUAL_SCHEMES,
+    PrefixMismatchMode,
+    _find_orphans,
+    _flatten_mapping,
+)
+from pyiceberg.table.statistics import StatisticsFile
+from pyiceberg.types import LongType, NestedField, StringType
+
+
+def _make_table(tmp_path: Path, name: str = "default.t", properties: dict[str, str] | None = None) -> Table:
+    catalog: Catalog = InMemoryCatalog("test", warehouse=f"file://{tmp_path}")
+    catalog.create_namespace("default")
+    schema = Schema(
+        NestedField(1, "c1", LongType(), required=False),
+        NestedField(2, "c2", StringType(), required=False),
+        NestedField(3, "c3", StringType(), required=False),
+    )
+    table = catalog.create_table(name, schema=schema, properties=properties or {})
+    return table
+
+
+def _append(table: Table, rows: list[dict[str, object]]) -> None:
+    table.append(pa.Table.from_pylist(rows, schema=table.schema().as_arrow()))
+
+
+def _location(table: Table) -> str:
+    return table.metadata.location.removeprefix("file://")
+
+
+def _backdate(path: str | Path, hours: int) -> None:
+    past = time.time() - hours * 3600
+    os.utime(path, (past, past))
+
+
+def _list_data_files(table: Table) -> list[str]:
+    """List files under <table>/data as ``file://`` URIs, matching what list_prefix returns."""
+    out = []
+    for root, _dirs, files in os.walk(f"{_location(table)}/data"):
+        for f in files:
+            if not f.startswith(".") and not f.startswith("_"):
+                out.append(f"file://{Path(root) / f}")
+    return out
+
+
+def _wait_until_after_now() -> None:
+    """Sleep until the wall clock advances past the moment of the call."""
+    target = time.time()
+    while time.time() <= target:
+        time.sleep(0.001)
+
+
+def _execute_paths_test(
+    valid_files: list[str],
+    actual_files: list[str],
+    expected_orphans: list[str],
+    equal_schemes: dict[str, str] | None = None,
+    equal_authorities: dict[str, str] | None = None,
+    mode: PrefixMismatchMode = PrefixMismatchMode.IGNORE,
+) -> None:
+    """Drive ``_find_orphans`` directly so path-normalization tests stay one-liners."""
+    schemes = dict(_DEFAULT_EQUAL_SCHEMES)
+    schemes.update(_flatten_mapping(equal_schemes or {}))
+    authorities = _flatten_mapping(equal_authorities or {})
+
+    candidates = [(p, 0) for p in actual_files]
+    orphans, conflicts = _find_orphans(candidates, set(valid_files), schemes, authorities, mode)
+
+    if mode == PrefixMismatchMode.ERROR and conflicts:
+        raise ValueError(f"Unable to determine whether certain files are orphan: {sorted(conflicts)}")
+
+    assert [p for p, _ in orphans] == expected_orphans
+
+
+def test_dry_run(tmp_path: Path) -> None:
+    """Default cutoff finds nothing; explicit cutoff finds the orphan; execute deletes it."""
+    table = _make_table(tmp_path)
+    _append(table, [{"c1": 1, "c2": "AAAAAAAAAA", "c3": "AAAA"}])
+    _append(table, [{"c1": 1, "c2": "AAAAAAAAAA", "c3": "AAAA"}])
+
+    valid_files = set(_list_data_files(table))
+    assert len(valid_files) == 2
+
+    orphan = Path(_location(table)) / "data" / "orphan.parquet"
+    orphan.write_bytes(b"junk")
+
+    all_files = set(_list_data_files(table))
+    invalid = sorted(all_files - valid_files)
+    assert invalid == [f"file://{orphan}"]
+
+    _wait_until_after_now()
+
+    result1 = table.maintenance.remove_orphan_files().delete_with(lambda _: None).execute()
+    assert result1.orphan_file_locations == []
+
+    cutoff = datetime.now(tz=timezone.utc)
+    result2 = table.maintenance.remove_orphan_files().older_than(cutoff).delete_with(lambda _: None).execute()
+    assert sorted(result2.orphan_file_locations) == invalid
+    assert orphan.exists()
+
+    result3 = table.maintenance.remove_orphan_files().older_than(cutoff).execute()
+    assert sorted(result3.deleted_files) == invalid
+    assert not orphan.exists()
+
+
+def test_all_valid_files_are_kept(tmp_path: Path) -> None:
+    """Files referenced by any snapshot survive the action even when older than the cutoff."""
+    table = _make_table(tmp_path)
+    _append(table, [{"c1": 1, "c2": "AAAAAAAAAA", "c3": "AAAA"}])
+    _append(table, [{"c1": 2, "c2": "AAAAAAAAAA", "c3": "AAAA"}])
+    _append(table, [{"c1": 3, "c2": "AAAAAAAAAA", "c3": "AAAA"}])
+
+    for root, _dirs, files in os.walk(_location(table)):
+        for f in files:
+            _backdate(Path(root) / f, hours=24 * 7)
+
+    result = table.maintenance.remove_orphan_files().execute()
+    assert result.orphan_file_locations == []
+    assert result.deleted_files == []
+
+
+def test_orphaned_file_removed_with_parallel_tasks(tmp_path: Path) -> None:
+    """Deletion fans out across multiple threads when max_concurrency > 1."""
+    table = _make_table(tmp_path)
+    _append(table, [{"c1": 1, "c2": "AAAAAAAAAA", "c3": "AAAA"}])
+
+    for i in range(4):
+        orphan = Path(_location(table)) / "data" / f"orphan-{i}.parquet"
+        orphan.write_bytes(b"junk")
+        _backdate(orphan, hours=24 * 4)
+
+    seen_threads: set[str] = set()
+    deleted: list[str] = []
+    lock = threading.Lock()
+
+    def record_and_delete(path: str) -> None:
+        # Hold each worker briefly so all four pick up a task before any returns.
+        time.sleep(0.05)
+        with lock:
+            seen_threads.add(threading.current_thread().name)
+            deleted.append(path)
+
+    result = table.maintenance.remove_orphan_files().max_concurrency(4).delete_with(record_and_delete).execute()
+
+    assert len(deleted) == 4
+    assert len(result.deleted_files) == 4
+    assert len(seen_threads) > 1, f"expected parallel deletes, only saw threads: {seen_threads}"
+
+
+def test_metadata_folder_is_intact(tmp_path: Path) -> None:
+    """When the scan is restricted to a data path, files under metadata/ are never touched."""
+    table = _make_table(tmp_path, properties={"write.data.path": f"file://{tmp_path}/data-redirect"})
+    _append(table, [{"c1": 1, "c2": "AAAAAAAAAA", "c3": "AAAA"}])
+
+    orphan = Path(f"{tmp_path}/data-redirect") / "stray.parquet"
+    orphan.parent.mkdir(parents=True, exist_ok=True)
+    orphan.write_bytes(b"junk")
+    _backdate(orphan, hours=24 * 4)
+
+    metadata_files_before = sorted(p.name for p in Path(_location(table), "metadata").iterdir())
+
+    result = table.maintenance.remove_orphan_files().location(f"file://{tmp_path}/data-redirect").execute()
+
+    assert len(result.deleted_files) == 1
+    assert result.deleted_files[0].endswith("stray.parquet")
+    metadata_files_after = sorted(p.name for p in Path(_location(table), "metadata").iterdir())
+    assert metadata_files_before == metadata_files_after
+
+
+def test_older_than_timestamp(tmp_path: Path) -> None:
+    """Only files modified strictly before the cutoff are deleted; fresher files are kept."""
+    table = _make_table(tmp_path)
+    _append(table, [{"c1": 1, "c2": "AAAAAAAAAA", "c3": "AAAA"}])
+
+    old1 = Path(_location(table)) / "data" / "old1.parquet"
+    old2 = Path(_location(table)) / "data" / "old2.parquet"
+    old1.write_bytes(b"junk")
+    old2.write_bytes(b"junk")
+    _backdate(old1, hours=2)
+    _backdate(old2, hours=2)
+
+    cutoff = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+
+    fresh = Path(_location(table)) / "data" / "fresh.parquet"
+    fresh.write_bytes(b"junk")
+
+    result = table.maintenance.remove_orphan_files().older_than(cutoff).execute()
+
+    deleted = sorted(p.split("/")[-1] for p in result.deleted_files)
+    assert deleted == ["old1.parquet", "old2.parquet"]
+    assert fresh.exists()
+
+
+def test_remove_unreachable_metadata_version_files(tmp_path: Path) -> None:
+    """A metadata.json file not tracked by metadata-log is treated as orphan."""
+    table = _make_table(tmp_path)
+    _append(table, [{"c1": 1, "c2": "AAAAAAAAAA", "c3": "AAAA"}])
+
+    stray = Path(_location(table)) / "metadata" / "v0.unreferenced.metadata.json"
+    stray.write_bytes(b"{}")
+    _backdate(stray, hours=24 * 4)
+
+    result = table.maintenance.remove_orphan_files().execute()
+
+    assert any(p.endswith("v0.unreferenced.metadata.json") for p in result.deleted_files)
+    assert not stray.exists()
+
+
+def test_garbage_collection_disabled(tmp_path: Path) -> None:
+    """The action refuses to run when the table's gc.enabled property is false."""
+    table = _make_table(tmp_path)
+    _append(table, [{"c1": 1, "c2": "AAAAAAAAAA", "c3": "AAAA"}])
+
+    table.metadata = table.metadata.model_copy(update={"properties": {**table.metadata.properties, "gc.enabled": "false"}})
+
+    with pytest.raises(ValueError, match="gc.enabled is false"):
+        table.maintenance.remove_orphan_files().execute()
+
+
+def test_compare_to_file_list(tmp_path: Path) -> None:
+    """The action consumes an explicit (path, last_modified) list and still respects location()."""
+    table = _make_table(tmp_path)
+    _append(table, [{"c1": 1, "c2": "AAAAAAAAAA", "c3": "AAAA"}])
+    _append(table, [{"c1": 1, "c2": "AAAAAAAAAA", "c3": "AAAA"}])
+
+    valid_files = set(_list_data_files(table))
+    orphan = Path(_location(table)) / "data" / "orphan.parquet"
+    orphan.write_bytes(b"junk")
+    all_files = set(_list_data_files(table))
+    invalid = sorted(all_files - valid_files)
+    assert invalid == [f"file://{orphan}"]
+
+    now = datetime.now(tz=timezone.utc)
+    file_list = [(p, now) for p in all_files]
+
+    result1 = table.maintenance.remove_orphan_files().compare_to_file_list(file_list).delete_with(lambda _: None).execute()
+    assert result1.orphan_file_locations == []
+
+    cutoff = datetime.now(tz=timezone.utc) + timedelta(seconds=5)
+    result2 = (
+        table.maintenance.remove_orphan_files()
+        .compare_to_file_list(file_list)
+        .older_than(cutoff)
+        .delete_with(lambda _: None)
+        .execute()
+    )
+    assert sorted(result2.orphan_file_locations) == invalid
+    assert orphan.exists()
+
+    result3 = table.maintenance.remove_orphan_files().compare_to_file_list(file_list).older_than(cutoff).execute()
+    assert sorted(result3.deleted_files) == invalid
+    assert not orphan.exists()
+
+    outside = [("/tmp/mock1", datetime.fromtimestamp(0, tz=timezone.utc))]
+    result4 = (
+        table.maintenance.remove_orphan_files()
+        .location(_location(table))
+        .compare_to_file_list(outside)
+        .delete_with(lambda _: None)
+        .execute()
+    )
+    assert result4.orphan_file_locations == []
+
+
+def test_remove_orphan_files_with_statistic_files(tmp_path: Path) -> None:
+    """Statistics files registered on the table are protected; once unregistered they become orphan."""
+    table = _make_table(tmp_path)
+    _append(table, [{"c1": 1, "c2": "AAAAAAAAAA", "c3": "AAAA"}])
+
+    current_snapshot = table.metadata.current_snapshot()
+    assert current_snapshot is not None
+    snapshot_id = current_snapshot.snapshot_id
+    stats_path = Path(_location(table)) / "data" / "some-stats-file.puffin"
+    stats_path.parent.mkdir(parents=True, exist_ok=True)
+    stats_path.write_bytes(b"PFA1stub")
+    _backdate(stats_path, hours=24 * 4)
+
+    stats_file = StatisticsFile(
+        snapshot_id=snapshot_id,
+        statistics_path=f"file://{stats_path}",
+        file_size_in_bytes=stats_path.stat().st_size,
+        file_footer_size_in_bytes=4,
+        blob_metadata=[],
+    )
+    table.metadata = table.metadata.model_copy(update={"statistics": [stats_file]})
+
+    result1 = table.maintenance.remove_orphan_files().execute()
+    assert all(not p.endswith("some-stats-file.puffin") for p in result1.deleted_files)
+    assert stats_path.exists()
+
+    table.metadata = table.metadata.model_copy(update={"statistics": []})
+
+    result2 = table.maintenance.remove_orphan_files().execute()
+    assert any(p.endswith("some-stats-file.puffin") for p in result2.deleted_files)
+    assert not stats_path.exists()
+
+
+def test_paths_with_extra_slashes() -> None:
+    """Runs of slashes inside a URI are collapsed during normalization."""
+    _execute_paths_test(
+        valid_files=["file:///dir1/dir2/file1"],
+        actual_files=["file:///dir1/////dir2///file1"],
+        expected_orphans=[],
+    )
+
+
+def test_paths_with_valid_file_having_no_authority() -> None:
+    """A referenced file with no authority does not flag an authority-bearing candidate as orphan."""
+    _execute_paths_test(
+        valid_files=["hdfs:///dir1/dir2/file1"],
+        actual_files=["hdfs://servicename/dir1/dir2/file1"],
+        expected_orphans=[],
+    )
+
+
+def test_paths_with_actual_file_having_no_authority() -> None:
+    """A candidate file with no authority is not flagged when the referenced version has one."""
+    _execute_paths_test(
+        valid_files=["hdfs://servicename/dir1/dir2/file1"],
+        actual_files=["hdfs:///dir1/dir2/file1"],
+        expected_orphans=[],
+    )
+
+
+def test_paths_with_equal_schemes() -> None:
+    """ERROR mode raises on a scheme conflict; declaring the schemes equal silences it."""
+    valid = ["scheme1://bucket1/dir1/dir2/file1"]
+    actual = ["scheme2://bucket1/dir1/dir2/file1"]
+
+    with pytest.raises(ValueError, match="scheme1.*scheme2|scheme2.*scheme1"):
+        _execute_paths_test(valid, actual, [], mode=PrefixMismatchMode.ERROR)
+
+    _execute_paths_test(
+        valid,
+        actual,
+        [],
+        equal_schemes={"scheme1,scheme2": "scheme"},
+        mode=PrefixMismatchMode.ERROR,
+    )
+
+
+def test_paths_with_equal_authorities() -> None:
+    """ERROR mode raises on an authority conflict; declaring the authorities equal silences it."""
+    valid = ["hdfs://servicename1/dir1/dir2/file1"]
+    actual = ["hdfs://servicename2/dir1/dir2/file1"]
+
+    with pytest.raises(ValueError, match="servicename1.*servicename2|servicename2.*servicename1"):
+        _execute_paths_test(valid, actual, [], mode=PrefixMismatchMode.ERROR)
+
+    _execute_paths_test(
+        valid,
+        actual,
+        [],
+        equal_authorities={"servicename1,servicename2": "servicename"},
+        mode=PrefixMismatchMode.ERROR,
+    )
+
+
+def test_remove_orphan_file_action_with_delete_mode() -> None:
+    """DELETE mode treats prefix-mismatched candidates as orphan rather than recording a conflict."""
+    _execute_paths_test(
+        valid_files=["hdfs://servicename1/dir1/dir2/file1"],
+        actual_files=["hdfs://servicename2/dir1/dir2/file1"],
+        expected_orphans=["hdfs://servicename2/dir1/dir2/file1"],
+        mode=PrefixMismatchMode.DELETE,
+    )


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
This adds support for the RemoveOrphanFiles metadata maintenance task. The goal is to match the Java implementation.

I had to add a list method to FileIO in order to fully implement this. I can separate that work into a separate PR if that's more useful.

A good follow-up would be to wire this into the CLI. Doing these ad-hoc actions without having to write a script / spin up a Spark cluster is a huge win!

## Are these changes tested?
I did some local testing where I took a table with orphaned files and tried both the Java/PyIceberg implementations against it. Results were the same.

There's also plenty of tests.

## Are there any user-facing changes?
- Adds support for the RemoveOrphanFiles maintenance action

<!-- In the case of user-facing changes, please add the changelog label. -->
