### PR TITLE
Test: Replace rest-scan-planning-enabled with scan-planning-mode

### DIFF
--- a/tests/catalog/test_scan_planning_models.py
+++ b/tests/catalog/test_scan_planning_models.py
@@ -48,7 +48,7 @@ def rest_scan_catalog(requests_mock: Mocker) -> RestCatalog:
     requests_mock.get(
         f"{TEST_URI}v1/config",
         json={
-            "defaults": {"rest-scan-planning-enabled": "true"},
+            "defaults": {"scan-planning-mode": "server"},
             "overrides": {},
             "endpoints": [
                 "POST /v1/{prefix}/namespaces/{namespace}/tables/{table}/plan",
@@ -61,7 +61,7 @@ def rest_scan_catalog(requests_mock: Mocker) -> RestCatalog:
     return RestCatalog(
         "test",
         uri=TEST_URI,
-        **{"rest-scan-planning-enabled": "true"},
+        **{"scan-planning-mode": "server"},
     )
 
 

--- a/tests/integration/test_rest_scan_planning_integration.py
+++ b/tests/integration/test_rest_scan_planning_integration.py
@@ -76,7 +76,7 @@ def scan_catalog() -> Catalog:
             "s3.endpoint": "http://localhost:9000",
             "s3.access-key-id": "admin",
             "s3.secret-access-key": "password",
-            "rest-scan-planning-enabled": "true",
+            "scan-planning-mode": "server",
         },
     )
     catalog.create_namespace_if_not_exists("default")


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

- Follow-up of https://github.com/apache/iceberg-python/pull/3376

There are no other usages of `rest-scan-planning-enabled`. 

## Are these changes tested?

Yes

## Are there any user-facing changes?

No
