### PR TITLE
Add replace_tag to ManageSnapshots

### DIFF
--- a/pyiceberg/table/update/snapshot.py
+++ b/pyiceberg/table/update/snapshot.py
@@ -894,6 +894,36 @@ class ManageSnapshots(UpdateTableMetadata["ManageSnapshots"]):
         """
         return self._remove_ref_snapshot(ref_name=tag_name)
 
+    def replace_tag(self, tag_name: str, snapshot_id: int) -> ManageSnapshots:
+        """
+        Replace the tag with the given name to point to the specified snapshot.
+
+        Args:
+            tag_name (str): Tag to replace
+            snapshot_id (int): new snapshot id for the given tag
+        Returns:
+            This for method chaining
+        """
+        self._commit_if_ref_updates_exist()
+
+        refs = self._transaction.table_metadata.refs
+        if tag_name not in refs:
+            raise ValueError(f"Tag does not exist: {tag_name}")
+
+        ref = refs[tag_name]
+        if ref.snapshot_ref_type != SnapshotRefType.TAG:
+            raise ValueError(f"Ref {tag_name} is not a tag")
+
+        update, requirement = self._transaction._set_ref_snapshot(
+            snapshot_id=snapshot_id,
+            ref_name=tag_name,
+            type=SnapshotRefType.TAG,
+            max_ref_age_ms=ref.max_ref_age_ms,
+        )
+        self._updates += update
+        self._requirements += requirement
+        return self
+
     def create_branch(
         self,
         snapshot_id: int,

--- a/pyiceberg/table/update/snapshot.py
+++ b/pyiceberg/table/update/snapshot.py
@@ -1098,6 +1098,36 @@ class ManageSnapshots(UpdateTableMetadata["ManageSnapshots"]):
         """
         return self._remove_ref_snapshot(ref_name=tag_name)
 
+    def replace_tag(self, tag_name: str, snapshot_id: int) -> ManageSnapshots:
+        """
+        Replace the tag with the given name to point to the specified snapshot.
+
+        Args:
+            tag_name (str): Tag to replace
+            snapshot_id (int): new snapshot id for the given tag
+        Returns:
+            This for method chaining
+        """
+        self._commit_if_ref_updates_exist()
+
+        refs = self._transaction.table_metadata.refs
+        if tag_name not in refs:
+            raise ValueError(f"Tag does not exist: {tag_name}")
+
+        ref = refs[tag_name]
+        if ref.snapshot_ref_type != SnapshotRefType.TAG:
+            raise ValueError(f"Ref {tag_name} is not a tag")
+
+        update, requirement = self._transaction._set_ref_snapshot(
+            snapshot_id=snapshot_id,
+            ref_name=tag_name,
+            type=SnapshotRefType.TAG,
+            max_ref_age_ms=ref.max_ref_age_ms,
+        )
+        self._updates += update
+        self._requirements += requirement
+        return self
+
     def create_branch(
         self,
         snapshot_id: int,

--- a/tests/integration/test_snapshot_operations.py
+++ b/tests/integration/test_snapshot_operations.py
@@ -23,7 +23,7 @@ from pytest_lazy_fixtures import lf
 
 from pyiceberg.catalog import Catalog
 from pyiceberg.table import Table
-from pyiceberg.table.refs import SnapshotRef
+from pyiceberg.table.refs import SnapshotRef, SnapshotRefType
 
 
 @pytest.fixture
@@ -105,6 +105,55 @@ def test_remove_branch(catalog: Catalog) -> None:
     # now, remove the branch
     tbl.manage_snapshots().remove_branch(branch_name=branch_name).commit()
     assert tbl.metadata.refs.get(branch_name, None) is None
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("catalog", [lf("session_catalog_hive"), lf("session_catalog")])
+def test_replace_tag(catalog: Catalog) -> None:
+    identifier = "default.test_table_snapshot_operations"
+    tbl = catalog.load_table(identifier)
+    assert len(tbl.history()) > 2
+
+    current_snapshot_id = tbl.history()[-1].snapshot_id
+    older_snapshot_id = tbl.history()[-2].snapshot_id
+
+    tag_name = "my-tag"
+    tbl.manage_snapshots().create_tag(older_snapshot_id, tag_name, 1).commit()
+    tag = tbl.metadata.refs.get(tag_name)
+    assert tag is not None
+    assert tag.snapshot_id == older_snapshot_id
+    assert tag.snapshot_ref_type == SnapshotRefType.TAG
+    assert tag.max_ref_age_ms == 1
+
+    tbl.manage_snapshots().replace_tag(tag_name=tag_name, snapshot_id=current_snapshot_id).commit()
+
+    tag = tbl.metadata.refs.get(tag_name)
+    assert tag is not None
+    assert tag.snapshot_id == current_snapshot_id
+    assert tag.snapshot_ref_type == SnapshotRefType.TAG
+    assert tag.max_ref_age_ms == 1
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("catalog", [lf("session_catalog_hive"), lf("session_catalog")])
+def test_replace_missing_tag(catalog: Catalog) -> None:
+    identifier = "default.test_table_snapshot_operations"
+    tbl = catalog.load_table(identifier)
+    snapshot_id = tbl.history()[-1].snapshot_id
+
+    with pytest.raises(ValueError, match="Tag does not exist: test"):
+        tbl.manage_snapshots().replace_tag(tag_name="test", snapshot_id=snapshot_id).commit()
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("catalog", [lf("session_catalog_hive"), lf("session_catalog")])
+def test_replace_tag_with_branch(catalog: Catalog) -> None:
+    identifier = "default.test_table_snapshot_operations"
+    tbl = catalog.load_table(identifier)
+    snapshot_id = tbl.history()[-1].snapshot_id
+
+    with pytest.raises(ValueError, match="Ref main is not a tag"):
+        tbl.manage_snapshots().replace_tag(tag_name="main", snapshot_id=snapshot_id).commit()
 
 
 @pytest.mark.integration


### PR DESCRIPTION
# Rationale for this change

Iceberg Java offers [replaceTag](https://github.com/apache/iceberg/blob/60d3fc01b95e51952d07bfd6228f5bc8c855de0b/api/src/main/java/org/apache/iceberg/ManageSnapshots.java#L147-L154) method. 
This PR enhances the coverage of tag operations. 

## Are these changes tested?

Yes

## Are there any user-facing changes?

Add `replace_tag` to `ManageSnapshots`.

<!-- In the case of user-facing changes, please add the changelog label. -->
