### PR TITLE
Return bounds sentinels for long date literals

### DIFF
--- a/pyiceberg/expressions/literals.py
+++ b/pyiceberg/expressions/literals.py
@@ -325,6 +325,10 @@ class LongLiteral(Literal[int]):
 
     @to.register(DateType)
     def _(self, _: DateType) -> Literal[int]:
+        if IntegerType.max < self.value:
+            return IntAboveMax()
+        elif IntegerType.min > self.value:
+            return IntBelowMin()
         return DateLiteral(self.value)
 
     @to.register(TimeType)

--- a/tests/expressions/test_expressions.py
+++ b/tests/expressions/test_expressions.py
@@ -67,6 +67,7 @@ from pyiceberg.expressions.visitors import _from_byte_buffer
 from pyiceberg.schema import Accessor, Schema
 from pyiceberg.typedef import Record
 from pyiceberg.types import (
+    DateType,
     DecimalType,
     DoubleType,
     FloatType,
@@ -1148,6 +1149,26 @@ def test_above_int_bounds_greater_than_or_equal(
 ) -> None:
     assert GreaterThanOrEqual("a", above_int_max).bind(int_schema) is AlwaysFalse()
     assert GreaterThanOrEqual("a", below_int_min).bind(int_schema) is AlwaysTrue()
+
+
+@pytest.fixture
+def date_schema() -> Schema:
+    return Schema(NestedField(field_id=1, name="a", field_type=DateType(), required=False))
+
+
+def test_above_date_bounds_equal_to(date_schema: Schema, above_int_max: Literal[int], below_int_min: Literal[int]) -> None:
+    assert EqualTo("a", above_int_max).bind(date_schema) is AlwaysFalse()
+    assert EqualTo("a", below_int_min).bind(date_schema) is AlwaysFalse()
+
+
+def test_above_date_bounds_less_than(date_schema: Schema, above_int_max: Literal[int], below_int_min: Literal[int]) -> None:
+    assert LessThan("a", above_int_max).bind(date_schema) is AlwaysTrue()
+    assert LessThan("a", below_int_min).bind(date_schema) is AlwaysFalse()
+
+
+def test_above_date_bounds_greater_than(date_schema: Schema, above_int_max: Literal[int], below_int_min: Literal[int]) -> None:
+    assert GreaterThan("a", above_int_max).bind(date_schema) is AlwaysFalse()
+    assert GreaterThan("a", below_int_min).bind(date_schema) is AlwaysTrue()
 
 
 @pytest.fixture

--- a/tests/expressions/test_literals.py
+++ b/tests/expressions/test_literals.py
@@ -160,6 +160,16 @@ def test_integer_to_date_conversion() -> None:
     assert date_lit.value == date_delta
 
 
+def test_long_to_date_outside_bound() -> None:
+    big_lit = literal(IntegerType.max + 1).to(LongType())
+    above_max_lit = big_lit.to(DateType())
+    assert above_max_lit == IntAboveMax()
+
+    small_lit = literal(IntegerType.min - 1).to(LongType())
+    below_min_lit = small_lit.to(DateType())
+    assert below_min_lit == IntBelowMin()
+
+
 def test_long_to_integer_within_bound() -> None:
     lit = literal(34).to(LongType())
     int_lit = lit.to(IntegerType())


### PR DESCRIPTION
## Rationale for this change

LongLiteral.to(DateType) was constructing DateLiteral values outside the int-backed Iceberg date range. Java returns overflow sentinels for long-to-date narrowing, and PyIceberg already uses those sentinels to simplify out-of-range predicates.

Reference: Java `LongLiteral.to(...)` handles `case DATE` by returning `aboveMax()` / `belowMin()` when the long value is outside `Integer.MAX_VALUE` / `Integer.MIN_VALUE`: https://github.com/apache/iceberg/blob/0b30919372df34afb632f037df88c05cdba0b134/api/src/main/java/org/apache/iceberg/expressions/Literals.java#L312-L318

This updates long-to-date conversion to return IntAboveMax or IntBelowMin when the literal falls outside the valid date range.

## Are these changes tested?

Yes:

- PYTHONPATH=. python -m pytest tests/expressions/test_literals.py tests/expressions/test_expressions.py
- commit hooks also ran successfully during git commit

## Are there any user-facing changes?

Yes. Out-of-range date predicates now simplify using the existing overflow sentinel behavior instead of carrying impossible DateLiteral values.