### PR TITLE
fix(table): validate snapshot timestamp drift

### DIFF
--- a/pyiceberg/table/update/__init__.py
+++ b/pyiceberg/table/update/__init__.py
@@ -58,6 +58,7 @@ if TYPE_CHECKING:
     from pyiceberg.table import Transaction
 
 U = TypeVar("U")
+ONE_MINUTE_MS = 60_000
 
 
 class UpdateTableMetadata(ABC, Generic[U]):
@@ -443,6 +444,19 @@ def _(update: AddSnapshotUpdate, base_metadata: TableMetadata, context: _TableMe
         raise ValueError(
             f"Cannot add snapshot with sequence number {update.snapshot.sequence_number} "
             f"older than last sequence number {base_metadata.last_sequence_number}"
+        )
+    elif (
+        base_metadata.snapshot_log
+        and update.snapshot.timestamp_ms - base_metadata.snapshot_log[-1].timestamp_ms < -ONE_MINUTE_MS
+    ):
+        raise ValueError(
+            f"Invalid snapshot timestamp {update.snapshot.timestamp_ms}: "
+            f"before last snapshot timestamp {base_metadata.snapshot_log[-1].timestamp_ms}"
+        )
+    elif update.snapshot.timestamp_ms - base_metadata.last_updated_ms < -ONE_MINUTE_MS:
+        raise ValueError(
+            f"Invalid snapshot timestamp {update.snapshot.timestamp_ms}: "
+            f"before last updated timestamp {base_metadata.last_updated_ms}"
         )
     elif base_metadata.format_version >= 3 and update.snapshot.first_row_id is None:
         raise ValueError("Cannot add snapshot without first row id")

--- a/pyiceberg/table/update/__init__.py
+++ b/pyiceberg/table/update/__init__.py
@@ -446,8 +446,7 @@ def _(update: AddSnapshotUpdate, base_metadata: TableMetadata, context: _TableMe
             f"older than last sequence number {base_metadata.last_sequence_number}"
         )
     elif (
-        base_metadata.snapshot_log
-        and update.snapshot.timestamp_ms - base_metadata.snapshot_log[-1].timestamp_ms < -ONE_MINUTE_MS
+        base_metadata.snapshot_log and update.snapshot.timestamp_ms - base_metadata.snapshot_log[-1].timestamp_ms < -ONE_MINUTE_MS
     ):
         raise ValueError(
             f"Invalid snapshot timestamp {update.snapshot.timestamp_ms}: "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ import uuid
 from collections.abc import Generator
 from datetime import date, datetime, timezone
 from pathlib import Path
-from random import choice, randint
+from random import choice
 from tempfile import TemporaryDirectory
 from typing import (
     TYPE_CHECKING,
@@ -807,19 +807,22 @@ def example_table_metadata_v2_with_extensive_snapshots() -> dict[str, Any]:
     snapshot_log = []
     initial_snapshot_id = 3051729675574597004
 
+    base_timestamp_ms = 1602638573590
     for i in range(2000):
         snapshot_id = initial_snapshot_id + i
         parent_snapshot_id = snapshot_id - 1 if i > 0 else None
-        timestamp_ms = int(time.time() * 1000) - randint(0, 1000000)
+        timestamp_ms = base_timestamp_ms + i
         snapshots.append(generate_snapshot(snapshot_id, parent_snapshot_id, timestamp_ms, i))
         snapshot_log.append({"snapshot-id": snapshot_id, "timestamp-ms": timestamp_ms})
+
+    last_updated_ms = snapshot_log[-1]["timestamp-ms"]
 
     return {
         "format-version": 2,
         "table-uuid": "9c12d441-03fe-4693-9a96-a0705ddf69c1",
         "location": "s3://bucket/test/location",
         "last-sequence-number": 34,
-        "last-updated-ms": 1602638573590,
+        "last-updated-ms": last_updated_ms,
         "last-column-id": 3,
         "current-schema-id": 1,
         "schemas": [

--- a/tests/table/test_init.py
+++ b/tests/table/test_init.py
@@ -830,6 +830,40 @@ def test_update_metadata_add_snapshot(table_v2: Table) -> None:
     assert new_metadata.last_updated_ms == new_snapshot.timestamp_ms
 
 
+def test_update_metadata_add_snapshot_rejects_old_timestamp_vs_snapshot_log(table_v2: Table) -> None:
+    oldest_allowed_snapshot_ts = table_v2.metadata.snapshot_log[-1].timestamp_ms - 60_000
+    new_snapshot = Snapshot(
+        snapshot_id=25,
+        parent_snapshot_id=19,
+        sequence_number=200,
+        timestamp_ms=oldest_allowed_snapshot_ts - 1,
+        manifest_list="s3:/a/b/c.avro",
+        summary=Summary(Operation.APPEND),
+        schema_id=3,
+    )
+
+    with pytest.raises(ValueError, match="before last snapshot timestamp"):
+        update_table_metadata(table_v2.metadata, (AddSnapshotUpdate(snapshot=new_snapshot),))
+
+
+def test_update_metadata_add_snapshot_rejects_old_timestamp_vs_last_updated(table_v2: Table) -> None:
+    # Clear snapshot-log to isolate the last_updated_ms guard.
+    base_metadata = table_v2.metadata.model_copy(update={"snapshot_log": []})
+    oldest_allowed_snapshot_ts = base_metadata.last_updated_ms - 60_000
+    new_snapshot = Snapshot(
+        snapshot_id=25,
+        parent_snapshot_id=19,
+        sequence_number=200,
+        timestamp_ms=oldest_allowed_snapshot_ts - 1,
+        manifest_list="s3:/a/b/c.avro",
+        summary=Summary(Operation.APPEND),
+        schema_id=3,
+    )
+
+    with pytest.raises(ValueError, match="before last updated timestamp"):
+        update_table_metadata(base_metadata, (AddSnapshotUpdate(snapshot=new_snapshot),))
+
+
 def test_update_metadata_set_ref_snapshot(table_v2: Table) -> None:
     update, _ = table_v2.transaction()._set_ref_snapshot(
         snapshot_id=3051729675574597004,


### PR DESCRIPTION
<!-- Closes #2938 -->

## Rationale
Align snapshot timestamp validation with the Java and Rust implementations by rejecting timestamps that drift backwards by more than one minute. Small clock skew remains allowed.

This also validates parsed table metadata:
- `snapshot-log` entries remain sorted within the one-minute tolerance
- `last-updated-ms` is not more than one minute behind the latest snapshot-log entry

## Attribution
This revives the implementation from #3062 by @mrutunjay-kinagi. I cherry-picked the original authored commits onto the latest `main`, preserving authorship, and am reopening it because the earlier PR was closed automatically after inactivity. It includes the metadata-level validation added in response to @Fokko's review.

## Verification
- `make lint`
- `make test` (`3713 passed, 1534 deselected`)
