### PR TITLE
REST: Add metadata_location to View, and register_view integration test

### DIFF
--- a/dev/docker-compose-integration.yml
+++ b/dev/docker-compose-integration.yml
@@ -44,7 +44,7 @@ services:
       retries: 5
       start_period: 90s
   rest:
-    image: apache/iceberg-rest-fixture:1.10.1
+    image: apache/iceberg-rest-fixture
     container_name: pyiceberg-rest
     networks:
       iceberg_net:

--- a/dev/spark/Dockerfile
+++ b/dev/spark/Dockerfile
@@ -19,7 +19,7 @@ FROM apache/spark:${BASE_IMAGE_SPARK_VERSION}
 
 # Dependency versions - keep these compatible
 # Changing these will invalidate the JAR download cache layer
-ARG ICEBERG_VERSION=1.10.1
+ARG ICEBERG_VERSION=1.11.0
 ARG ICEBERG_SPARK_RUNTIME_VERSION=4.0_2.13
 ARG HADOOP_VERSION=3.4.1
 ARG AWS_SDK_VERSION=2.24.6

--- a/pyiceberg/catalog/rest/__init__.py
+++ b/pyiceberg/catalog/rest/__init__.py
@@ -851,6 +851,7 @@ class RestCatalog(Catalog):
     def _response_to_view(self, identifier_tuple: tuple[str, ...], view_response: ViewResponse) -> View:
         return View(
             identifier=identifier_tuple,
+            metadata_location=view_response.metadata_location,
             metadata=view_response.metadata,
         )
 

--- a/pyiceberg/view/__init__.py
+++ b/pyiceberg/view/__init__.py
@@ -29,14 +29,17 @@ class View:
 
     _identifier: Identifier
     metadata: ViewMetadata
+    metadata_location: str | None
 
     def __init__(
         self,
         identifier: Identifier,
         metadata: ViewMetadata,
+        metadata_location: str | None = None,
     ) -> None:
         self._identifier = identifier
         self.metadata = metadata
+        self.metadata_location = metadata_location
 
     def name(self) -> Identifier:
         """Return the identifier of this view."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2473,6 +2473,11 @@ def clean_up(test_catalog: Catalog) -> None:
         if "my_iceberg_database-" in database_name:
             for identifier in test_catalog.list_tables(database_name):
                 test_catalog.drop_table(identifier)
+            try:
+                for identifier in test_catalog.list_views(database_name):
+                    test_catalog.drop_view(identifier)
+            except NotImplementedError:
+                pass
             test_catalog.drop_namespace(database_name)
 
 

--- a/tests/integration/test_catalog.py
+++ b/tests/integration/test_catalog.py
@@ -618,7 +618,6 @@ def test_register_table_existing(test_catalog: Catalog, table_schema_nested: Sch
 
 
 @pytest.mark.integration
-@pytest.mark.skip(reason="Requires Iceberg REST Fixtures 1.11.x")
 def test_rest_custom_namespace_separator(rest_catalog: RestCatalog, table_schema_simple: Schema) -> None:
     """
     Tests that the REST catalog correctly picks up the namespace-separator from the config endpoint.

--- a/tests/integration/test_catalog.py
+++ b/tests/integration/test_catalog.py
@@ -44,6 +44,7 @@ from pyiceberg.table.metadata import INITIAL_SPEC_ID
 from pyiceberg.table.sorting import INITIAL_SORT_ORDER_ID, SortField, SortOrder
 from pyiceberg.transforms import BucketTransform, DayTransform, IdentityTransform
 from pyiceberg.types import IntegerType, LongType, NestedField, TimestampType, UUIDType
+from pyiceberg.view.metadata import SQLViewRepresentation, ViewVersion
 from tests.conftest import (
     clean_up,
     does_support_atomic_concurrent_updates,
@@ -615,6 +616,36 @@ def test_register_table_existing(test_catalog: Catalog, table_schema_nested: Sch
     # Assert that registering the table again raises TableAlreadyExistsError
     with pytest.raises(TableAlreadyExistsError):
         test_catalog.register_table(identifier, metadata_location=table.metadata_location)
+
+
+@pytest.mark.integration
+def test_rest_register_view(rest_catalog: RestCatalog, table_schema_simple: Schema, database_name: str, view_name: str) -> None:
+    identifier = (database_name, view_name)
+
+    rest_catalog.create_namespace_if_not_exists(database_name)
+
+    view_version = ViewVersion(
+        version_id=1,
+        schema_id=1,
+        timestamp_ms=1,
+        summary={},
+        representations=[
+            SQLViewRepresentation(
+                type="sql",
+                sql="SELECT 1 as some_col",
+                dialect="spark",
+            )
+        ],
+        default_namespace=["default"],
+    )
+
+    view = rest_catalog.create_view(identifier, table_schema_simple, view_version)
+    assert rest_catalog.view_exists(identifier)
+
+    register_identifier = (database_name, "register_identifier")
+    assert not rest_catalog.view_exists(register_identifier)
+    rest_catalog.register_view(register_identifier, view.metadata_location)
+    assert rest_catalog.view_exists(register_identifier)
 
 
 @pytest.mark.integration


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

Add `metadata_location` to `View` for consistency with `Table`.
This PR also adds `register_view` integration test.

- Requires Iceberg 1.11.0 https://github.com/apache/iceberg-python/pull/3389

## Are these changes tested?

Yes

## Are there any user-facing changes?

Add `metadata_location` to `View`. 
