### PR TITLE
Add test for UpdateStatistics chaining set and remove

### DIFF
--- a/tests/table/test_init.py
+++ b/tests/table/test_init.py
@@ -1688,7 +1688,7 @@ def test_remove_partition_statistics_update_with_invalid_snapshot_id(table_v2_wi
             table_v2_with_statistics.metadata,
             (RemovePartitionStatisticsUpdate(snapshot_id=123456789),),
         )
-
+@pytest.mark.xfail(reason="remove_statistics uses = instead of +=, dropping preceeding updates")
 def test_update_statistics_set_remove_chain(tmp_path: Path) -> None:
 
    catalog = InMemoryCatalog("test",warehouse = f"file://{tmp_path}")

--- a/tests/table/test_init.py
+++ b/tests/table/test_init.py
@@ -18,12 +18,14 @@
 import json
 import uuid
 from copy import copy
+from pathlib import Path
 from typing import Any
 
 import pytest
 from pydantic import BaseModel, ValidationError
 from pytest_lazy_fixtures import lf
 
+from pyiceberg.catalog.memory import InMemoryCatalog
 from pyiceberg.catalog.noop import NoopCatalog
 from pyiceberg.exceptions import CommitFailedException
 from pyiceberg.expressions import (
@@ -1536,7 +1538,6 @@ def test_set_statistics_update(table_v2_with_statistics: Table) -> None:
     assert len(updated_statistics) == 1
     assert json.loads(updated_statistics[0].model_dump_json()) == json.loads(expected)
 
-
 def test_set_statistics_update_handles_deprecated_snapshot_id(table_v2_with_statistics: Table) -> None:
     snapshot_id = table_v2_with_statistics.metadata.current_snapshot_id
 
@@ -1586,7 +1587,6 @@ def test_set_statistics_update_handles_deprecated_snapshot_id(table_v2_with_stat
     update_with_json = SetStatisticsUpdate.model_validate_json(update_json)
     assert model_roundtrips(update_with_json)
     assert update_with_json.snapshot_id == snapshot_id
-
 
 def test_remove_statistics_update(table_v2_with_statistics: Table) -> None:
     update = RemoveStatisticsUpdate(
@@ -1688,6 +1688,49 @@ def test_remove_partition_statistics_update_with_invalid_snapshot_id(table_v2_wi
             table_v2_with_statistics.metadata,
             (RemovePartitionStatisticsUpdate(snapshot_id=123456789),),
         )
+
+def test_update_statistics_set_remove_chain(tmp_path: Path) -> None:
+
+   catalog = InMemoryCatalog("test",warehouse = f"file://{tmp_path}")
+   catalog.create_namespace("default")
+   table = catalog.create_table("default.test",schema = Schema(NestedField(1,"x", LongType())))
+
+   snapshot_id_1 = 1111111111
+   snapshot_id_2 = 2222222222
+
+   statistics_file_1 = StatisticsFile(
+       snapshot_id=snapshot_id_1,
+       statistics_path="s3://bucket/warehouse/stats1.puffin",
+       file_size_in_bytes=124,
+       file_footer_size_in_bytes=27,
+       blob_metadata=[BlobMetadata(
+           type="apache-datasketches-theta-v1",
+           snapshot_id=snapshot_id_1,
+           sequence_number=1,
+           fields=[1],
+       )],
+   )
+
+   statistics_file_2 = StatisticsFile(
+       snapshot_id=snapshot_id_2,
+       statistics_path="s3://bucket/warehouse/stats2.puffin",
+       file_size_in_bytes=124,
+       file_footer_size_in_bytes=27,
+       blob_metadata=[BlobMetadata(
+           type="apache-datasketches-theta-v1",
+           snapshot_id=snapshot_id_2,
+           sequence_number=2,
+           fields=[1],
+       )],
+   )
+
+   with table.update_statistics() as update:
+       update.set_statistics(statistics_file_1)
+
+   with table.update_statistics() as update:
+       update.set_statistics(statistics_file_2).remove_statistics(snapshot_id_1)
+
+   assert len(table.metadata.statistics) == 1
 
 
 def test_add_snapshot_update_fails_without_first_row_id(table_v3: Table) -> None:

--- a/tests/table/test_init.py
+++ b/tests/table/test_init.py
@@ -1538,6 +1538,7 @@ def test_set_statistics_update(table_v2_with_statistics: Table) -> None:
     assert len(updated_statistics) == 1
     assert json.loads(updated_statistics[0].model_dump_json()) == json.loads(expected)
 
+
 def test_set_statistics_update_handles_deprecated_snapshot_id(table_v2_with_statistics: Table) -> None:
     snapshot_id = table_v2_with_statistics.metadata.current_snapshot_id
 
@@ -1587,6 +1588,7 @@ def test_set_statistics_update_handles_deprecated_snapshot_id(table_v2_with_stat
     update_with_json = SetStatisticsUpdate.model_validate_json(update_json)
     assert model_roundtrips(update_with_json)
     assert update_with_json.snapshot_id == snapshot_id
+
 
 def test_remove_statistics_update(table_v2_with_statistics: Table) -> None:
     update = RemoveStatisticsUpdate(
@@ -1688,49 +1690,54 @@ def test_remove_partition_statistics_update_with_invalid_snapshot_id(table_v2_wi
             table_v2_with_statistics.metadata,
             (RemovePartitionStatisticsUpdate(snapshot_id=123456789),),
         )
-@pytest.mark.xfail(reason="remove_statistics uses = instead of +=, dropping preceeding updates")
+
+
+@pytest.mark.xfail(reason="remove_statistics uses = instead of +=, dropping preceding updates")
 def test_update_statistics_set_remove_chain(tmp_path: Path) -> None:
+    catalog = InMemoryCatalog("test", warehouse=f"file://{tmp_path}")
+    catalog.create_namespace("default")
+    table = catalog.create_table("default.test", schema=Schema(NestedField(1, "x", LongType())))
 
-   catalog = InMemoryCatalog("test",warehouse = f"file://{tmp_path}")
-   catalog.create_namespace("default")
-   table = catalog.create_table("default.test",schema = Schema(NestedField(1,"x", LongType())))
+    snapshot_id_1 = 1111111111
+    snapshot_id_2 = 2222222222
 
-   snapshot_id_1 = 1111111111
-   snapshot_id_2 = 2222222222
+    statistics_file_1 = StatisticsFile(
+        snapshot_id=snapshot_id_1,
+        statistics_path="s3://bucket/warehouse/stats1.puffin",
+        file_size_in_bytes=124,
+        file_footer_size_in_bytes=27,
+        blob_metadata=[
+            BlobMetadata(
+                type="apache-datasketches-theta-v1",
+                snapshot_id=snapshot_id_1,
+                sequence_number=1,
+                fields=[1],
+            )
+        ],
+    )
 
-   statistics_file_1 = StatisticsFile(
-       snapshot_id=snapshot_id_1,
-       statistics_path="s3://bucket/warehouse/stats1.puffin",
-       file_size_in_bytes=124,
-       file_footer_size_in_bytes=27,
-       blob_metadata=[BlobMetadata(
-           type="apache-datasketches-theta-v1",
-           snapshot_id=snapshot_id_1,
-           sequence_number=1,
-           fields=[1],
-       )],
-   )
+    statistics_file_2 = StatisticsFile(
+        snapshot_id=snapshot_id_2,
+        statistics_path="s3://bucket/warehouse/stats2.puffin",
+        file_size_in_bytes=124,
+        file_footer_size_in_bytes=27,
+        blob_metadata=[
+            BlobMetadata(
+                type="apache-datasketches-theta-v1",
+                snapshot_id=snapshot_id_2,
+                sequence_number=2,
+                fields=[1],
+            )
+        ],
+    )
 
-   statistics_file_2 = StatisticsFile(
-       snapshot_id=snapshot_id_2,
-       statistics_path="s3://bucket/warehouse/stats2.puffin",
-       file_size_in_bytes=124,
-       file_footer_size_in_bytes=27,
-       blob_metadata=[BlobMetadata(
-           type="apache-datasketches-theta-v1",
-           snapshot_id=snapshot_id_2,
-           sequence_number=2,
-           fields=[1],
-       )],
-   )
+    with table.update_statistics() as update:
+        update.set_statistics(statistics_file_1)
 
-   with table.update_statistics() as update:
-       update.set_statistics(statistics_file_1)
+    with table.update_statistics() as update:
+        update.set_statistics(statistics_file_2).remove_statistics(snapshot_id_1)
 
-   with table.update_statistics() as update:
-       update.set_statistics(statistics_file_2).remove_statistics(snapshot_id_1)
-
-   assert len(table.metadata.statistics) == 1
+    assert len(table.metadata.statistics) == 1
 
 
 def test_add_snapshot_update_fails_without_first_row_id(table_v3: Table) -> None:


### PR DESCRIPTION
## Context

The intention of this PR is to shed light on a potential issue.
It is meant as an inquiry to understand what the maintainers feel about this scenario.
This is perhaps an edge case, so feel free to prioritise it in accordance.

## Observation

When executing `update_statistics` on a table, there are two methods which can be chained by design: `set_statistics` and `remove_statistics`.

`set_statistics` appends to `_updates` using `+=` (line 56).
`remove_statistics` replaces `_updates` using `=` (line 65).

When chaining both, `remove_statistics` drops all preceding `set_statistics` calls. This may lead to the query engine scanning more data in the absence of the required statistics files.

See `pyiceberg/table/update/statistics.py`, lines 56 and 65.

## AI Use Disclaimer

I used claude code to understand test coverage and discover improvement opportunities. I used
claude code to verify that the test adds value and is not going to be a waste of time for the reviwers. I did not use claude code to write any code, commit messages or descriptions, all writing, including this, is my own.