### PR TITLE
Reject unsupported identity transform types

### DIFF
--- a/pyiceberg/transforms.py
+++ b/pyiceberg/transforms.py
@@ -719,6 +719,7 @@ class IdentityTransform(Transform[S, S]):
         return lambda v: v
 
     def can_transform(self, source: IcebergType) -> bool:
+        # TODO: disallow VariantType when PyIceberg supports it.
         return source.is_primitive and not isinstance(source, (GeographyType, GeometryType))
 
     def result_type(self, source: IcebergType) -> IcebergType:

--- a/pyiceberg/transforms.py
+++ b/pyiceberg/transforms.py
@@ -73,6 +73,8 @@ from pyiceberg.types import (
     DateType,
     DecimalType,
     FixedType,
+    GeographyType,
+    GeometryType,
     IcebergType,
     IntegerType,
     LongType,
@@ -717,7 +719,7 @@ class IdentityTransform(Transform[S, S]):
         return lambda v: v
 
     def can_transform(self, source: IcebergType) -> bool:
-        return source.is_primitive
+        return source.is_primitive and not isinstance(source, (GeographyType, GeometryType))
 
     def result_type(self, source: IcebergType) -> IcebergType:
         return source

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -258,7 +258,7 @@ def test_identity_transform_unknown_type() -> None:
 
 
 @pytest.mark.parametrize("type_var", [GeometryType(), GeographyType()])
-def test_identity_transform_unsupported_type(type_var: PrimitiveType) -> None:
+def test_identity_can_transform_unsupported_type(type_var: PrimitiveType) -> None:
     assert not IdentityTransform().can_transform(type_var)
 
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -101,6 +101,8 @@ from pyiceberg.types import (
     DoubleType,
     FixedType,
     FloatType,
+    GeographyType,
+    GeometryType,
     IntegerType,
     LongType,
     NestedField,
@@ -253,6 +255,11 @@ def test_identity_transform_unknown_type() -> None:
     assert IdentityTransform().result_type(UnknownType()) == UnknownType()
     assert IdentityTransform().transform(UnknownType())(None) is None
     assert IdentityTransform().to_human_string(UnknownType(), None) == "null"
+
+
+@pytest.mark.parametrize("type_var", [GeometryType(), GeographyType()])
+def test_identity_transform_unsupported_type(type_var: PrimitiveType) -> None:
+    assert not IdentityTransform().can_transform(type_var)
 
 
 def test_string_with_surrogate_pair() -> None:


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

# Rationale for this change

Per spec[1], the identity transform source type must be any primitive except for geometry, geography, and variant. This PR rejects GeographyType and GeometryType as source types for identity transforms.(No VariantType yet)

[1] https://iceberg.apache.org/spec/#partition-transforms

## Are these changes tested?

Yes

## Are there any user-facing changes?

No

