### PR TITLE
Make `View.version` return None for unknown id

### DIFF
--- a/pyiceberg/view/__init__.py
+++ b/pyiceberg/view/__init__.py
@@ -59,9 +59,9 @@ class View:
         """Get the versions of this view."""
         return self.metadata.versions
 
-    def version(self, version_id: int) -> ViewVersion:
-        """Get the version in this view by ID."""
-        return next(version for version in self.metadata.versions if version.version_id == version_id)
+    def version(self, version_id: int) -> ViewVersion | None:
+        """Get the version in this view by ID, or None if the ID cannot be found."""
+        return next((version for version in self.metadata.versions if version.version_id == version_id), None)
 
     def history(self) -> list[ViewHistoryEntry]:
         """Get the version of this history view."""

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -119,8 +119,7 @@ def test_view_versions_multiple(example_view_metadata_v1_multiple_versions: dict
 
 
 def test_view_version_unknown_id(view: View) -> None:
-    with pytest.raises(StopIteration):
-        view.version(999)
+    assert not view.version(999)
 
 
 def test_view_sql_for_unknown_dialect(view: View) -> None:


### PR DESCRIPTION
# Rationale for this change

Follow-up of https://github.com/apache/iceberg-python/pull/3338
It would be preferable to return `None` instead of throwing `StopIteration`. 

Iceberg Java returns null if the specified version doesn't exist: 

https://github.com/apache/iceberg/blob/6a737004506176a902784ec30fc4d545c1ce6997/api/src/main/java/org/apache/iceberg/view/View.java#L60-L66

> `@return` a version, or null if the ID cannot be found


## Are these changes tested?

Yes

## Are there any user-facing changes?

No, the method isn't released yet. 

<!-- In the case of user-facing changes, please add the changelog label. -->
