### PR TITLE
Make `View.sql_for` case-insensitive and return None for unknown dialect

### DIFF
--- a/pyiceberg/view/__init__.py
+++ b/pyiceberg/view/__init__.py
@@ -80,9 +80,12 @@ class View:
         """Return the view's UUID."""
         return UUID(self.metadata.view_uuid)
 
-    def sql_for(self, dialect: str) -> SQLViewRepresentation:
-        """Return the view representation for the sql dialect."""
-        return next(repr.root for repr in self.current_version().representations if repr.root.dialect == dialect)
+    def sql_for(self, dialect: str) -> SQLViewRepresentation | None:
+        """Return the view representation for the sql dialect, or None if no representation could be resolved."""
+        return next(
+            (repr.root for repr in self.current_version().representations if repr.root.dialect.casefold() == dialect.casefold()),
+            None,
+        )
 
     def __eq__(self, other: Any) -> bool:
         """Return the equality of two instances of the View class."""

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -96,6 +96,13 @@ def test_view_sql_for_dialect(view: View) -> None:
     assert repr.sql == "SELECT * FROM prod.db.table"
 
 
+def test_view_sql_for_dialect_ignore_case(view: View) -> None:
+    repr = view.sql_for("Spark")
+    assert isinstance(repr, SQLViewRepresentation)
+    assert repr.dialect == "spark"
+    assert repr.sql == "SELECT * FROM prod.db.table"
+
+
 def test_view_schemas_multiple(example_view_metadata_v1_multiple_versions: dict[str, Any]) -> None:
     view = View(("default", "test_view"), ViewMetadata.model_validate(example_view_metadata_v1_multiple_versions))
     schemas = view.schemas()
@@ -117,5 +124,4 @@ def test_view_version_unknown_id(view: View) -> None:
 
 
 def test_view_sql_for_unknown_dialect(view: View) -> None:
-    with pytest.raises(StopIteration):
-        view.sql_for("trino")
+    assert not view.sql_for("trino")


### PR DESCRIPTION
# Rationale for this change

Iceberg Java compares the dialect in a case-insensitive manner, and returns null if the dialect is unknown.

https://github.com/apache/iceberg/blob/29ba0a14dc6667db0683fdfcd520639b3da77774/core/src/main/java/org/apache/iceberg/view/BaseView.java#L113-L130

## Are these changes tested?

Yes

## Are there any user-facing changes?

No - the method isn't released yet

<!-- In the case of user-facing changes, please add the changelog label. -->
