### PR TITLE
fix(upsert): bound file match filter to avoid segfault

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -874,8 +874,8 @@ class Transaction:
             format_version=self.table_metadata.format_version,
         )
 
-        # get list of rows that exist so we don't have to load the entire target table
-        matched_predicate = upsert_util.create_match_filter(df, join_cols)
+        # Use a conservative file-pruning predicate for the initial scan; exact matching happens below.
+        matched_predicate = upsert_util.create_file_match_filter(df, join_cols)
 
         # We must use Transaction.table_metadata for the scan. This includes all uncommitted - but relevant - changes.
 

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -923,8 +923,8 @@ class Transaction:
             format_version=self.table_metadata.format_version,
         )
 
-        # get list of rows that exist so we don't have to load the entire target table
-        matched_predicate = upsert_util.create_match_filter(df, join_cols)
+        # Use a conservative file-pruning predicate for the initial scan; exact matching happens below.
+        matched_predicate = upsert_util.create_file_match_filter(df, join_cols)
 
         # We must use Transaction.table_metadata for the scan. This includes all uncommitted - but relevant - changes.
 

--- a/pyiceberg/table/upsert_util.py
+++ b/pyiceberg/table/upsert_util.py
@@ -25,9 +25,39 @@ from pyiceberg.expressions import (
     AlwaysFalse,
     BooleanExpression,
     EqualTo,
+    GreaterThanOrEqual,
     In,
+    IsNull,
+    LessThanOrEqual,
     Or,
 )
+
+
+def create_file_match_filter(df: pyarrow_table, join_cols: list[str]) -> BooleanExpression:
+    """Build a conservative predicate for upsert file pruning.
+
+    The returned predicate may match extra files, but must not exclude files that
+    could contain a matching row. Exact row matching still happens downstream.
+    """
+    if len(df) == 0:
+        return AlwaysFalse()
+
+    per_col: list[BooleanExpression] = []
+    for col in join_cols:
+        col_arr = df.column(col)
+        bounds = pc.min_max(col_arr).as_py()
+        col_min, col_max = bounds["min"], bounds["max"]
+
+        if col_min is None:
+            per_col.append(IsNull(col))
+            continue
+
+        pred: BooleanExpression = GreaterThanOrEqual(col, col_min) & LessThanOrEqual(col, col_max)
+        if pc.any(pc.is_null(col_arr)).as_py():
+            pred = pred | IsNull(col)
+        per_col.append(pred)
+
+    return functools.reduce(operator.and_, per_col)
 
 
 def create_match_filter(df: pyarrow_table, join_cols: list[str]) -> BooleanExpression:

--- a/tests/table/test_upsert.py
+++ b/tests/table/test_upsert.py
@@ -14,6 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import subprocess
+import sys
+import textwrap
 from pathlib import PosixPath
 
 import pyarrow as pa
@@ -23,13 +26,23 @@ from pyarrow import Table as pa_table
 
 from pyiceberg.catalog import Catalog
 from pyiceberg.exceptions import NoSuchTableError
-from pyiceberg.expressions import AlwaysTrue, And, EqualTo, Reference
+from pyiceberg.expressions import (
+    AlwaysFalse,
+    AlwaysTrue,
+    And,
+    EqualTo,
+    GreaterThanOrEqual,
+    IsNull,
+    LessThanOrEqual,
+    Or,
+    Reference,
+)
 from pyiceberg.expressions.literals import LongLiteral
 from pyiceberg.io.pyarrow import schema_to_pyarrow
 from pyiceberg.schema import Schema
 from pyiceberg.table import Table, UpsertResult
 from pyiceberg.table.snapshots import Operation
-from pyiceberg.table.upsert_util import create_match_filter
+from pyiceberg.table.upsert_util import create_file_match_filter, create_match_filter
 from pyiceberg.types import IntegerType, NestedField, StringType, StructType
 from tests.catalog.test_base import InMemoryCatalog
 
@@ -441,6 +454,138 @@ def test_create_match_filter_single_condition() -> None:
         EqualTo(term=Reference(name="order_id"), literal=LongLiteral(101)),
         EqualTo(term=Reference(name="order_line_id"), literal=LongLiteral(1)),
     )
+
+
+def test_create_file_match_filter_empty_source_prunes_everything() -> None:
+    table = pa.table({"order_id": pa.array([], type=pa.int64()), "order_line_id": pa.array([], type=pa.int64())})
+
+    assert create_file_match_filter(table, ["order_id", "order_line_id"]) == AlwaysFalse()
+
+
+def test_create_file_match_filter_multi_column_bounds() -> None:
+    table = pa.table({"order_id": [1, 2, 3], "order_line_id": [100, 200, 300]})
+
+    expr = create_file_match_filter(table, ["order_id", "order_line_id"])
+
+    leaves: list[object] = []
+
+    def collect(node: object) -> None:
+        if isinstance(node, And):
+            collect(node.left)
+            collect(node.right)
+        else:
+            leaves.append(node)
+
+    collect(expr)
+    bounds_by_col: dict[str, dict[type, object]] = {}
+    for leaf in leaves:
+        bounds_by_col.setdefault(leaf.term.name, {})[type(leaf)] = leaf.literal.value  # type: ignore[attr-defined]
+
+    assert bounds_by_col == {
+        "order_id": {GreaterThanOrEqual: 1, LessThanOrEqual: 3},
+        "order_line_id": {GreaterThanOrEqual: 100, LessThanOrEqual: 300},
+    }
+
+
+@pytest.mark.parametrize(
+    ("values", "expected"),
+    [
+        ([1, 5], And(GreaterThanOrEqual("order_id", 1), LessThanOrEqual("order_id", 5))),
+        ([None, None], IsNull("order_id")),
+        ([1, None, 5], Or(And(GreaterThanOrEqual("order_id", 1), LessThanOrEqual("order_id", 5)), IsNull("order_id"))),
+    ],
+)
+def test_create_file_match_filter_null_shape(values: list[int | None], expected: object) -> None:
+    table = pa.table({"order_id": pa.array(values, type=pa.int64())})
+
+    assert create_file_match_filter(table, ["order_id"]) == expected
+
+
+def test_upsert_multi_col_file_match_filter_culls_false_positives(catalog: Catalog) -> None:
+    identifier = "default.test_upsert_multi_col_file_match_filter_culls_false_positives"
+    _drop_table(catalog, identifier)
+
+    schema = pa.schema([("order_id", pa.int32()), ("order_line_id", pa.int32()), ("payload", pa.string())])
+    table = catalog.create_table(identifier, schema)
+    table.append(
+        pa.Table.from_pylist(
+            [
+                {"order_id": 1, "order_line_id": 200, "payload": "keep-1"},
+                {"order_id": 2, "order_line_id": 100, "payload": "keep-2"},
+                {"order_id": 1, "order_line_id": 100, "payload": "old"},
+            ],
+            schema=schema,
+        )
+    )
+
+    source = pa.Table.from_pylist(
+        [
+            {"order_id": 1, "order_line_id": 100, "payload": "new"},
+            {"order_id": 2, "order_line_id": 200, "payload": "insert"},
+        ],
+        schema=schema,
+    )
+
+    result = table.upsert(source, join_cols=["order_id", "order_line_id"])
+
+    assert result.rows_updated == 1
+    assert result.rows_inserted == 1
+    rows_by_key = {(row["order_id"], row["order_line_id"]): row["payload"] for row in table.scan().to_arrow().to_pylist()}
+    assert rows_by_key == {
+        (1, 200): "keep-1",
+        (2, 100): "keep-2",
+        (1, 100): "new",
+        (2, 200): "insert",
+    }
+
+
+def test_upsert_large_composite_key_initial_scan_does_not_recurse(tmp_path: PosixPath) -> None:
+    """Regression: initial scan planning must not build the exact composite-key tree.
+
+    Running this in a subprocess keeps the test runner alive on runtimes where the
+    old recursive visitor shape can overflow the C stack.
+    """
+    script = textwrap.dedent(
+        f"""
+        import sys
+
+        sys.setrecursionlimit(10**7)
+
+        import pyarrow as pa
+
+        from tests.catalog.test_base import InMemoryCatalog
+
+        n = 30_000
+        catalog = InMemoryCatalog("test", warehouse={str(tmp_path)!r})
+        catalog.create_namespace("default")
+        schema = pa.schema([
+            ("order_id", pa.int64()),
+            ("order_line_id", pa.int64()),
+            ("payload", pa.string()),
+        ])
+        table = catalog.create_table("default.regression", schema)
+        table.append(
+            pa.Table.from_pylist(
+                [{{"order_id": 0, "order_line_id": 100_000, "payload": "old"}}],
+                schema=schema,
+            )
+        )
+        source = pa.table({{
+            "order_id": pa.array(range(n), type=pa.int64()),
+            "order_line_id": pa.array(range(100_000, 100_000 + n), type=pa.int64()),
+            "payload": pa.array(["old"] * n, type=pa.string()),
+        }})
+
+        table.upsert(
+            source,
+            join_cols=["order_id", "order_line_id"],
+            when_not_matched_insert_all=False,
+        )
+        """
+    )
+    result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
 
 
 def test_upsert_with_duplicate_rows_in_table(catalog: Catalog) -> None:

--- a/tests/table/test_upsert.py
+++ b/tests/table/test_upsert.py
@@ -14,6 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import subprocess
+import sys
+import textwrap
 from datetime import datetime
 from pathlib import PosixPath
 
@@ -24,14 +27,24 @@ from pyarrow import Table as pa_table
 
 from pyiceberg.catalog import Catalog
 from pyiceberg.exceptions import NoSuchTableError
-from pyiceberg.expressions import AlwaysTrue, And, EqualTo, Reference
+from pyiceberg.expressions import (
+    AlwaysFalse,
+    AlwaysTrue,
+    And,
+    EqualTo,
+    GreaterThanOrEqual,
+    IsNull,
+    LessThanOrEqual,
+    Or,
+    Reference,
+)
 from pyiceberg.expressions.literals import LongLiteral
 from pyiceberg.io.pyarrow import schema_to_pyarrow
 from pyiceberg.partitioning import PartitionField, PartitionSpec
 from pyiceberg.schema import Schema
 from pyiceberg.table import Table, UpsertResult
 from pyiceberg.table.snapshots import Operation
-from pyiceberg.table.upsert_util import create_match_filter
+from pyiceberg.table.upsert_util import create_file_match_filter, create_match_filter
 from pyiceberg.transforms import DayTransform
 from pyiceberg.types import IntegerType, NestedField, StringType, StructType, TimestampType
 from tests.catalog.test_base import InMemoryCatalog
@@ -444,6 +457,138 @@ def test_create_match_filter_single_condition() -> None:
         EqualTo(term=Reference(name="order_id"), literal=LongLiteral(101)),
         EqualTo(term=Reference(name="order_line_id"), literal=LongLiteral(1)),
     )
+
+
+def test_create_file_match_filter_empty_source_prunes_everything() -> None:
+    table = pa.table({"order_id": pa.array([], type=pa.int64()), "order_line_id": pa.array([], type=pa.int64())})
+
+    assert create_file_match_filter(table, ["order_id", "order_line_id"]) == AlwaysFalse()
+
+
+def test_create_file_match_filter_multi_column_bounds() -> None:
+    table = pa.table({"order_id": [1, 2, 3], "order_line_id": [100, 200, 300]})
+
+    expr = create_file_match_filter(table, ["order_id", "order_line_id"])
+
+    leaves: list[object] = []
+
+    def collect(node: object) -> None:
+        if isinstance(node, And):
+            collect(node.left)
+            collect(node.right)
+        else:
+            leaves.append(node)
+
+    collect(expr)
+    bounds_by_col: dict[str, dict[type, object]] = {}
+    for leaf in leaves:
+        bounds_by_col.setdefault(leaf.term.name, {})[type(leaf)] = leaf.literal.value  # type: ignore[attr-defined]
+
+    assert bounds_by_col == {
+        "order_id": {GreaterThanOrEqual: 1, LessThanOrEqual: 3},
+        "order_line_id": {GreaterThanOrEqual: 100, LessThanOrEqual: 300},
+    }
+
+
+@pytest.mark.parametrize(
+    ("values", "expected"),
+    [
+        ([1, 5], And(GreaterThanOrEqual("order_id", 1), LessThanOrEqual("order_id", 5))),
+        ([None, None], IsNull("order_id")),
+        ([1, None, 5], Or(And(GreaterThanOrEqual("order_id", 1), LessThanOrEqual("order_id", 5)), IsNull("order_id"))),
+    ],
+)
+def test_create_file_match_filter_null_shape(values: list[int | None], expected: object) -> None:
+    table = pa.table({"order_id": pa.array(values, type=pa.int64())})
+
+    assert create_file_match_filter(table, ["order_id"]) == expected
+
+
+def test_upsert_multi_col_file_match_filter_culls_false_positives(catalog: Catalog) -> None:
+    identifier = "default.test_upsert_multi_col_file_match_filter_culls_false_positives"
+    _drop_table(catalog, identifier)
+
+    schema = pa.schema([("order_id", pa.int32()), ("order_line_id", pa.int32()), ("payload", pa.string())])
+    table = catalog.create_table(identifier, schema)
+    table.append(
+        pa.Table.from_pylist(
+            [
+                {"order_id": 1, "order_line_id": 200, "payload": "keep-1"},
+                {"order_id": 2, "order_line_id": 100, "payload": "keep-2"},
+                {"order_id": 1, "order_line_id": 100, "payload": "old"},
+            ],
+            schema=schema,
+        )
+    )
+
+    source = pa.Table.from_pylist(
+        [
+            {"order_id": 1, "order_line_id": 100, "payload": "new"},
+            {"order_id": 2, "order_line_id": 200, "payload": "insert"},
+        ],
+        schema=schema,
+    )
+
+    result = table.upsert(source, join_cols=["order_id", "order_line_id"])
+
+    assert result.rows_updated == 1
+    assert result.rows_inserted == 1
+    rows_by_key = {(row["order_id"], row["order_line_id"]): row["payload"] for row in table.scan().to_arrow().to_pylist()}
+    assert rows_by_key == {
+        (1, 200): "keep-1",
+        (2, 100): "keep-2",
+        (1, 100): "new",
+        (2, 200): "insert",
+    }
+
+
+def test_upsert_large_composite_key_initial_scan_does_not_recurse(tmp_path: PosixPath) -> None:
+    """Regression: initial scan planning must not build the exact composite-key tree.
+
+    Running this in a subprocess keeps the test runner alive on runtimes where the
+    old recursive visitor shape can overflow the C stack.
+    """
+    script = textwrap.dedent(
+        f"""
+        import sys
+
+        sys.setrecursionlimit(10**7)
+
+        import pyarrow as pa
+
+        from tests.catalog.test_base import InMemoryCatalog
+
+        n = 30_000
+        catalog = InMemoryCatalog("test", warehouse={str(tmp_path)!r})
+        catalog.create_namespace("default")
+        schema = pa.schema([
+            ("order_id", pa.int64()),
+            ("order_line_id", pa.int64()),
+            ("payload", pa.string()),
+        ])
+        table = catalog.create_table("default.regression", schema)
+        table.append(
+            pa.Table.from_pylist(
+                [{{"order_id": 0, "order_line_id": 100_000, "payload": "old"}}],
+                schema=schema,
+            )
+        )
+        source = pa.table({{
+            "order_id": pa.array(range(n), type=pa.int64()),
+            "order_line_id": pa.array(range(100_000, 100_000 + n), type=pa.int64()),
+            "payload": pa.array(["old"] * n, type=pa.string()),
+        }})
+
+        table.upsert(
+            source,
+            join_cols=["order_id", "order_line_id"],
+            when_not_matched_insert_all=False,
+        )
+        """
+    )
+    result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
 
 
 def test_upsert_with_duplicate_rows_in_table(catalog: Catalog) -> None:


### PR DESCRIPTION
# Rationale for this change

Upserts with large composite (multi-column) keys segfault during scan planning. The initial scan builds one `And(EqualTo, EqualTo)` per unique source key and `Or`s them into a deep tree, which PyArrow's C++ engine recurses over in `GetFragments` → `Canonicalize`, overflowing the C stack (SIGSEGV) at tens of thousands of keys.

This PR uses a bounded `create_file_match_filter` for the initial file-pruning scan: per-column min/max bounds (plus `IsNull` where needed), so predicate size scales with the number of join columns, not source rows. The exact `create_match_filter` is still used downstream for overwrite and insert filtering, so row-level correctness is unchanged.

The bounds are loose by design. With composite keys they can pull in false positives, but exact matching drops those before anything is written, so the only cost is scanning a few extra files in exchange for upserts that no longer crash. A follow-up could tighten this, for example per-prefix bounds or a grouped `In`, as long as the predicate size stays bounded.

## Benchmarks

Timings cover expression construction, schema binding, PyArrow conversion, and applying the resulting Arrow filter to an in-memory table. They do not measure end-to-end upsert time, which also depends on table layout, file pruning, IO, and downstream exact matching. [Benchmark script](https://gist.github.com/abnobdoss/824698ea74c29c02ead8da6410b89b6e).

Before, exact match-filter path:

| Unique source keys | 1 join column | 2 join columns | 3 join columns |
| --- | --- | --- | --- |
| 100 | 1.5 ms | 7.3 ms | 11 ms |
| 1k | 4.7 ms | 87 ms | 147 ms |
| 10k | 33 ms | SIGSEGV | SIGSEGV |
| 100k | 650 ms | SIGSEGV | SIGSEGV |
| 1m | 6.59 s | >30 s | >30 s |

After, bounded file-match filter path:

| Unique source keys | 1 join column | 2 join columns | 3 join columns |
| --- | --- | --- | --- |
| 100 | 1.0 ms | 1.1 ms | 1.2 ms |
| 1k | 1.0 ms | 1.1 ms | 1.2 ms |
| 10k | 1.1 ms | 1.1 ms | 1.3 ms |
| 100k | 1.3 ms | 1.6 ms | 1.9 ms |
| 1m | 3.7 ms | 6.8 ms | 9.0 ms |

## Related

- #2159: upsert slow from building a massive `BooleanExpression` in `create_match_filter` before any IO. This PR replaces that pre-IO full-source predicate with the bounded filter. The overwrite and insert predicates are still exact and unchanged.
- #3129: large-upsert performance. Removes the full-source `create_match_filter` call from `upsert()`. Does not change the `txn.delete()` path or the direct `create_match_filter` use in that report's flow.
- #3508: segfault on large multi-column upserts. This PR fixes the initial scan path. The overwrite and insert paths still hit the same recursion and are left to follow-up.

## Are these changes tested?

Yes. Added coverage for bounded-filter construction, the false-positive culling path, and a large composite-key regression test. The regression test runs the upsert in a subprocess, so a runtime that would segfault reports a pytest failure instead of killing the worker: the base branch exits 139 under Python 3.10, and this branch exits 0.

Ran:

- `uv run python -m pytest tests/table/test_upsert.py -k "large_composite_key_initial_scan or file_match_filter or create_match_filter"`
- `uv run python -m pytest tests/table/test_upsert.py`
- commit hooks

## Are there any user-facing changes?

No API changes. Large composite-key upserts no longer crash during initial scan planning, and may scan a conservative superset of candidate files before exact row matching.
