### PR TITLE
Bug Fix: Cast UINT32 to INT32 to ensure compatibility with other engines 

### DIFF
--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -1970,13 +1970,14 @@ class ArrowProjectionVisitor(SchemaWithPartnerVisitor[pa.Array, pa.Array | None]
                             return values.cast(target_type)
                     raise ValueError(f"Unsupported schema projection from {values.type} to {target_type}")
                 elif isinstance(field.field_type, (IntegerType, LongType)):
-                    # Cast smaller integer types to target type for cross-platform compatibility
-                    # Only allow widening conversions (smaller bit width to larger)
-                    # Narrowing conversions fall through to promote() handling below
+                    # Cast integer types for cross-platform compatibility (e.g. Spark reads):
+                    # widening (smaller bit width to larger) and unsigned-to-signed at same width
                     if pa.types.is_integer(values.type):
                         source_width = values.type.bit_width
                         target_width = target_type.bit_width
-                        if source_width < target_width:
+                        if source_width < target_width or (
+                            pa.types.is_unsigned_integer(values.type) and source_width <= target_width
+                        ):
                             return values.cast(target_type)
 
             if field.field_type != file_field.field_type:

--- a/tests/io/test_pyarrow.py
+++ b/tests/io/test_pyarrow.py
@@ -3084,6 +3084,7 @@ def test__to_requested_schema_timestamps_without_downcast_raises_exception(
         (pa.int8(), IntegerType(), pa.int32()),
         (pa.int16(), IntegerType(), pa.int32()),
         (pa.uint16(), IntegerType(), pa.int32()),
+        (pa.uint32(), IntegerType(), pa.int32()),
         (pa.uint32(), LongType(), pa.int64()),
         (pa.int32(), LongType(), pa.int64()),
     ],

--- a/tests/io/test_pyarrow.py
+++ b/tests/io/test_pyarrow.py
@@ -3110,6 +3110,19 @@ def test__to_requested_schema_integer_promotion(
     assert result.column(0).to_pylist() == [1, 2, 3, None]
 
 
+def test__to_requested_schema_uint32_overflow_raises() -> None:
+    """Test that uint32 values exceeding INT32_MAX raise an error rather than wrapping."""
+    requested_schema = Schema(NestedField(1, "col", IntegerType(), required=False))
+    file_schema = requested_schema
+
+    arrow_schema = pa.schema([pa.field("col", pa.uint32())])
+    data = pa.array([2**31], type=pa.uint32())
+    batch = pa.RecordBatch.from_arrays([data], schema=arrow_schema)
+
+    with pytest.raises(pa.lib.ArrowInvalid, match="Integer value .* not in range"):
+        _to_requested_schema(requested_schema, file_schema, batch, downcast_ns_timestamp_to_us=False, include_field_ids=False)
+
+
 def test_pyarrow_file_io_fs_by_scheme_cache() -> None:
     # It's better to set up multi-region minio servers for an integration test once `endpoint_url` argument
     # becomes available for `resolve_s3_region`


### PR DESCRIPTION
# Rationale for this change
* PyIceberg was preserving original Arrow types in Parquet files, causing Spark to fail with Unsupported logical type: UINT_32 
* Extends the integer casting logic in `ArrowProjectionVisitor._cast_if_needed` to handle unsigned-to-signed conversions at the same bit width. Specifically uint32 -> int32. 

## Context:
This is a follow-up to #2799 (which fixed #2791) where uint8/uint16 casting was addressed. That fix only covered widening conversions (`source_width < target_width`), which missed the uint32 case since both uint32 and int32 are 32-bit. Without this cast, Parquet files are written with the `UINT_32` physical type while Iceberg metadata declares `INT_32`, causing Spark to fail on read.

## Changes / Are these changes tested?
`pyiceberg/io/pyarrow.py`: Extended the cast condition to also trigger when the source is an unsigned integer with the same (or smaller) bit width as the signed target
`tests/io/test_pyarrow.py`: Added (`pa.uint32()`, `IntegerType()`, `pa.int32()`) test case


## Notes
* The cast uses PyArrow's default `safe=True`, so values exceeding `INT32_MAX (2^31-1)` will raise rather than silently corrupt
* Existing behavior for all other integer type combinations is unchanged
