### PR TITLE
Update astral-sh/setup-uv to v8.2.0

### DIFF
--- a/.github/workflows/nightly-pypi-build.yml
+++ b/.github/workflows/nightly-pypi-build.yml
@@ -44,7 +44,7 @@ jobs:
           python-version: 3.12
 
       - name: Install UV
-        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Set version
         id: set-version

--- a/.github/workflows/pypi-build-artifacts.yml
+++ b/.github/workflows/pypi-build-artifacts.yml
@@ -54,7 +54,7 @@ jobs:
             3.14
 
       - name: Install UV
-        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Set version with RC
         shell: bash

--- a/.github/workflows/python-ci-docs.yml
+++ b/.github/workflows/python-ci-docs.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           python-version: 3.12
       - name: Install UV
-        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Build docs
         run: make docs-build
       - name: Run linters

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -62,7 +62,7 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - name: Install UV
-      uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
         enable-cache: true
     - name: Install system dependencies
@@ -88,7 +88,7 @@ jobs:
       with:
         python-version: '3.12'
     - name: Install UV
-      uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
         enable-cache: true
     - name: Install system dependencies
@@ -117,7 +117,7 @@ jobs:
       with:
         python-version: '3.12'
     - name: Install UV
-      uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
         enable-cache: true
     - name: Install system dependencies
@@ -146,7 +146,7 @@ jobs:
       with:
         python-version: '3.12'
     - name: Install UV
-      uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
         enable-cache: true
     - name: Install system dependencies
@@ -175,7 +175,7 @@ jobs:
       with:
         python-version: '3.12'
     - name: Install UV
-      uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
         enable-cache: true
     - name: Install system dependencies
@@ -205,7 +205,7 @@ jobs:
       with:
         python-version: '3.12'
     - name: Install UV
-      uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
         enable-cache: true
     - name: Install dependencies
@@ -228,7 +228,7 @@ jobs:
       with:
         python-version: '3.12'
     - name: Install UV
-      uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
         enable-cache: true
     # Why this exists:

--- a/.github/workflows/python-release-docs.yml
+++ b/.github/workflows/python-release-docs.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           python-version: 3.12
       - name: Install UV
-        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Build docs
         run: make docs-build
       - name: Copy

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -110,7 +110,7 @@ jobs:
           python-version: 3.12
 
       - name: Install UV
-        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: false
 

--- a/.github/workflows/svn-build-artifacts.yml
+++ b/.github/workflows/svn-build-artifacts.yml
@@ -54,7 +54,7 @@ jobs:
             3.14
 
       - name: Install UV
-        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       # Publish the source distribution with the version that's in
       # the repository, otherwise the tests will fail


### PR DESCRIPTION
# Rationale for this change

Fixes CI errors: https://github.com/apache/iceberg-python/actions/runs/27572961574
```
Error
The action astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 is not allowed in apache/iceberg-python
```

https://github.com/apache/infrastructure-actions/commit/40884a236319db372f0b3fccd4d50e1e14b26386 has removed `5a095e7a2014a4212f075830d4f7277575a9d098` version as the expiration date. 

`fac544c07dec837d0ccb6301d7b5580bf5edae39` is the latest version in the approved list: 
https://github.com/apache/infrastructure-actions/blob/8d7b86287d0beafc4d68a06fa23e751a04e3976d/approved_patterns.yml#L38-L42

## Are these changes tested?

N/A

## Are there any user-facing changes?

No

<!-- In the case of user-facing changes, please add the changelog label. -->
