### PR TITLE
Infra: Set timeout for jobs in python-ci.yml

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -48,6 +48,7 @@ concurrency:
 jobs:
   lint-and-unit-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       max-parallel: 15
       fail-fast: true
@@ -80,6 +81,7 @@ jobs:
 
   integration-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
@@ -109,6 +111,7 @@ jobs:
 
   integration-test-s3:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
@@ -138,6 +141,7 @@ jobs:
 
   integration-test-adls:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
@@ -167,6 +171,7 @@ jobs:
 
   integration-test-gcs:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:


### PR DESCRIPTION
# Rationale for this change

I suggest setting a timeout for CI to allow us to identify unexpected slowdown:
* #3580

Each job takes about:
* lint-and-unit-test: 3~5 minutes
* integration-test: ~12 minutes
* integration-test-s3, integration-test-adls, integration-test-gcs: 1 minute

## Are these changes tested?

Yes

## Are there any user-facing changes?

No