### PR TITLE
DOCS: Fix layout of sqlite warning

### DIFF
--- a/mkdocs/docs/configuration.md
+++ b/mkdocs/docs/configuration.md
@@ -632,7 +632,7 @@ In the case of SQLite:
 
 <!-- prettier-ignore-start -->
 
-!!! warning inline end "Development only"
+!!! warning "Development only"
     SQLite is not built for concurrency, you should use this catalog for exploratory or development purposes.
 
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

 Fix broken layout in the documentation. 

Before: 
<img width="1114" height="447" alt="Screenshot 2026-06-05 at 13 43 29" src="https://github.com/user-attachments/assets/090f9204-9e5d-4df8-84c9-9ce2117888f9" />

After: 
<img width="1068" height="592" alt="Screenshot 2026-06-05 at 13 45 32" src="https://github.com/user-attachments/assets/16851dd8-a543-4ab9-9dab-387af943efa0" />


## Are these changes tested?

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
