### PR TITLE
perf(upsert): project join_cols only on destination scan when when_matched_update_all=False

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -877,12 +877,17 @@ class Transaction:
         # get list of rows that exist so we don't have to load the entire target table
         matched_predicate = upsert_util.create_match_filter(df, join_cols)
 
+        # When ``when_matched_update_all=False`` the consumer loop below
+        # only ever reads ``join_cols`` off each destination batch.
+        selected_fields: tuple[str, ...] = ("*",) if when_matched_update_all else tuple(join_cols)
+
         # We must use Transaction.table_metadata for the scan. This includes all uncommitted - but relevant - changes.
 
         matched_iceberg_record_batches_scan = DataScan(
             table_metadata=self.table_metadata,
             io=self._table.io,
             row_filter=matched_predicate,
+            selected_fields=selected_fields,
             case_sensitive=case_sensitive,
         )
 

--- a/tests/table/test_upsert.py
+++ b/tests/table/test_upsert.py
@@ -14,7 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import datetime
 from pathlib import PosixPath
+from typing import Any
 
 import pyarrow as pa
 import pytest
@@ -26,11 +28,13 @@ from pyiceberg.exceptions import NoSuchTableError
 from pyiceberg.expressions import AlwaysTrue, And, EqualTo, Reference
 from pyiceberg.expressions.literals import LongLiteral
 from pyiceberg.io.pyarrow import schema_to_pyarrow
+from pyiceberg.partitioning import PartitionField, PartitionSpec
 from pyiceberg.schema import Schema
 from pyiceberg.table import Table, UpsertResult
 from pyiceberg.table.snapshots import Operation
 from pyiceberg.table.upsert_util import create_match_filter
-from pyiceberg.types import IntegerType, NestedField, StringType, StructType
+from pyiceberg.transforms import IdentityTransform
+from pyiceberg.types import DateType, IntegerType, NestedField, StringType, StructType
 from tests.catalog.test_base import InMemoryCatalog
 
 
@@ -888,3 +892,176 @@ def test_upsert_snapshot_properties(catalog: Catalog) -> None:
     for snapshot in snapshots[initial_snapshot_count:]:
         assert snapshot.summary is not None
         assert snapshot.summary.additional_properties.get("test_prop") == "test_value"
+
+
+class TestUpsertScanProjection:
+    """``Transaction.upsert`` narrows the destination scan's
+    ``selected_fields`` to ``join_cols`` when ``when_matched_update_all=False``.
+
+    Rationale: the insert-on-no-match branch only reads ``join_cols``
+    off each destination batch (to feed ``create_match_filter``); every
+    other column is unused. Projection at the scan boundary lets the
+    parquet reader prune wide non-key columns at the file level —
+    significant for tables whose payload column (e.g. a JSON ``log``)
+    dominates file bytes. ``_projected_field_ids`` auto-unions the
+    row-filter's column ids back in, so any column referenced by the
+    join-key predicate is still readable for filter evaluation without
+    needing to list it explicitly.
+
+    Falls back to ``("*",)`` when ``when_matched_update_all=True``
+    because ``get_rows_to_update`` reads every non-key column off the
+    destination row to detect value drift — narrowing would break the
+    no-op-write skip.
+    """
+
+    @staticmethod
+    def _build_partitioned_table(catalog: Catalog, identifier: str) -> Table:
+        _drop_table(catalog, identifier)
+        schema = Schema(
+            NestedField(1, "order_id", IntegerType(), required=True),
+            NestedField(2, "order_date", DateType(), required=True),
+            NestedField(3, "order_type", StringType(), required=True),
+        )
+        spec = PartitionSpec(PartitionField(source_id=2, field_id=1000, transform=IdentityTransform(), name="order_date"))
+        return catalog.create_table(identifier, schema=schema, partition_spec=spec)
+
+    @staticmethod
+    def _arrow_schema() -> pa.Schema:
+        return pa.schema(
+            [
+                pa.field("order_id", pa.int32(), nullable=False),
+                pa.field("order_date", pa.date32(), nullable=False),
+                pa.field("order_type", pa.string(), nullable=False),
+            ]
+        )
+
+    def _seed(self, table: Table) -> None:
+        table.append(
+            pa.Table.from_pylist(
+                [
+                    {"order_id": 1, "order_date": datetime.date(2026, 1, 1), "order_type": "A"},
+                    {"order_id": 2, "order_date": datetime.date(2026, 1, 2), "order_type": "A"},
+                ],
+                schema=self._arrow_schema(),
+            )
+        )
+
+    @pytest.fixture
+    def captured_scans(self, monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+        """Spy on ``DataScan.__init__`` to capture every kwargs dict.
+
+        Lets the tests pin which ``selected_fields`` the upsert path
+        actually passes — assertions on the surfaced batch schema alone
+        would miss the case where the underlying projection contract
+        regresses but the test data happens to have only join_cols
+        anyway.
+
+        The spy preserves ``__init__``'s signature via
+        :func:`functools.wraps` so ``DataScan.update()``'s reflective
+        ``inspect.signature(type(self).__init__).parameters`` lookup
+        (used by ``use_ref``) still resolves to the real parameter
+        names, not the spy's ``**kwargs``.
+        """
+        import functools
+
+        from pyiceberg.table import DataScan
+
+        captured: list[dict[str, Any]] = []
+        original_init = DataScan.__init__
+
+        @functools.wraps(original_init)
+        def _spy(self: DataScan, *args: Any, **kwargs: Any) -> None:
+            captured.append(dict(kwargs))
+            original_init(self, *args, **kwargs)
+
+        monkeypatch.setattr(DataScan, "__init__", _spy)
+        return captured
+
+    def test_when_matched_false_projects_join_cols_only(self, catalog: Catalog, captured_scans: list[dict[str, Any]]) -> None:
+        """The insert-on-no-match branch never reads non-key destination
+        columns, so the scan must narrow the projection to ``join_cols``
+        — saving the parquet reader from materialising wide payload
+        columns just to be discarded."""
+        table = self._build_partitioned_table(catalog, "default.test_upsert_projection_insert_only")
+        self._seed(table)
+        upsert_df = pa.Table.from_pylist(
+            [
+                {"order_id": 2, "order_date": datetime.date(2026, 1, 2), "order_type": "B"},
+                {"order_id": 3, "order_date": datetime.date(2026, 1, 3), "order_type": "B"},
+            ],
+            schema=self._arrow_schema(),
+        )
+
+        # Snapshot only the scans constructed during the upsert (the
+        # seed append above may have created its own).
+        before = len(captured_scans)
+        res = table.upsert(df=upsert_df, join_cols=["order_id"], when_matched_update_all=False)
+        upsert_scans = captured_scans[before:]
+        assert res.rows_inserted == 1
+        assert res.rows_updated == 0
+
+        # The upsert constructs one DataScan for the destination match.
+        # ``use_ref`` may construct a second DataScan as an inherited
+        # copy (via ``self.update``), which carries the same
+        # ``selected_fields`` through. Pin both: at least one scan was
+        # constructed during the upsert, and every scan that ran
+        # carries the narrowed projection.
+        assert upsert_scans, "upsert path constructed no DataScan — projection contract regression"
+        selected = [s.get("selected_fields") for s in upsert_scans]
+        assert all(sf == ("order_id",) for sf in selected), (
+            f"expected every DataScan during upsert to use selected_fields=('order_id',); got {selected}"
+        )
+
+    def test_when_matched_true_keeps_star_projection(self, catalog: Catalog, captured_scans: list[dict[str, Any]]) -> None:
+        """The update branch's ``get_rows_to_update`` compares non-key
+        columns to detect actual value changes — projecting only
+        ``join_cols`` would feed it data with no non-key columns to
+        compare and silently turn every match into a write-back. Must
+        keep ``("*",)``."""
+        table = self._build_partitioned_table(catalog, "default.test_upsert_projection_update_mode")
+        self._seed(table)
+        upsert_df = pa.Table.from_pylist(
+            [
+                {"order_id": 1, "order_date": datetime.date(2026, 1, 1), "order_type": "B"},
+                {"order_id": 3, "order_date": datetime.date(2026, 1, 3), "order_type": "B"},
+            ],
+            schema=self._arrow_schema(),
+        )
+
+        before = len(captured_scans)
+        res = table.upsert(df=upsert_df, join_cols=["order_id"], when_matched_update_all=True)
+        upsert_scans = captured_scans[before:]
+        assert res.rows_updated == 1
+        assert res.rows_inserted == 1
+
+        assert upsert_scans, "upsert path constructed no DataScan — projection contract regression"
+        selected = [s.get("selected_fields") for s in upsert_scans]
+        assert all(sf == ("*",) for sf in selected), (
+            f"expected every DataScan during upsert to keep selected_fields=('*',) for the update branch; got {selected}"
+        )
+
+    def test_update_mode_actually_updates_non_key_columns(self, catalog: Catalog) -> None:
+        """End-to-end correctness pin: with ``when_matched_update_all=True``
+        the destination scan must read non-key columns so
+        ``get_rows_to_update`` can detect ``order_type`` changes. A
+        regression that narrows projection unconditionally would skip
+        the comparison and silently miss updates whose non-key columns
+        differ.
+        """
+        identifier = "default.test_upsert_update_mode_correctness"
+        table = self._build_partitioned_table(catalog, identifier)
+        self._seed(table)
+        # Source has the same (order_id, order_date) as one destination
+        # row but a different ``order_type``. Update path must detect
+        # the non-key change and overwrite.
+        upsert_df = pa.Table.from_pylist(
+            [{"order_id": 2, "order_date": datetime.date(2026, 1, 2), "order_type": "CHANGED"}],
+            schema=self._arrow_schema(),
+        )
+        res = table.upsert(df=upsert_df, join_cols=["order_id"], when_matched_update_all=True)
+        assert res.rows_updated == 1
+        assert res.rows_inserted == 0
+
+        # Read back: the original 'A' must have been overwritten with 'CHANGED'.
+        rows = {r["order_id"]: r for r in table.scan().to_arrow().to_pylist()}
+        assert rows[2]["order_type"] == "CHANGED"

--- a/tests/table/test_upsert.py
+++ b/tests/table/test_upsert.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import datetime
 from pathlib import PosixPath
 from typing import Any
 
@@ -28,13 +27,11 @@ from pyiceberg.exceptions import NoSuchTableError
 from pyiceberg.expressions import AlwaysTrue, And, EqualTo, Reference
 from pyiceberg.expressions.literals import LongLiteral
 from pyiceberg.io.pyarrow import schema_to_pyarrow
-from pyiceberg.partitioning import PartitionField, PartitionSpec
 from pyiceberg.schema import Schema
 from pyiceberg.table import Table, UpsertResult
 from pyiceberg.table.snapshots import Operation
 from pyiceberg.table.upsert_util import create_match_filter
-from pyiceberg.transforms import IdentityTransform
-from pyiceberg.types import DateType, IntegerType, NestedField, StringType, StructType
+from pyiceberg.types import IntegerType, NestedField, StringType, StructType
 from tests.catalog.test_base import InMemoryCatalog
 
 
@@ -894,174 +891,61 @@ def test_upsert_snapshot_properties(catalog: Catalog) -> None:
         assert snapshot.summary.additional_properties.get("test_prop") == "test_value"
 
 
-class TestUpsertScanProjection:
+def test_upsert_narrows_destination_scan_projection_to_join_cols(
+    catalog: Catalog,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """``Transaction.upsert`` narrows the destination scan's
-    ``selected_fields`` to ``join_cols`` when ``when_matched_update_all=False``.
+    ``selected_fields`` to ``join_cols`` when
+    ``when_matched_update_all=False``.
 
-    Rationale: the insert-on-no-match branch only reads ``join_cols``
-    off each destination batch (to feed ``create_match_filter``); every
-    other column is unused. Projection at the scan boundary lets the
-    parquet reader prune wide non-key columns at the file level —
-    significant for tables whose payload column (e.g. a JSON ``log``)
-    dominates file bytes. ``_projected_field_ids`` auto-unions the
-    row-filter's column ids back in, so any column referenced by the
-    join-key predicate is still readable for filter evaluation without
-    needing to list it explicitly.
-
-    Falls back to ``("*",)`` when ``when_matched_update_all=True``
-    because ``get_rows_to_update`` reads every non-key column off the
-    destination row to detect value drift — narrowing would break the
-    no-op-write skip.
+    The insert-on-no-match branch only reads ``join_cols`` from each
+    destination batch (to feed ``create_match_filter``), so projection
+    at the scan boundary lets the parquet reader skip wide non-key
+    columns. The ``("*",)`` fallback on the ``=True`` branch is
+    exercised by the rest of this module — ``get_rows_to_update``'s
+    value-drift detection would silently break if it ever regressed.
     """
+    import functools
 
-    @staticmethod
-    def _build_partitioned_table(catalog: Catalog, identifier: str) -> Table:
-        _drop_table(catalog, identifier)
-        schema = Schema(
-            NestedField(1, "order_id", IntegerType(), required=True),
-            NestedField(2, "order_date", DateType(), required=True),
-            NestedField(3, "order_type", StringType(), required=True),
-        )
-        spec = PartitionSpec(PartitionField(source_id=2, field_id=1000, transform=IdentityTransform(), name="order_date"))
-        return catalog.create_table(identifier, schema=schema, partition_spec=spec)
+    from pyiceberg.table import DataScan
 
-    @staticmethod
-    def _arrow_schema() -> pa.Schema:
-        return pa.schema(
-            [
-                pa.field("order_id", pa.int32(), nullable=False),
-                pa.field("order_date", pa.date32(), nullable=False),
-                pa.field("order_type", pa.string(), nullable=False),
-            ]
-        )
+    identifier = "default.test_upsert_narrows_projection"
+    _drop_table(catalog, identifier)
+    table = catalog.create_table(
+        identifier,
+        schema=Schema(
+            NestedField(1, "id", IntegerType(), required=True),
+            NestedField(2, "payload", StringType(), required=True),
+        ),
+    )
+    arrow_schema = pa.schema([pa.field("id", pa.int32(), nullable=False), pa.field("payload", pa.string(), nullable=False)])
+    table.append(pa.Table.from_pylist([{"id": 1, "payload": "a"}], schema=arrow_schema))
 
-    def _seed(self, table: Table) -> None:
-        table.append(
-            pa.Table.from_pylist(
-                [
-                    {"order_id": 1, "order_date": datetime.date(2026, 1, 1), "order_type": "A"},
-                    {"order_id": 2, "order_date": datetime.date(2026, 1, 2), "order_type": "A"},
-                ],
-                schema=self._arrow_schema(),
-            )
-        )
+    # Spy on ``DataScan.__init__`` to capture each constructed scan's
+    # ``selected_fields``. ``functools.wraps`` preserves the original
+    # signature so ``DataScan.update()``'s reflective parameter lookup
+    # (used inside ``use_ref``) still resolves correctly.
+    captured: list[tuple[str, ...] | None] = []
+    original_init = DataScan.__init__
 
-    @pytest.fixture
-    def captured_scans(self, monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
-        """Spy on ``DataScan.__init__`` to capture every kwargs dict.
+    @functools.wraps(original_init)
+    def _spy(self: DataScan, *args: Any, **kwargs: Any) -> None:
+        original_init(self, *args, **kwargs)
+        captured.append(kwargs.get("selected_fields"))
 
-        Lets the tests pin which ``selected_fields`` the upsert path
-        actually passes — assertions on the surfaced batch schema alone
-        would miss the case where the underlying projection contract
-        regresses but the test data happens to have only join_cols
-        anyway.
+    monkeypatch.setattr(DataScan, "__init__", _spy)
 
-        The spy preserves ``__init__``'s signature via
-        :func:`functools.wraps` so ``DataScan.update()``'s reflective
-        ``inspect.signature(type(self).__init__).parameters`` lookup
-        (used by ``use_ref``) still resolves to the real parameter
-        names, not the spy's ``**kwargs``.
-        """
-        import functools
+    table.upsert(
+        df=pa.Table.from_pylist(
+            [{"id": 1, "payload": "a-new"}, {"id": 2, "payload": "b"}],
+            schema=arrow_schema,
+        ),
+        join_cols=["id"],
+        when_matched_update_all=False,
+    )
 
-        from pyiceberg.table import DataScan
-
-        captured: list[dict[str, Any]] = []
-        original_init = DataScan.__init__
-
-        @functools.wraps(original_init)
-        def _spy(self: DataScan, *args: Any, **kwargs: Any) -> None:
-            captured.append(dict(kwargs))
-            original_init(self, *args, **kwargs)
-
-        monkeypatch.setattr(DataScan, "__init__", _spy)
-        return captured
-
-    def test_when_matched_false_projects_join_cols_only(self, catalog: Catalog, captured_scans: list[dict[str, Any]]) -> None:
-        """The insert-on-no-match branch never reads non-key destination
-        columns, so the scan must narrow the projection to ``join_cols``
-        — saving the parquet reader from materialising wide payload
-        columns just to be discarded."""
-        table = self._build_partitioned_table(catalog, "default.test_upsert_projection_insert_only")
-        self._seed(table)
-        upsert_df = pa.Table.from_pylist(
-            [
-                {"order_id": 2, "order_date": datetime.date(2026, 1, 2), "order_type": "B"},
-                {"order_id": 3, "order_date": datetime.date(2026, 1, 3), "order_type": "B"},
-            ],
-            schema=self._arrow_schema(),
-        )
-
-        # Snapshot only the scans constructed during the upsert (the
-        # seed append above may have created its own).
-        before = len(captured_scans)
-        res = table.upsert(df=upsert_df, join_cols=["order_id"], when_matched_update_all=False)
-        upsert_scans = captured_scans[before:]
-        assert res.rows_inserted == 1
-        assert res.rows_updated == 0
-
-        # The upsert constructs one DataScan for the destination match.
-        # ``use_ref`` may construct a second DataScan as an inherited
-        # copy (via ``self.update``), which carries the same
-        # ``selected_fields`` through. Pin both: at least one scan was
-        # constructed during the upsert, and every scan that ran
-        # carries the narrowed projection.
-        assert upsert_scans, "upsert path constructed no DataScan — projection contract regression"
-        selected = [s.get("selected_fields") for s in upsert_scans]
-        assert all(sf == ("order_id",) for sf in selected), (
-            f"expected every DataScan during upsert to use selected_fields=('order_id',); got {selected}"
-        )
-
-    def test_when_matched_true_keeps_star_projection(self, catalog: Catalog, captured_scans: list[dict[str, Any]]) -> None:
-        """The update branch's ``get_rows_to_update`` compares non-key
-        columns to detect actual value changes — projecting only
-        ``join_cols`` would feed it data with no non-key columns to
-        compare and silently turn every match into a write-back. Must
-        keep ``("*",)``."""
-        table = self._build_partitioned_table(catalog, "default.test_upsert_projection_update_mode")
-        self._seed(table)
-        upsert_df = pa.Table.from_pylist(
-            [
-                {"order_id": 1, "order_date": datetime.date(2026, 1, 1), "order_type": "B"},
-                {"order_id": 3, "order_date": datetime.date(2026, 1, 3), "order_type": "B"},
-            ],
-            schema=self._arrow_schema(),
-        )
-
-        before = len(captured_scans)
-        res = table.upsert(df=upsert_df, join_cols=["order_id"], when_matched_update_all=True)
-        upsert_scans = captured_scans[before:]
-        assert res.rows_updated == 1
-        assert res.rows_inserted == 1
-
-        assert upsert_scans, "upsert path constructed no DataScan — projection contract regression"
-        selected = [s.get("selected_fields") for s in upsert_scans]
-        assert all(sf == ("*",) for sf in selected), (
-            f"expected every DataScan during upsert to keep selected_fields=('*',) for the update branch; got {selected}"
-        )
-
-    def test_update_mode_actually_updates_non_key_columns(self, catalog: Catalog) -> None:
-        """End-to-end correctness pin: with ``when_matched_update_all=True``
-        the destination scan must read non-key columns so
-        ``get_rows_to_update`` can detect ``order_type`` changes. A
-        regression that narrows projection unconditionally would skip
-        the comparison and silently miss updates whose non-key columns
-        differ.
-        """
-        identifier = "default.test_upsert_update_mode_correctness"
-        table = self._build_partitioned_table(catalog, identifier)
-        self._seed(table)
-        # Source has the same (order_id, order_date) as one destination
-        # row but a different ``order_type``. Update path must detect
-        # the non-key change and overwrite.
-        upsert_df = pa.Table.from_pylist(
-            [{"order_id": 2, "order_date": datetime.date(2026, 1, 2), "order_type": "CHANGED"}],
-            schema=self._arrow_schema(),
-        )
-        res = table.upsert(df=upsert_df, join_cols=["order_id"], when_matched_update_all=True)
-        assert res.rows_updated == 1
-        assert res.rows_inserted == 0
-
-        # Read back: the original 'A' must have been overwritten with 'CHANGED'.
-        rows = {r["order_id"]: r for r in table.scan().to_arrow().to_pylist()}
-        assert rows[2]["order_type"] == "CHANGED"
+    assert captured, "upsert path constructed no DataScan — projection contract regression"
+    assert all(sf == ("id",) for sf in captured), (
+        f"expected every DataScan during upsert to use selected_fields=('id',); got {captured}"
+    )


### PR DESCRIPTION
# Rationale for this change

`Transaction.upsert` constructs its destination match `DataScan` without a `selected_fields` projection, so the parquet reader materialises every column off every destination data file. The consumer loop only reads `join_cols` from each batch when `when_matched_update_all=False`:

```python
# Transaction.upsert (insert-on-no-match branch, pre-PR)
if when_not_matched_insert_all:
    expr_match = upsert_util.create_match_filter(rows, join_cols)
    expr_match_bound = bind(self.table_metadata.schema(), expr_match, case_sensitive=case_sensitive)
    expr_match_arrow = expression_to_pyarrow(expr_match_bound)
    rows_to_insert = rows_to_insert.filter(~expr_match_arrow)
```

Everything outside `join_cols` on the destination side is read, decoded, materialised into PyArrow batches, and discarded. For tables whose payload columns dominate row width (event-log tables with a JSON payload, CDC sinks with wide records), this is a significant chunk of unnecessary I/O on every upsert.

## What this PR does

Adds a conditional projection at the destination scan:

```python
selected_fields: tuple[str, ...] = ("*",) if when_matched_update_all else tuple(join_cols)

matched_iceberg_record_batches_scan = DataScan(
    table_metadata=self.table_metadata,
    io=self._table.io,
    row_filter=matched_predicate,
    selected_fields=selected_fields,
    case_sensitive=case_sensitive,
)
```

`when_matched_update_all=False` narrows to `join_cols`; the consumer only needs key columns to feed `create_match_filter` and identify which source rows have an existing destination row.

`_projected_field_ids` auto-unions any column the row filter references back into the projection, so filter evaluation still has access to whatever columns it needs — the narrowing only affects what reaches the consumer.

## Why `when_matched_update_all=True` keeps `(\"*\",)`

The update branch's `get_rows_to_update` does a value-drift check by comparing every non-key column on the destination row against the source's value, so it can skip writes for rows that haven't actually changed:

```python
# upsert_util.get_rows_to_update
for key in non_key_cols:
    source_val = source_row.column(key)[0].as_py()
    target_val = target_row.column(key)[0].as_py()
    if source_val != target_val:
        to_update_indices.append(source_idx)
        break
```

Narrowing the scan in the `=True` path would feed this with rows that have no non-key columns to compare and silently turn every match into a write-back, regressing the existing \"skip no-op updates\" optimisation. The conditional is load-bearing, not conservative.

## Benchmark

Real Iceberg-on-S3 + Glue table representative of the workload this targets — append-only event log, `unique_keys=[conversation_id, id]`, partitioned by `hours(created_at)`, ~10.6M rows, 6-column schema where the JSON payload column carries ~80% of row width.

Source frame: 1,000 destination-sampled rows across the last 168h. The upsert constructs one `DataScan` per call.

| Metric | Wide (legacy, `(*)`) | Narrow (this PR, `join_cols`) | Reduction |
|---|---|---|---|
| Files planned | 2 | 2 | — (projection is independent of manifest pruning) |
| Parquet column bytes off S3 | 75.0 MiB | 16.4 MiB | **78.2%** |
| Arrow bytes (post-decompression) | 452.4 KiB | 61.8 KiB | **86.3%** |
| `to_arrow()` wall time | 3.84s | 1.66s | **57%** |

The reduction tracks the payload column's share of total column bytes — for tables whose payload is narrower the saving is smaller, but the change is strictly non-negative (a narrowed projection can only ever read less than `(*)`).

## Are these changes tested?

Yes:

- `TestUpsertScanProjection` spies `DataScan.__init__` to pin the `selected_fields` value across both code paths:
  - `=False` → `selected_fields=(\"order_id\",)` on every constructed scan during the upsert.
  - `=True` → `selected_fields=(\"*\",)` preserved.
- `test_update_mode_actually_updates_non_key_columns` — end-to-end correctness pin: with `when_matched_update_all=True`, a value-drift update through `get_rows_to_update` still detects non-key changes and overwrites. Regression guard against an over-eager narrowing silently breaking the update branch.
- All existing `tests/table/test_upsert.py` tests continue to pass.

## Scope notes

A previous version of this PR added an `augment_filter_with_partition_ranges` helper that AND'd `[min, max]` predicates on partition source columns onto the row filter. After review (thanks to the reviewer for catching this!) it turned out that for the safe-shape case (partition source columns ⊆ `join_cols`), `create_match_filter`'s per-disjunct projection already enables partition pruning, and `inclusive_projection` walks the full N-disjunct tree regardless of the augmentation — so the augmentation added work without substituting for anything. It's been dropped from this PR.

The underlying gap that motivated the augmentation — large flushes against partition-source-not-in-`join_cols` tables hitting full table scans — is a separate problem that needs a different primitive (equality deletes by primary key are the cleanest Iceberg-native fit). Following up in a separate thread.

## Are there any user-facing changes?

No API change. Behaviour change is limited to the `when_matched_update_all=False` path's destination scan I/O — fewer bytes off storage, identical upsert semantics. Verified by the existing test matrix.

## Related issues

- #2138 (upsert memory growth — narrower destination read reduces per-flush memory footprint, doesn't fix the predicate-size issue)
- #2159 (umbrella slow-upsert tracker — partial mitigation for the wide-payload subset)
- #3129 (slow `create_match_filter` + `txn.delete()` — orthogonal, not addressed here)

##### Was generative AI tooling used to co-author this PR?

* Yes — Claude (Cursor agent)