### PR TITLE
Do not throw error on list_tables, list_namespaces

### DIFF
--- a/pyiceberg/catalog/rest/__init__.py
+++ b/pyiceberg/catalog/rest/__init__.py
@@ -1039,7 +1039,8 @@ class RestCatalog(Catalog):
     @retry(**_RETRY_ARGS)
     @override
     def list_tables(self, namespace: str | Identifier) -> list[Identifier]:
-        self._check_endpoint(Capability.V1_LIST_TABLES)
+        if Capability.V1_LIST_TABLES not in self._supported_endpoints:
+            return []
         namespace_tuple = self._check_valid_namespace_identifier(namespace)
         namespace_concat = self._encode_namespace_path(namespace_tuple)
         url = self.url(Endpoints.list_tables, namespace=namespace_concat)
@@ -1277,7 +1278,8 @@ class RestCatalog(Catalog):
     @retry(**_RETRY_ARGS)
     @override
     def list_namespaces(self, namespace: str | Identifier = ()) -> list[Identifier]:
-        self._check_endpoint(Capability.V1_LIST_NAMESPACES)
+        if Capability.V1_LIST_NAMESPACES not in self._supported_endpoints:
+            return []
         namespace_tuple = self.identifier_to_tuple(namespace)
 
         params: dict[str, str] = {}

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -2887,6 +2887,34 @@ class TestRestCatalogClose:
         with pytest.raises(NotImplementedError, match="Server does not support endpoint"):
             catalog._check_endpoint(Capability.V1_LIST_TABLES)
 
+    def test_list_tables_returns_empty_when_unsupported(self, requests_mock: Mocker) -> None:
+        requests_mock.get(
+            f"{TEST_URI}v1/config",
+            json={
+                "defaults": {},
+                "overrides": {},
+                "endpoints": ["GET /v1/{prefix}/namespaces"],
+            },
+            status_code=200,
+        )
+        catalog = RestCatalog("rest", uri=TEST_URI, token="token")
+
+        assert catalog.list_tables(("examples",)) == []
+
+    def test_list_namespaces_returns_empty_when_unsupported(self, requests_mock: Mocker) -> None:
+        requests_mock.get(
+            f"{TEST_URI}v1/config",
+            json={
+                "defaults": {},
+                "overrides": {},
+                "endpoints": ["GET /v1/{prefix}/namespaces/{namespace}/tables"],
+            },
+            status_code=200,
+        )
+        catalog = RestCatalog("rest", uri=TEST_URI, token="token")
+
+        assert catalog.list_namespaces() == []
+
     def test_config_returns_invalid_endpoint(self, requests_mock: Mocker) -> None:
         requests_mock.get(
             f"{TEST_URI}v1/config",


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
The Java (and soon Go) implementations of Iceberg specify that if list_tables / list_namespaces aren't supported, they should return an empty array, not throw an error.

I'm not a huge fan of this personally, but I think it's best to match the reference implementation.

[List Tables on Java](https://github.com/apache/iceberg/blob/8b45abce036b480fbecd2427d4ae70fae0536640/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java#L306-L308)
[List Namespaces on Java](https://github.com/apache/iceberg/blob/8b45abce036b480fbecd2427d4ae70fae0536640/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java#L754-L756)

## Are these changes tested?
Test included.

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
