### PR TITLE
Return overflow sentinel in LongLiteral.to(FloatType)

### DIFF
--- a/pyiceberg/expressions/literals.py
+++ b/pyiceberg/expressions/literals.py
@@ -319,7 +319,7 @@ class LongLiteral(Literal[int]):
     def _(self, _: FloatType) -> Literal[float]:
         if FloatType.max < self.value:
             return FloatAboveMax()
-        elif FloatType.min > self.value:
+        elif self.value < FloatType.min:
             return FloatBelowMin()
         return FloatLiteral(float(self.value))
 

--- a/pyiceberg/expressions/literals.py
+++ b/pyiceberg/expressions/literals.py
@@ -317,6 +317,10 @@ class LongLiteral(Literal[int]):
 
     @to.register(FloatType)
     def _(self, _: FloatType) -> Literal[float]:
+        if FloatType.max < self.value:
+            return FloatAboveMax()
+        elif FloatType.min > self.value:
+            return FloatBelowMin()
         return FloatLiteral(float(self.value))
 
     @to.register(DoubleType)

--- a/tests/expressions/test_literals.py
+++ b/tests/expressions/test_literals.py
@@ -184,6 +184,16 @@ def test_long_to_float_conversion() -> None:
     assert lit.value == float_lit.value
 
 
+def test_long_to_float_outside_bound() -> None:
+    big_lit = literal(10**39)
+    above_max_lit = big_lit.to(FloatType())
+    assert above_max_lit == FloatAboveMax()
+
+    small_lit = literal(-(10**39))
+    below_min_lit = small_lit.to(FloatType())
+    assert below_min_lit == FloatBelowMin()
+
+
 def test_long_to_double_conversion() -> None:
     lit = literal(34).to(LongType())
     dbl_lit = lit.to(DoubleType())


### PR DESCRIPTION
# Rationale for this change

- Fixes #3494

## Are these changes tested?

Yes, added assertions fail if we revert this PR's change.

## Are there any user-facing changes?

Yes, users receive an overflow sentinel instead of OverflowError. 

<!-- In the case of user-facing changes, please add the changelog label. -->
