### PR TITLE
Make scan_plan_helper internal (#3541)

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -2110,7 +2110,7 @@ class DataScan(TableScan):
     def partition_filters(self) -> KeyDefaultDict[int, BooleanExpression]:
         return self._manifest_planner.partition_filters
 
-    def scan_plan_helper(self) -> Iterator[list[ManifestEntry]]:
+    def _scan_plan_helper(self) -> Iterator[list[ManifestEntry]]:
         """Filter and return manifest entries based on partition and metrics evaluators.
 
         Returns:

--- a/pyiceberg/table/inspect.py
+++ b/pyiceberg/table/inspect.py
@@ -311,7 +311,7 @@ class InspectTable:
 
         partitions_map: dict[tuple[str, Any], Any] = {}
 
-        for entry in itertools.chain.from_iterable(scan.scan_plan_helper()):
+        for entry in itertools.chain.from_iterable(scan._scan_plan_helper()):
             partition = entry.data_file.partition
             partition_record_dict = {
                 field.name: partition[pos] for pos, field in enumerate(self.tbl.metadata.specs()[entry.data_file.spec_id].fields)


### PR DESCRIPTION
scan_plan_helper is an internal helper for local scan planning, not a public extension point. Rename it to _scan_plan_helper to reflect its intended visibility and update its only caller in inspect.py.

The method was introduced recently in d99936a and has not been part of any released public API, so no deprecation shim is required.
Fixes: #3541

<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

## Are these changes tested?

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
