### PR TITLE
Add defaults to ViewVersion fields

### DIFF
--- a/pyiceberg/view/metadata.py
+++ b/pyiceberg/view/metadata.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import time
 from typing import Literal
 
 from pydantic import Field, RootModel, field_validator
@@ -44,13 +45,13 @@ class ViewRepresentation(IcebergBaseModel, RootModel):
 class ViewVersion(IcebergBaseModel):
     """A version of the view definition."""
 
-    version_id: int = Field(alias="version-id")
+    version_id: int = Field(alias="version-id", default=1)
     """ID for the version"""
     schema_id: int = Field(alias="schema-id")
     """ID of the schema for the view version"""
-    timestamp_ms: int = Field(alias="timestamp-ms")
+    timestamp_ms: int = Field(alias="timestamp-ms", default=int(time.time() * 1000))
     """Timestamp when the version was created (ms from epoch)"""
-    summary: dict[str, str] = Field()
+    summary: dict[str, str] = Field(default={})
     """A string to string map of summary metadata about the version"""
     representations: list[ViewRepresentation] = Field()
     """A list of representations for the view definition"""

--- a/pyiceberg/view/metadata.py
+++ b/pyiceberg/view/metadata.py
@@ -49,9 +49,9 @@ class ViewVersion(IcebergBaseModel):
     """ID for the version"""
     schema_id: int = Field(alias="schema-id")
     """ID of the schema for the view version"""
-    timestamp_ms: int = Field(alias="timestamp-ms", default=int(time.time() * 1000))
+    timestamp_ms: int = Field(alias="timestamp-ms", default_factory=lambda: int(time.time() * 1000))
     """Timestamp when the version was created (ms from epoch)"""
-    summary: dict[str, str] = Field(default={})
+    summary: dict[str, str] = Field(default_factory=dict)
     """A string to string map of summary metadata about the version"""
     representations: list[ViewRepresentation] = Field()
     """A list of representations for the view definition"""

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -1746,10 +1746,7 @@ def test_create_view_200(rest_mock: Mocker, table_schema_simple: Schema, example
         identifier=("fokko", "fokko2"),
         schema=table_schema_simple,
         view_version=ViewVersion(
-            version_id=1,
-            timestamp_ms=12345,
             schema_id=1,
-            summary={"engine-name": "spark", "engineVersion": "3.3"},
             representations=[
                 {
                     "type": "sql",
@@ -1791,10 +1788,7 @@ def test_create_view_409(
             identifier=("fokko", "fokko2"),
             schema=table_schema_simple,
             view_version=ViewVersion(
-                version_id=1,
-                timestamp_ms=12345,
                 schema_id=1,
-                summary={"engine-name": "spark", "engineVersion": "3.3"},
                 representations=[],
                 default_namespace=[],
             ),

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -1747,6 +1747,7 @@ def test_create_view_200(rest_mock: Mocker, table_schema_simple: Schema, example
         schema=table_schema_simple,
         view_version=ViewVersion(
             schema_id=1,
+            summary={"engine-name": "spark", "engineVersion": "3.3"},
             representations=[
                 {
                     "type": "sql",
@@ -1789,6 +1790,7 @@ def test_create_view_409(
             schema=table_schema_simple,
             view_version=ViewVersion(
                 schema_id=1,
+                summary={"engine-name": "spark", "engineVersion": "3.3"},
                 representations=[],
                 default_namespace=[],
             ),

--- a/tests/integration/test_writes/test_writes.py
+++ b/tests/integration/test_writes/test_writes.py
@@ -1769,10 +1769,7 @@ def test_create_view(
     identifier = "default.some_view"
     schema = pa.schema([pa.field("some_col", pa.int32())])
     view_version = ViewVersion(
-        version_id=1,
         schema_id=1,
-        timestamp_ms=int(time.time() * 1000),
-        summary={},
         representations=[
             SQLViewRepresentation(
                 type="sql",


### PR DESCRIPTION
# Rationale for this change

Allow users to create a view with fewer parameters.

We can set an environment context (`engine-name` and `engine-version`) in `summary` field by default
once https://github.com/apache/iceberg-python/pull/3441 is merged.

## Are these changes tested?

Yes

## Are there any user-facing changes?

No

<!-- In the case of user-facing changes, please add the changelog label. -->
