### PR TITLE
docs: fix New York longitude sign in partial overwrite example

### DIFF
--- a/mkdocs/docs/api.md
+++ b/mkdocs/docs/api.md
@@ -436,7 +436,7 @@ You can overwrite the record of `Paris` with a record of `New York`:
 from pyiceberg.expressions import EqualTo
 df = pa.Table.from_pylist(
     [
-        {"city": "New York", "lat": 40.7128, "long": 74.0060},
+        {"city": "New York", "lat": 40.7128, "long": -74.0060},
     ]
 )
 tbl.overwrite(df, overwrite_filter=EqualTo('city', "Paris"))
@@ -452,7 +452,7 @@ long: double
 ----
 city: [["New York"],["Amsterdam","San Francisco","Drachten"]]
 lat: [[40.7128],[52.371807,37.773972,53.11254]]
-long: [[74.006],[4.896029,-122.431297,6.0989]]
+long: [[-74.006],[4.896029,-122.431297,6.0989]]
 ```
 
 If the PyIceberg table is partitioned, you can use `tbl.dynamic_partition_overwrite(df)` to replace the existing partitions with new ones provided in the dataframe. The partitions to be replaced are detected automatically from the provided arrow table.


### PR DESCRIPTION
## Summary
- correct the New York longitude in the partial overwrite docs example
- update the rendered output snippet to keep the example internally consistent

Closes #3402
