### PR TITLE
REST: Allow Identifier type in `drop_view` method

### DIFF
--- a/pyiceberg/catalog/rest/__init__.py
+++ b/pyiceberg/catalog/rest/__init__.py
@@ -1438,7 +1438,7 @@ class RestCatalog(Catalog):
 
     @retry(**_RETRY_ARGS)
     @override
-    def drop_view(self, identifier: str) -> None:
+    def drop_view(self, identifier: str | Identifier) -> None:
         self._check_endpoint(Capability.V1_DELETE_VIEW)
         response = self._session.delete(
             self.url(Endpoints.drop_view, prefixed=True, **self._split_identifier_for_path(identifier, IdentifierKind.VIEW)),


### PR DESCRIPTION
# Rationale for this change

Fix the warning message in the IDE. 

The base class and other classes use the `str | Identifier` style in the `drop_view` method. 
I also confirmed that other methods in the REST catalog class use `str | Identifier` for identifiers. 

## Are these changes tested?

N/A

## Are there any user-facing changes?

No

<!-- In the case of user-facing changes, please add the changelog label. -->
