### PR TITLE
fix(fsspec): parse S3 virtual addressing as a boolean

### DIFF
--- a/pyiceberg/io/fsspec.py
+++ b/pyiceberg/io/fsspec.py
@@ -201,7 +201,7 @@ def _s3(properties: Properties) -> AbstractFileSystem:
     if request_timeout := properties.get(S3_REQUEST_TIMEOUT):
         config_kwargs["read_timeout"] = float(request_timeout)
 
-    if _force_virtual_addressing := properties.get(S3_FORCE_VIRTUAL_ADDRESSING):
+    if property_as_bool(properties, S3_FORCE_VIRTUAL_ADDRESSING, False):
         config_kwargs["s3"] = {"addressing_style": "virtual"}
 
     if s3_anonymous := properties.get(S3_ANONYMOUS):

--- a/pyiceberg/utils/properties.py
+++ b/pyiceberg/utils/properties.py
@@ -54,13 +54,13 @@ def property_as_float(
 
 
 def property_as_bool(
-    properties: dict[str, str],
+    properties: Properties,
     property_name: str,
     default: bool,
 ) -> bool:
-    if value := properties.get(property_name):
+    if (value := properties.get(property_name)) not in (None, ""):
         try:
-            return strtobool(value)
+            return strtobool(str(value))
         except ValueError as e:
             raise ValueError(f"Could not parse table property {property_name} to a boolean: {value}") from e
     return default

--- a/tests/io/test_fsspec.py
+++ b/tests/io/test_fsspec.py
@@ -320,9 +320,20 @@ def test_fsspec_s3_session_properties() -> None:
         )
 
 
-def test_fsspec_s3_session_properties_force_virtual_addressing() -> None:
+@pytest.mark.parametrize(
+    ("force_virtual_addressing", "config_kwargs"),
+    [
+        ("true", {"s3": {"addressing_style": "virtual"}}),
+        ("false", {}),
+        (True, {"s3": {"addressing_style": "virtual"}}),
+        (False, {}),
+    ],
+)
+def test_fsspec_s3_session_properties_force_virtual_addressing(
+    force_virtual_addressing: str | bool, config_kwargs: Properties
+) -> None:
     session_properties: Properties = {
-        "s3.force-virtual-addressing": True,
+        "s3.force-virtual-addressing": force_virtual_addressing,
         "s3.endpoint": "http://localhost:9000",
         "s3.access-key-id": "admin",
         "s3.secret-access-key": "password",
@@ -346,7 +357,7 @@ def test_fsspec_s3_session_properties_force_virtual_addressing() -> None:
                 "region_name": "us-east-1",
                 "aws_session_token": "s3.session-token",
             },
-            config_kwargs={"s3": {"addressing_style": "virtual"}},
+            config_kwargs=config_kwargs,
         )
 
 

--- a/tests/utils/test_properties.py
+++ b/tests/utils/test_properties.py
@@ -67,14 +67,23 @@ def test_property_as_float_with_invalid_value() -> None:
         assert "Could not parse table property some_float_prop to a float: invalid" in str(exc.value)
 
 
-def test_property_as_bool() -> None:
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("True", True),
+        ("False", False),
+        (True, True),
+        (False, False),
+    ],
+)
+def test_property_as_bool(value: str | bool, expected: bool) -> None:
     properties = {
-        "bool": "True",
+        "bool": value,
     }
 
-    assert property_as_bool(properties, "bool", default=False) is True
+    assert property_as_bool(properties, "bool", default=not expected) is expected
     assert property_as_bool(properties, "missing", default=False) is False
-    assert property_as_float(properties, "missing") is None
+    assert property_as_bool(properties, "missing", default=True) is True
 
 
 def test_property_as_bool_with_invalid_value() -> None:


### PR DESCRIPTION
# Rationale for this change

`FsspecFileIO` evaluated `s3.force-virtual-addressing` using the raw truthiness of the property value. As a result, the non-empty string `"false"` incorrectly enabled virtual-hosted-style S3 addressing.

This change uses the shared `property_as_bool` utility so string and native boolean values are parsed consistently. The utility now accepts the repository's `Properties` type and preserves support for native `bool` values. When the property is absent, fsspec retains its existing default addressing behavior.

A dedicated properties abstraction could prevent similar mistakes more broadly, but that larger refactor is outside this targeted fix.

## Are these changes tested?

Yes. The fsspec S3 session-property test now covers `"true"`, `"false"`, `True`, and `False`. The shared property utility tests cover the same input forms and verify default handling.

The following checks pass locally:

- `PYTHONPATH=. uv run --extra s3fs pytest tests/io/test_fsspec.py -k "s3_session_properties" -q`
- `PYTHONPATH=. uv run pytest tests/utils/test_properties.py -q`
- `uv run prek run --files pyiceberg/io/fsspec.py pyiceberg/utils/properties.py tests/io/test_fsspec.py tests/utils/test_properties.py`

## Are there any user-facing changes?

Yes. Setting `s3.force-virtual-addressing=false` for fsspec S3 FileIO no longer enables virtual-hosted-style addressing. String and native boolean values now produce consistent results, while an absent property continues to use the existing default.
