### PR TITLE
feat: support Time64Type[ns] via downcast to microseconds (#1169)

### DIFF
--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -1449,8 +1449,19 @@ class _ConvertToIceberg(PyArrowSchemaVisitor[IcebergType | Schema]):
             return StringType()
         elif pa.types.is_date32(primitive):
             return DateType()
-        elif isinstance(primitive, pa.Time64Type) and primitive.unit == "us":
-            return TimeType()
+        elif isinstance(primitive, pa.Time64Type):
+            if primitive.unit == "us":
+                return TimeType()
+            elif primitive.unit == "ns":
+                if self._downcast_ns_timestamp_to_us:
+                    logger.warning("Iceberg does not yet support 'ns' time precision. Downcasting to 'us'.")
+                    return TimeType()
+                else:
+                    raise TypeError(
+                        "Iceberg does not yet support 'ns' time precision. "
+                        "Use 'downcast-ns-timestamp-to-us-on-write' configuration property to automatically "
+                        "downcast 'ns' to 'us' on write.",
+                    )
         elif pa.types.is_timestamp(primitive):
             primitive = cast(pa.TimestampType, primitive)
             if primitive.unit in ("s", "ms", "us"):
@@ -1968,6 +1979,12 @@ class ArrowProjectionVisitor(SchemaWithPartnerVisitor[pa.Array, pa.Array | None]
                             return values.cast(target_type, safe=False)
                         elif target_type.unit == "us" and values.type.unit in {"s", "ms", "us"}:
                             return values.cast(target_type)
+                    raise ValueError(f"Unsupported schema projection from {values.type} to {target_type}")
+                elif field.field_type == TimeType():
+                    if pa.types.is_time(target_type) and pa.types.is_time(values.type):
+                        # Downcasting of nanoseconds to microseconds
+                        if target_type.unit == "us" and values.type.unit == "ns" and self._downcast_ns_timestamp_to_us:
+                            return values.cast(target_type, safe=False)
                     raise ValueError(f"Unsupported schema projection from {values.type} to {target_type}")
                 elif isinstance(field.field_type, (IntegerType, LongType)):
                     # Cast smaller integer types to target type for cross-platform compatibility

--- a/tests/io/test_pyarrow.py
+++ b/tests/io/test_pyarrow.py
@@ -21,7 +21,7 @@ import tempfile
 import uuid
 import warnings
 from collections.abc import Iterator
-from datetime import date, datetime, timezone
+from datetime import date, datetime, time, timezone
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -3075,6 +3075,35 @@ def test__to_requested_schema_timestamps_without_downcast_raises_exception(
         _to_requested_schema(requested_schema, file_schema, batch, downcast_ns_timestamp_to_us=False, include_field_ids=False)
 
     assert "Unsupported schema projection from timestamp[ns] to timestamp[us]" in str(exc_info.value)
+
+
+def test__to_requested_schema_time_ns_downcast() -> None:
+    """Test that a time64[ns] column is downcast to time64[us] on write when the flag is set."""
+    requested_schema = Schema(NestedField(1, "time_field", TimeType(), required=False))
+    file_schema = requested_schema
+
+    arrow_schema = pa.schema([pa.field("time_field", pa.time64("ns"))])
+    data = pa.array([time(12, 0, 0, 1), None], type=pa.time64("ns"))
+    batch = pa.RecordBatch.from_arrays([data], schema=arrow_schema)
+
+    result = _to_requested_schema(requested_schema, file_schema, batch, downcast_ns_timestamp_to_us=True, include_field_ids=False)
+
+    assert result.schema[0].type == pa.time64("us")
+    assert result.column(0).to_pylist() == [time(12, 0, 0, 1), None]
+
+
+def test__to_requested_schema_time_ns_without_downcast_raises_exception() -> None:
+    requested_schema = Schema(NestedField(1, "time_field", TimeType(), required=False))
+    file_schema = requested_schema
+
+    arrow_schema = pa.schema([pa.field("time_field", pa.time64("ns"))])
+    data = pa.array([time(12, 0, 0, 1), None], type=pa.time64("ns"))
+    batch = pa.RecordBatch.from_arrays([data], schema=arrow_schema)
+
+    with pytest.raises(ValueError) as exc_info:
+        _to_requested_schema(requested_schema, file_schema, batch, downcast_ns_timestamp_to_us=False, include_field_ids=False)
+
+    assert "Unsupported schema projection from time64[ns] to time64[us]" in str(exc_info.value)
 
 
 @pytest.mark.parametrize(

--- a/tests/io/test_pyarrow_visitor.py
+++ b/tests/io/test_pyarrow_visitor.py
@@ -173,8 +173,22 @@ def test_pyarrow_time64_us_to_iceberg() -> None:
 
 def test_pyarrow_time64_ns_to_iceberg() -> None:
     pyarrow_type = pa.time64("ns")
-    with pytest.raises(TypeError, match=re.escape("Unsupported type: time64[ns]")):
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "Iceberg does not yet support 'ns' time precision. Use 'downcast-ns-timestamp-to-us-on-write' "
+            "configuration property to automatically downcast 'ns' to 'us' on write."
+        ),
+    ):
         visit_pyarrow(pyarrow_type, _ConvertToIceberg())
+
+
+def test_pyarrow_time64_ns_to_iceberg_downcast() -> None:
+    pyarrow_type = pa.time64("ns")
+    converted_iceberg_type = visit_pyarrow(pyarrow_type, _ConvertToIceberg(downcast_ns_timestamp_to_us=True))
+    assert converted_iceberg_type == TimeType()
+    # 'ns' time is downcast to 'us' precision
+    assert visit(converted_iceberg_type, _ConvertToArrowSchema()) == pa.time64("us")
 
 
 @pytest.mark.parametrize("precision", ["s", "ms", "us", "ns"])


### PR DESCRIPTION
<!-- Closes #1169 -->
Closes #1169

# Rationale for this change

PyArrow `pa.time64("ns")` was unsupported on write and raised
`Unsupported type: time64[ns]`, even though Iceberg's `time` type is microsecond
precision by spec. This forced users to manually downcast a `time64[ns]` column
before they could write it, while the analogous `timestamp[ns]` case has been
handled by an opt-in downcast since #848.

This change mirrors that existing `ns -> us` timestamp behavior for `time`, gated on
the same `downcast-ns-timestamp-to-us-on-write` configuration property:

- `pyiceberg/io/pyarrow.py`, `_ConvertToIceberg.primitive`: a `time64[ns]` PyArrow
  type now maps to Iceberg `TimeType()` (with a warning) when
  `downcast-ns-timestamp-to-us-on-write` is set, and otherwise raises a `TypeError`
  pointing the user at that property. `time64[us]` keeps working unchanged.
- `pyiceberg/io/pyarrow.py`, `ArrowProjectionVisitor._cast_if_needed`: a new
  `TimeType` branch casts a `time64[ns]` array to `time64[us]` (`safe=False`) on write
  when the flag is set, so the data, not just the schema mapping, is actually
  downcast. This is guarded by the existing `target_type != values.type` check, so the
  supported `us -> us` path is untouched.

This matches the acceptance criteria left by @kevinjqliu on the earlier (stale-closed)
PR #1215, and the implementation pattern referenced there (the timestamp downcast from
#848).

**One point for reviewers:** this reuses the timestamp-named flag
`downcast-ns-timestamp-to-us-on-write` for `time` as well, which is what the issue
asks for and is consistent with prior maintainer guidance. If you'd prefer a dedicated
flag for the `time` type, I'm happy to change it.

**Note on prior work / assignment:** this issue has a long history of attempts
(#1188, #1206, #1215) that were all auto-closed by the stale bot for inactivity rather
than on merit, and there is no open PR for it today. It is still assigned to
@zaryab-ali from the original 2024 attempt, and @jaimeferj later offered to revive it.
I picked it up because it has been inactive for a long time and users are still asking
for it; happy to defer or coordinate if either of you is still working on it.

## Are these changes tested?

Yes, with unit tests (no Docker/Spark required):

- `tests/io/test_pyarrow_visitor.py`
  - `test_pyarrow_time64_us_to_iceberg` - `us` still maps to `TimeType()` (unchanged).
  - `test_pyarrow_time64_ns_to_iceberg` - updated: without the flag, `ns` now raises a
    `TypeError` with the new `downcast-ns-timestamp-to-us-on-write` guidance message.
  - `test_pyarrow_time64_ns_to_iceberg_downcast` (new) - with the flag, `ns` maps to
    `TimeType()` and round-trips back to `pa.time64("us")`.
- `tests/io/test_pyarrow.py`
  - `test__to_requested_schema_time_ns_downcast` (new) - a `time64[ns]` column is cast
    to `time64[us]` on write with the flag, values preserved.
  - `test__to_requested_schema_time_ns_without_downcast_raises_exception` (new) -
    without the flag, the projection raises
    `Unsupported schema projection from time64[ns] to time64[us]`.

All five pass; `make lint` (ruff, ruff-format, mypy, license headers, `uv-lock`) is
green and no dependencies / `uv.lock` change. I also verified end-to-end against a
local `SqlCatalog` (sqlite metadata + local-FS warehouse): with
`PYICEBERG_DOWNCAST_NS_TIMESTAMP_TO_US_ON_WRITE=true`, creating, appending, and
scanning a table with a `time64[ns]` column writes and reads it back as `time64[us]`
with values intact; without the flag, the write fails with a clear error citing the
config property.

The Docker/Spark integration suite was not run in my environment; the behavior is
covered by the unit and `SqlCatalog` tests above.

## Are there any user-facing changes?

Yes. Writing a PyArrow table with a `time64[ns]` column no longer hard-fails:

- With `downcast-ns-timestamp-to-us-on-write` set, the column is downcast to Iceberg
  `time` (microseconds), consistent with how `timestamp[ns]` is already handled.
- Without it, the error message now explains how to enable the downcast instead of
  just reporting an unsupported type.
