### PR TITLE
bug: TruncateTransform.project when length > width

### DIFF
--- a/pyiceberg/transforms.py
+++ b/pyiceberg/transforms.py
@@ -812,6 +812,10 @@ class TruncateTransform(Transform[S, S]):
             if isinstance(pred, BoundLiteralPredicate):
                 return _truncate_number(name, pred, self.transform(field_type))
         elif isinstance(field_type, (BinaryType, StringType)):
+            if isinstance(pred, BoundNotStartsWith) and len(pred.literal.value) > self.width:
+                # A prefix longer than the width can't be projected: the truncated partition
+                # holds both matching and non-matching rows, so it cannot be pruned.
+                return None
             if isinstance(pred, BoundLiteralPredicate):
                 return _truncate_array(name, pred, self.transform(field_type))
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1037,9 +1037,7 @@ def test_projection_truncate_string_not_starts_with(bound_reference_str: BoundRe
     ) == NotStartsWith(term="name", literal=literal("he"))
 
     # longer than width: can't be projected, so the partition is always read
-    assert (
-        TruncateTransform(2).project("name", BoundNotStartsWith(term=bound_reference_str, literal=literal("hello"))) is None
-    )
+    assert TruncateTransform(2).project("name", BoundNotStartsWith(term=bound_reference_str, literal=literal("hello"))) is None
 
 
 def _test_projection(lhs: UnboundPredicate | None, rhs: UnboundPredicate | None) -> None:

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1026,9 +1026,20 @@ def test_projection_truncate_string_starts_with(bound_reference_str: BoundRefere
 
 
 def test_projection_truncate_string_not_starts_with(bound_reference_str: BoundReference) -> None:
+    # shorter than width: projects to not-starts-with on the untruncated prefix
     assert TruncateTransform(2).project(
-        "name", BoundNotStartsWith(term=bound_reference_str, literal=literal("hello"))
+        "name", BoundNotStartsWith(term=bound_reference_str, literal=literal("h"))
+    ) == NotStartsWith(term="name", literal=literal("h"))
+
+    # equal to width: projects to not-starts-with on the full prefix
+    assert TruncateTransform(2).project(
+        "name", BoundNotStartsWith(term=bound_reference_str, literal=literal("he"))
     ) == NotStartsWith(term="name", literal=literal("he"))
+
+    # longer than width: can't be projected, so the partition is always read
+    assert (
+        TruncateTransform(2).project("name", BoundNotStartsWith(term=bound_reference_str, literal=literal("hello"))) is None
+    )
 
 
 def _test_projection(lhs: UnboundPredicate | None, rhs: UnboundPredicate | None) -> None:


### PR DESCRIPTION
<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
We've diverged from the Java implementation for TruncateTransform.project

In [Java](https://github.com/apache/iceberg/blob/34cd01ba2e057866cdb13db8f9919bc98e11e638/api/src/main/java/org/apache/iceberg/transforms/Truncate.java#L339-L346), we return `null` when length > width. This means that the predicate can't be projected. 

## Are these changes tested?
We had one test that was (incorrectly) passing. I've changed up the test to test the three use-cases: `length < width`, `length == width`, `length > width`. This better matches the test suite from Java.

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
