### PR TITLE
Widen expression predicate term field type for mypy compatibility

### DIFF
--- a/pyiceberg/expressions/__init__.py
+++ b/pyiceberg/expressions/__init__.py
@@ -21,10 +21,10 @@ import copy
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable, Sequence
 from functools import cached_property
-from typing import Any, TypeAlias
+from typing import Annotated, Any, TypeAlias
 from typing import Literal as TypingLiteral
 
-from pydantic import ConfigDict, Field, SerializeAsAny, model_validator
+from pydantic import BeforeValidator, ConfigDict, Field, SerializeAsAny, model_validator
 from pydantic_core.core_schema import ValidatorFunctionWrapHandler
 
 from pyiceberg.expressions.literals import AboveMax, BelowMin, Literal, literal
@@ -508,7 +508,7 @@ class BoundPredicate(Bound, BooleanExpression, ABC):
 class UnboundPredicate(Unbound, BooleanExpression, ABC):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    term: UnboundTerm
+    term: Annotated[str | UnboundTerm, BeforeValidator(_to_unbound_term)]
 
     def __init__(self, term: str | UnboundTerm, **kwargs: Any) -> None:
         super().__init__(term=_to_unbound_term(term), **kwargs)
@@ -540,7 +540,7 @@ class UnaryPredicate(UnboundPredicate, ABC):
         return f"{str(self.__class__.__name__)}(term={str(self.term)})"
 
     def bind(self, schema: Schema, case_sensitive: bool = True) -> BoundUnaryPredicate:
-        bound_term = self.term.bind(schema, case_sensitive)
+        bound_term = self.term.bind(schema, case_sensitive)  # type: ignore[union-attr]
         bound_type = self.as_bound
         return bound_type(bound_term)  # type: ignore[misc]
 
@@ -696,7 +696,7 @@ class SetPredicate(UnboundPredicate, ABC):
         super().__init__(term=_to_unbound_term(term), values=literal_set)
 
     def bind(self, schema: Schema, case_sensitive: bool = True) -> BoundSetPredicate:
-        bound_term = self.term.bind(schema, case_sensitive)
+        bound_term = self.term.bind(schema, case_sensitive)  # type: ignore[union-attr]
         literal_set = self.literals
         return self.as_bound(bound_term, {lit.to(bound_term.ref().field.field_type) for lit in literal_set})  # type: ignore
 
@@ -870,7 +870,7 @@ class NotIn(SetPredicate, ABC):
 
 class LiteralPredicate(UnboundPredicate, ABC):
     type: TypingLiteral["lt", "lt-eq", "gt", "gt-eq", "eq", "not-eq", "starts-with", "not-starts-with"] = Field(alias="type")
-    term: UnboundTerm
+    term: Annotated[str | UnboundTerm, BeforeValidator(_to_unbound_term)]
     value: LiteralValue = Field()
     model_config = ConfigDict(populate_by_name=True, frozen=True, arbitrary_types_allowed=True)
 
@@ -885,7 +885,7 @@ class LiteralPredicate(UnboundPredicate, ABC):
         return self.value
 
     def bind(self, schema: Schema, case_sensitive: bool = True) -> BoundLiteralPredicate:
-        bound_term = self.term.bind(schema, case_sensitive)
+        bound_term = self.term.bind(schema, case_sensitive)  # type: ignore[union-attr]
         lit = self.literal.to(bound_term.ref().field.field_type)
 
         if isinstance(lit, AboveMax):

--- a/pyiceberg/expressions/__init__.py
+++ b/pyiceberg/expressions/__init__.py
@@ -21,7 +21,7 @@ import copy
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable, Sequence
 from functools import cached_property
-from typing import Annotated, Any, TypeAlias
+from typing import Annotated, Any, TypeAlias, cast
 from typing import Literal as TypingLiteral
 
 from pydantic import BeforeValidator, ConfigDict, Field, SerializeAsAny, model_validator
@@ -540,8 +540,7 @@ class UnaryPredicate(UnboundPredicate, ABC):
         return f"{str(self.__class__.__name__)}(term={str(self.term)})"
 
     def bind(self, schema: Schema, case_sensitive: bool = True) -> BoundUnaryPredicate:
-        assert isinstance(self.term, UnboundTerm)
-        bound_term = self.term.bind(schema, case_sensitive)
+        bound_term = cast(UnboundTerm, self.term).bind(schema, case_sensitive)
         bound_type = self.as_bound
         return bound_type(bound_term)  # type: ignore[misc]
 
@@ -697,8 +696,7 @@ class SetPredicate(UnboundPredicate, ABC):
         super().__init__(term=_to_unbound_term(term), values=literal_set)
 
     def bind(self, schema: Schema, case_sensitive: bool = True) -> BoundSetPredicate:
-        assert isinstance(self.term, UnboundTerm)
-        bound_term = self.term.bind(schema, case_sensitive)
+        bound_term = cast(UnboundTerm, self.term).bind(schema, case_sensitive)
         literal_set = self.literals
         return self.as_bound(bound_term, {lit.to(bound_term.ref().field.field_type) for lit in literal_set})  # type: ignore
 
@@ -887,8 +885,7 @@ class LiteralPredicate(UnboundPredicate, ABC):
         return self.value
 
     def bind(self, schema: Schema, case_sensitive: bool = True) -> BoundLiteralPredicate:
-        assert isinstance(self.term, UnboundTerm)
-        bound_term = self.term.bind(schema, case_sensitive)
+        bound_term = cast(UnboundTerm, self.term).bind(schema, case_sensitive)
         lit = self.literal.to(bound_term.ref().field.field_type)
 
         if isinstance(lit, AboveMax):

--- a/pyiceberg/expressions/__init__.py
+++ b/pyiceberg/expressions/__init__.py
@@ -716,7 +716,7 @@ class SetPredicate(UnboundPredicate, ABC):
         """Return the equality of two instances of the SetPredicate class."""
         return self.term == other.term and self.literals == other.literals if isinstance(other, self.__class__) else False
 
-    def __getnewargs__(self) -> tuple[UnboundTerm, set[Any]]:
+    def __getnewargs__(self) -> tuple[str | UnboundTerm, set[Any]]:
         """Pickle the SetPredicate class."""
         return (self.term, self.literals)
 

--- a/pyiceberg/expressions/__init__.py
+++ b/pyiceberg/expressions/__init__.py
@@ -540,7 +540,8 @@ class UnaryPredicate(UnboundPredicate, ABC):
         return f"{str(self.__class__.__name__)}(term={str(self.term)})"
 
     def bind(self, schema: Schema, case_sensitive: bool = True) -> BoundUnaryPredicate:
-        bound_term = self.term.bind(schema, case_sensitive)  # type: ignore[union-attr]
+        assert isinstance(self.term, UnboundTerm)
+        bound_term = self.term.bind(schema, case_sensitive)
         bound_type = self.as_bound
         return bound_type(bound_term)  # type: ignore[misc]
 
@@ -696,7 +697,8 @@ class SetPredicate(UnboundPredicate, ABC):
         super().__init__(term=_to_unbound_term(term), values=literal_set)
 
     def bind(self, schema: Schema, case_sensitive: bool = True) -> BoundSetPredicate:
-        bound_term = self.term.bind(schema, case_sensitive)  # type: ignore[union-attr]
+        assert isinstance(self.term, UnboundTerm)
+        bound_term = self.term.bind(schema, case_sensitive)
         literal_set = self.literals
         return self.as_bound(bound_term, {lit.to(bound_term.ref().field.field_type) for lit in literal_set})  # type: ignore
 
@@ -885,7 +887,8 @@ class LiteralPredicate(UnboundPredicate, ABC):
         return self.value
 
     def bind(self, schema: Schema, case_sensitive: bool = True) -> BoundLiteralPredicate:
-        bound_term = self.term.bind(schema, case_sensitive)  # type: ignore[union-attr]
+        assert isinstance(self.term, UnboundTerm)
+        bound_term = self.term.bind(schema, case_sensitive)
         lit = self.literal.to(bound_term.ref().field.field_type)
 
         if isinstance(lit, AboveMax):


### PR DESCRIPTION
# Rationale for this change

Without the pydantic mypy plugin, mypy generates `__init__` signatures from field declarations rather than from the explicit `__init__` overrides on `UnboundPredicate` and its subclasses. This causes downstream users to get type errors when constructing predicates with string column names:

```python
from pyiceberg.expressions import EqualTo

expr = EqualTo(term="my_column", value=42)
# mypy error: Argument "term" has incompatible type "str"; expected "UnboundTerm"
```

Closes #3101.

# What changes were included in this PR?

Widen the `term` field declaration from `UnboundTerm` to `Annotated[str | UnboundTerm, BeforeValidator(_to_unbound_term)]` in `UnboundPredicate` and `LiteralPredicate`. This uses the same `Annotated` + `BeforeValidator` pattern already established in `partitioning.py` for `transform` field coercion.

The `BeforeValidator` calls the existing `_to_unbound_term` helper, which coerces `str` to `Reference`. The stored value is always `UnboundTerm` at runtime.

Changes:
- `UnboundPredicate.term`: `UnboundTerm` -> `Annotated[str | UnboundTerm, BeforeValidator(_to_unbound_term)]`
- `LiteralPredicate.term`: same widening (re-declares the field)
- Added `# type: ignore[union-attr]` on 3 `bind()` call sites where `self.term.bind()` is called -- the validator guarantees the runtime type, but mypy sees the union
- All existing `__init__` methods are preserved unchanged (they handle more than just term coercion)

# How was this patch tested?

All 757 existing expression and conversion tests pass. Verified with mypy that keyword construction `EqualTo(term="col", value=42)` no longer produces the `arg-type` error on `term`.

**Note:** Positional construction `EqualTo("col", 42)` still produces mypy errors (`Too many positional arguments`) because mypy without the pydantic plugin cannot infer positional signatures from explicit `__init__` overrides. That is a broader issue affecting all Pydantic model constructors in the codebase and is outside the scope of this fix.