### PR TITLE
docs: add Tencent COS S3-compatible configuration example

### DIFF
--- a/mkdocs/docs/configuration.md
+++ b/mkdocs/docs/configuration.md
@@ -201,12 +201,12 @@ Tencent Cloud Object Storage (COS) is S3-compatible and can be used with PyIcebe
 
 No additional dependencies are required.
 
-| Key                  | Example                                           | Description |
-| -------------------- | ------------------------------------------------- | ----------- |
-| s3.endpoint          | https://cos.ap-guangzhou.myqcloud.com            | Tencent COS S3-compatible endpoint |
-| s3.access-key-id     | <access-key>                                      | Access key for COS |
-| s3.secret-access-key | <secret-key>                                      | Secret key for COS |
-| s3.session-token     | <optional-session-token>                          | Optional session token |
+| Key                  | Example                        | Description |
+| -------------------- | ------------------------------ | ----------- |
+| s3.endpoint          | https://cos.ap-guangzhou.myqcloud.com | Tencent COS S3-compatible endpoint |
+| s3.access-key-id     | `<access-key>`                 | Access key for COS |
+| s3.secret-access-key | `<secret-key>`                  | Secret key for COS |
+| s3.session-token     | `<optional-session-token>`      | Optional session token |
 
 ### Example
 

--- a/mkdocs/docs/configuration.md
+++ b/mkdocs/docs/configuration.md
@@ -212,7 +212,7 @@ No additional dependencies are required.
 
 | Key                  | Example                        | Description |
 | -------------------- | ------------------------------ | ----------- |
-| s3.endpoint          | https://cos.ap-guangzhou.myqcloud.com | Tencent COS S3-compatible endpoint |
+| s3.endpoint          | <https://cos.ap-guangzhou.myqcloud.com> | Tencent COS S3-compatible endpoint |
 | s3.access-key-id     | admin                           | Access key for COS |
 | s3.secret-access-key | password                        | Secret key for COS |
 | s3.session-token     | AQoDYXdzEJr...                  | Optional session token |

--- a/mkdocs/docs/configuration.md
+++ b/mkdocs/docs/configuration.md
@@ -203,7 +203,7 @@ No additional dependencies are required.
 
 | Key                  | Example                        | Description |
 | -------------------- | ------------------------------ | ----------- |
-| s3.endpoint          | https://cos.ap-guangzhou.myqcloud.com | Tencent COS S3-compatible endpoint |
+| s3.endpoint          | <https://cos.ap-guangzhou.myqcloud.com> | Tencent COS S3-compatible endpoint |
 | s3.access-key-id     | `<access-key>`                 | Access key for COS |
 | s3.secret-access-key | `<secret-key>`                  | Secret key for COS |
 | s3.session-token     | `<optional-session-token>`      | Optional session token |

--- a/mkdocs/docs/configuration.md
+++ b/mkdocs/docs/configuration.md
@@ -193,14 +193,32 @@ For the FileIO there are several configuration options available:
 
 PyIceberg uses [S3FileSystem](https://arrow.apache.org/docs/python/generated/pyarrow.fs.S3FileSystem.html) class to connect to OSS bucket as the service is [compatible with S3 SDK](https://www.alibabacloud.com/help/en/oss/developer-reference/use-amazon-s3-sdks-to-access-oss) as long as the endpoint is addressed with virtual hosted style.
 
-| Key                  | Example             | Description                                      |
-| -------------------- | ------------------- | ------------------------------------------------ |
-| s3.endpoint          | <https://s3.oss-your-bucket-region.aliyuncs.com/>      | Configure an endpoint of the OSS service for the FileIO to access. Be sure to use S3 compatible endpoint as given in the example. |
-| s3.access-key-id     | admin                      | Configure the static access key id used to access the FileIO.                                                                                                                                                                                             |
-| s3.secret-access-key | password                   | Configure the static secret access key used to access the FileIO.                                                                                                                                                                                         |
-| s3.session-token     | AQoDYXdzEJr...             | Configure the static session token used to access the FileIO.                                                                                                                                                                                             |
-| s3.force-virtual-addressing   | True                       | Whether to use virtual addressing of buckets. This is set to `True` by default as OSS can only be accessed with virtual hosted style address.                                                                                                                                                                                                        |
-| s3.anonymous                | True                       | Configure whether to use anonymous connection. If False (default), uses key/secret if configured or standard AWS configuration methods. |
+---
+
+### Tencent Cloud Object Storage (COS)
+
+Tencent Cloud Object Storage (COS) is S3-compatible and can be used with PyIceberg using the existing S3FileIO / PyArrowFileIO implementation.
+
+No additional dependencies are required.
+
+| Key                  | Example                                           | Description |
+| -------------------- | ------------------------------------------------- | ----------- |
+| s3.endpoint          | https://cos.ap-guangzhou.myqcloud.com            | Tencent COS S3-compatible endpoint |
+| s3.access-key-id     | <access-key>                                      | Access key for COS |
+| s3.secret-access-key | <secret-key>                                      | Secret key for COS |
+| s3.session-token     | <optional-session-token>                          | Optional session token |
+
+### Example
+
+```python
+catalog = load_catalog(
+    {
+        "s3.endpoint": "https://cos.ap-guangzhou.myqcloud.com",
+        "s3.access-key-id": "<access-key>",
+        "s3.secret-access-key": "<secret-key>",
+    }
+)
+```
 
 <!-- markdown-link-check-enable-->
 

--- a/mkdocs/docs/configuration.md
+++ b/mkdocs/docs/configuration.md
@@ -189,6 +189,15 @@ For the FileIO there are several configuration options available:
 
 ### Alibaba Cloud Object Storage Service (OSS)
 
+| Key                          | Example                                       | Description |
+| ---------------------------- | --------------------------------------------- | ----------- |
+| s3.endpoint                  | <https://s3.oss-your-bucket-region.aliyuncs.com/> | Configure an endpoint of the OSS service for the FileIO to access. Be sure to use S3 compatible endpoint as given in the example. |
+| s3.access-key-id             | admin                                         | Configure the static access key id used to access the FileIO. |
+| s3.secret-access-key         | password                                      | Configure the static secret access key used to access the FileIO. |
+| s3.session-token             | AQoDYXdzEJr...                                | Configure the static session token used to access the FileIO. |
+| s3.force-virtual-addressing  | True                                          | Whether to use virtual addressing of buckets. This is set to `True` by default as OSS can only be accessed with virtual hosted style address. |
+| s3.anonymous                 | True                                          | Configure whether to use anonymous connection. If False (default), uses key/secret if configured or standard AWS configuration methods. |
+
 <!-- markdown-link-check-disable -->
 
 PyIceberg uses [S3FileSystem](https://arrow.apache.org/docs/python/generated/pyarrow.fs.S3FileSystem.html) class to connect to OSS bucket as the service is [compatible with S3 SDK](https://www.alibabacloud.com/help/en/oss/developer-reference/use-amazon-s3-sdks-to-access-oss) as long as the endpoint is addressed with virtual hosted style.
@@ -203,19 +212,19 @@ No additional dependencies are required.
 
 | Key                  | Example                        | Description |
 | -------------------- | ------------------------------ | ----------- |
-| s3.endpoint          | <https://cos.ap-guangzhou.myqcloud.com> | Tencent COS S3-compatible endpoint |
-| s3.access-key-id     | `<access-key>`                 | Access key for COS |
-| s3.secret-access-key | `<secret-key>`                  | Secret key for COS |
-| s3.session-token     | `<optional-session-token>`      | Optional session token |
+| s3.endpoint          | https://cos.ap-guangzhou.myqcloud.com | Tencent COS S3-compatible endpoint |
+| s3.access-key-id     | admin                           | Access key for COS |
+| s3.secret-access-key | password                        | Secret key for COS |
+| s3.session-token     | AQoDYXdzEJr...                  | Optional session token |
 
 ### Example
 
 ```python
 catalog = load_catalog(
-    {
+    **{
         "s3.endpoint": "https://cos.ap-guangzhou.myqcloud.com",
-        "s3.access-key-id": "<access-key>",
-        "s3.secret-access-key": "<secret-key>",
+        "s3.access-key-id": "admin",
+        "s3.secret-access-key": "password",
     }
 )
 ```

--- a/tests/integration/test_writes/test_writes.py
+++ b/tests/integration/test_writes/test_writes.py
@@ -870,7 +870,9 @@ def test_summaries_with_only_nulls(
 @pytest.mark.integration
 def test_duckdb_url_import(warehouse: Path, arrow_table_with_null: pa.Table) -> None:
     os.environ["TZ"] = "Etc/UTC"
-    time.tzset()
+
+    if hasattr(time, "tzset"):
+        time.tzset()
     tz = pytz.timezone(os.environ["TZ"])
 
     catalog = SqlCatalog("test_sql_catalog", uri="sqlite:///:memory:", warehouse=f"/{warehouse}")


### PR DESCRIPTION
Related to #3239

## Rationale for this change

This PR adds documentation for Tencent Cloud Object Storage (COS) showing how it can be used with PyIceberg via the existing S3FileIO / PyArrowFileIO implementation.

Tencent COS is S3-compatible, so no new filesystem backend (like fsspec/cosfs) or additional dependencies are required. Users can configure COS using standard S3 configuration keys such as `s3.endpoint`, `s3.access-key-id`, and `s3.secret-access-key`.

## Are these changes tested?

Yes.

Verified locally that Tencent COS works using the S3-compatible configuration approach by setting the appropriate `s3.endpoint`. No code changes were required, only configuration-level validation.

## Are there any user-facing changes?

Yes.

This improves documentation by adding a clear example for Tencent COS integration, helping users configure COS with PyIceberg using existing S3FileIO support.