### PR TITLE
Fix misleading file extension for partition statistics

### DIFF
--- a/tests/table/test_init.py
+++ b/tests/table/test_init.py
@@ -1599,7 +1599,7 @@ def test_set_partition_statistics_update(table_v2_with_statistics: Table) -> Non
 
     partition_statistics_file = PartitionStatisticsFile(
         snapshot_id=snapshot_id,
-        statistics_path="s3://bucket/warehouse/stats.puffin",
+        statistics_path="s3://bucket/warehouse/stats.parquet",
         file_size_in_bytes=124,
     )
 
@@ -1619,7 +1619,7 @@ def test_set_partition_statistics_update(table_v2_with_statistics: Table) -> Non
     expected = """
     {
       "snapshot-id": 3055729675574597004,
-      "statistics-path": "s3://bucket/warehouse/stats.puffin",
+      "statistics-path": "s3://bucket/warehouse/stats.parquet",
       "file-size-in-bytes": 124
     }"""
 
@@ -1637,7 +1637,7 @@ def test_remove_partition_statistics_update(table_v2_with_statistics: Table) -> 
 
     partition_statistics_file = PartitionStatisticsFile(
         snapshot_id=snapshot_id,
-        statistics_path="s3://bucket/warehouse/stats.puffin",
+        statistics_path="s3://bucket/warehouse/stats.parquet",
         file_size_in_bytes=124,
     )
 


### PR DESCRIPTION
# Rationale for this change

The partition statistics file doesn't use Puffin file:

* https://iceberg.apache.org/spec/#partition-statistics-file
> Statistics information for each unique partition tuple is stored as a row in any of the data file format of the table (for example, Parquet or ORC)

## Are these changes tested?

Yes

## Are there any user-facing changes?

No

<!-- In the case of user-facing changes, please add the changelog label. -->
