### PR TITLE
chore: allow optional whitespace around parameters similar to other language implementations

### DIFF
--- a/pyiceberg/types.py
+++ b/pyiceberg/types.py
@@ -57,7 +57,7 @@ from pyiceberg.typedef import IcebergBaseModel, IcebergRootModel, L, TableVersio
 from pyiceberg.utils.parsing import ParseNumberFromBrackets
 from pyiceberg.utils.singleton import Singleton
 
-DECIMAL_REGEX = re.compile(r"decimal\((\d+),\s*(\d+)\)")
+DECIMAL_REGEX = re.compile(r"decimal\(\s*(\d+)\s*,\s*(\d+)\s*\)")
 FIXED = "fixed"
 FIXED_PARSER = ParseNumberFromBrackets(FIXED)
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -514,6 +514,21 @@ def test_deserialization_decimal() -> None:
     assert decimal.scale == 25
 
 
+@pytest.mark.parametrize(
+    "decimal_str",
+    [
+        "decimal(9,2)",
+        "decimal(9, 2)",
+        "decimal( 9, 2 )",
+        "decimal( 9 , 2 )",
+        "decimal(9 ,2)",
+    ],
+)
+def test_deserialization_decimal_optional_whitespace(decimal_str: str) -> None:
+    # Readers accept optional whitespace around parameters and the separator.
+    assert DecimalType.model_validate_json(f'"{decimal_str}"') == DecimalType(9, 2)
+
+
 def test_deserialization_decimal_failure() -> None:
     with pytest.raises(ValidationError) as exc_info:
         _ = DecimalType.model_validate_json('"decimal(abc, def)"')


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

Reference: https://github.com/apache/iceberg/pull/16798

# Rationale for this change

PyIceberg is a bit more strict in its parsing than the other language implementations. This allows json string representations like `decimal( 9, 2 )` like the other libraries.

## Are these changes tested?
Unit tested

## Are there any user-facing changes?
Yes, more permissive metadata parsing by PyIceberg clients.

<!-- In the case of user-facing changes, please add the changelog label. -->
