### PR TITLE
REST: Add pagination support for list_namespaces

### DIFF
--- a/pyiceberg/catalog/rest/__init__.py
+++ b/pyiceberg/catalog/rest/__init__.py
@@ -350,6 +350,7 @@ class ConfigResponse(IcebergBaseModel):
 
 class ListNamespaceResponse(IcebergBaseModel):
     namespaces: list[Identifier] = Field()
+    next_page_token: str | None = Field(default=None, alias="next-page-token")
 
 
 class NamespaceResponse(IcebergBaseModel):
@@ -1243,19 +1244,31 @@ class RestCatalog(Catalog):
     def list_namespaces(self, namespace: str | Identifier = ()) -> list[Identifier]:
         self._check_endpoint(Capability.V1_LIST_NAMESPACES)
         namespace_tuple = self.identifier_to_tuple(namespace)
-        response = self._session.get(
-            self.url(
-                f"{Endpoints.list_namespaces}?parent={self._encode_namespace_path(namespace_tuple)}"
-                if namespace_tuple
-                else Endpoints.list_namespaces
-            ),
+        url = (
+            self.url(f"{Endpoints.list_namespaces}?parent={self._encode_namespace_path(namespace_tuple)}")
+            if namespace_tuple
+            else self.url(Endpoints.list_namespaces)
         )
-        try:
-            response.raise_for_status()
-        except HTTPError as exc:
-            _handle_non_200_response(exc, {404: NoSuchNamespaceError})
 
-        return ListNamespaceResponse.model_validate_json(response.text).namespaces
+        namespaces: list[Identifier] = []
+        page_token: str | None = None
+
+        while True:
+            params = {"pageToken": page_token} if page_token else None
+            response = self._session.get(url, params=params)
+            try:
+                response.raise_for_status()
+            except HTTPError as exc:
+                _handle_non_200_response(exc, {404: NoSuchNamespaceError})
+
+            parsed = ListNamespaceResponse.model_validate_json(response.text)
+            namespaces.extend(parsed.namespaces)
+
+            if not parsed.next_page_token:
+                break
+            page_token = parsed.next_page_token
+
+        return namespaces
 
     @retry(**_RETRY_ARGS)
     @override

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -841,6 +841,50 @@ def test_list_namespace_with_parent_404(rest_mock: Mocker) -> None:
         RestCatalog("rest", uri=TEST_URI, token=TEST_TOKEN).list_namespaces(("some_namespace",))
 
 
+def test_list_namespaces_paginated_200(rest_mock: Mocker) -> None:
+    rest_mock.get(
+        f"{TEST_URI}v1/namespaces",
+        json={"namespaces": [["default"], ["examples"]], "next-page-token": "page2token"},
+        status_code=200,
+        request_headers=TEST_HEADERS,
+    )
+    rest_mock.get(
+        f"{TEST_URI}v1/namespaces?pageToken=page2token",
+        json={"namespaces": [["fokko"], ["system"]]},
+        status_code=200,
+        request_headers=TEST_HEADERS,
+    )
+
+    assert RestCatalog("rest", uri=TEST_URI, token=TEST_TOKEN).list_namespaces() == [
+        ("default",),
+        ("examples",),
+        ("fokko",),
+        ("system",),
+    ]
+
+
+def test_list_namespaces_paginated_200_none_next_page_token(rest_mock: Mocker) -> None:
+    rest_mock.get(
+        f"{TEST_URI}v1/namespaces",
+        json={"namespaces": [["default"], ["examples"]], "next-page-token": "page2token"},
+        status_code=200,
+        request_headers=TEST_HEADERS,
+    )
+    rest_mock.get(
+        f"{TEST_URI}v1/namespaces?pageToken=page2token",
+        json={"namespaces": [["fokko"], ["system"]], "next-page-token": None},
+        status_code=200,
+        request_headers=TEST_HEADERS,
+    )
+
+    assert RestCatalog("rest", uri=TEST_URI, token=TEST_TOKEN).list_namespaces() == [
+        ("default",),
+        ("examples",),
+        ("fokko",),
+        ("system",),
+    ]
+
+
 @pytest.mark.filterwarnings(
     "ignore:Deprecated in 0.8.0, will be removed in 1.0.0. "
     "Iceberg REST client is missing the OAuth2 server URI:DeprecationWarning"


### PR DESCRIPTION
Follows the REST catalog spec:

- /v1/{prefix}/namespaces: https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml
- PageToken: https://github.com/apache/iceberg/blob/e7a5a87f26f9de5b200254155aa037368b13a29c/open-api/rest-catalog-open-api.yaml#L2233-L2256

## Rationale for this change

`RestCatalog.list_namespaces` was making a single HTTP request and returning only the first page of results. If the server paginates the response, PyIceberg silently returned an incomplete namespace list.

This is the same gap that was fixed for `list_views` by @ebyhr in #3349 also is being fixed for `list_tables` in #3348.

## Are these changes tested?

Yes, includes unit tests for paginated cases:
- `test_list_namespaces_paginated_200` — verifies all pages are fetched when `next-page-token` is omitted on the last page
- `test_list_namespaces_paginated_200_none_next_page_token` — verifies all pages are fetched when `next-page-token` is explicitly `null` on the last page

## Are there any user-facing changes?

- Before: returned incomplete namespace list when server paginated (only first page)
- After: returns complete namespace list (fetches all pages)

Closes #3382