### PR TITLE
Rename _scan_plan_helper method to _plan_manifest_entries

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -2224,7 +2224,7 @@ class DataScan(TableScan):
     def partition_filters(self) -> KeyDefaultDict[int, BooleanExpression]:
         return self._manifest_planner.partition_filters
 
-    def _scan_plan_helper(self) -> Iterator[list[ManifestEntry]]:
+    def _plan_manifest_entries(self) -> Iterator[list[ManifestEntry]]:
         """Filter and return manifest entries based on partition and metrics evaluators.
 
         Returns:

--- a/pyiceberg/table/inspect.py
+++ b/pyiceberg/table/inspect.py
@@ -311,7 +311,7 @@ class InspectTable:
 
         partitions_map: dict[tuple[str, Any], Any] = {}
 
-        for entry in itertools.chain.from_iterable(scan._scan_plan_helper()):
+        for entry in itertools.chain.from_iterable(scan._plan_manifest_entries()):
             partition = entry.data_file.partition
             partition_record_dict = {
                 field.name: partition[pos] for pos, field in enumerate(self.tbl.metadata.specs()[entry.data_file.spec_id].fields)


### PR DESCRIPTION
# Rationale for this change

The method name should describe what it does. 

- Follow-up of https://github.com/apache/iceberg-python/pull/3553

## Are these changes tested?

Yes

## Are there any user-facing changes?

No, this is an internal method.