### PR TITLE
Build: Bump gcsfs to 2026.6.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,12 @@ test-adls: ## Run tests marked with @pytest.mark.adls
 
 test-gcs: ## Run tests marked with @pytest.mark.gcs
 	sh ./dev/run-gcs-server.sh
-	$(TEST_RUNNER) pytest tests/ -m gcs $(PYTEST_ARGS)
+	# gcsfs 2026.6.0 sends HNS/Zonal bucket detection to endpoint_url.
+	# fake-gcs-server does not support that API, so repeated detection retries
+	# make GCS sanity tests take close to an hour. Disable it here.
+	# Workaround documented by gcsfs:
+	# https://github.com/fsspec/gcsfs/blob/2026.6.0/docs/source/hns_buckets.rst#L99-L101
+	GCSFS_EXPERIMENTAL_ZB_HNS_SUPPORT=false $(TEST_RUNNER) pytest tests/ -m gcs $(PYTEST_ARGS)
 
 test-coverage: ## Run all tests with coverage and report
 	$(MAKE) COVERAGE=1 test test-integration test-s3 test-adls test-gcs

--- a/uv.lock
+++ b/uv.lock
@@ -1645,7 +1645,7 @@ wheels = [
 
 [[package]]
 name = "gcsfs"
-version = "2026.5.0"
+version = "2026.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1657,9 +1657,9 @@ dependencies = [
     { name = "google-cloud-storage-control" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/da/915029bc34b541c5ac3e6ba8b32ca14d278cd17588bbbb6e4b297a944cd9/gcsfs-2026.5.0.tar.gz", hash = "sha256:283941a7a53bdbfed2133f6b471c640e61c0a1379eb52280a26618b83acc49c0", size = 922614, upload-time = "2026-05-07T15:15:51.484Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/ad/36777b2030b96d32f5c557606ac11bf5d0e152620fc15055bd1e30194037/gcsfs-2026.6.0.tar.gz", hash = "sha256:bfb1f912b3f51006b00bcd5fcef915214cb51f8b892a3974178430a55990ba3f", size = 1007987, upload-time = "2026-06-18T03:16:08.99Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/da/7bed8e864afbb8f1870f8120dc4148ecec5480ba988d4241769a2b308a35/gcsfs-2026.5.0-py3-none-any.whl", hash = "sha256:a6abf1e6ee4b8ad7e0f137ca423c2f1441610ac98c3b933e11c505f8c62a90a9", size = 77744, upload-time = "2026-05-07T15:15:50.01Z" },
+    { url = "https://files.pythonhosted.org/packages/69/43/a0096d96d3271640bbda056b9d22249be141a54509859b99002ee6149a01/gcsfs-2026.6.0-py3-none-any.whl", hash = "sha256:4a81fe40fbdef450aeaacb534b42c04059f8f3b080e3e169137247a5bb023464", size = 89629, upload-time = "2026-06-18T03:16:07.407Z" },
 ]
 
 [[package]]
@@ -1845,7 +1845,7 @@ wheels = [
 
 [[package]]
 name = "google-cloud-storage"
-version = "3.9.0"
+version = "3.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core" },
@@ -1855,9 +1855,9 @@ dependencies = [
     { name = "google-resumable-media" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/b1/4f0798e88285b50dfc60ed3a7de071def538b358db2da468c2e0deecbb40/google_cloud_storage-3.9.0.tar.gz", hash = "sha256:f2d8ca7db2f652be757e92573b2196e10fbc09649b5c016f8b422ad593c641cc", size = 17298544, upload-time = "2026-02-02T13:36:34.119Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/72/86f94e1639a8bcd9d33e8e01b49afcaa1c3a13bda7683c681717e0901e15/google_cloud_storage-3.12.0.tar.gz", hash = "sha256:03ae9847c6babb368f35f054126b8a08cbc0e3266efb990eb17b9926a45cf3be", size = 17338620, upload-time = "2026-06-12T18:03:29.215Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/0b/816a6ae3c9fd096937d2e5f9670558908811d57d59ddf69dd4b83b326fd1/google_cloud_storage-3.9.0-py3-none-any.whl", hash = "sha256:2dce75a9e8b3387078cbbdad44757d410ecdb916101f8ba308abf202b6968066", size = 321324, upload-time = "2026-02-02T13:36:32.271Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bd/a89eaebd2f9db5f92ddcc8e4f23c266be1dbd11058bb83451d8dd029f34c/google_cloud_storage-3.12.0-py3-none-any.whl", hash = "sha256:3880773754ddf7c27567b04e2a4d193950b6b99429f37b9097d873686e95b09c", size = 340605, upload-time = "2026-06-12T18:03:12.677Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Re-apply the `gcsfs` 2026.6.0 bump from #3560, which was reverted in #3580 after `integration-test-gcs` became very slow.
- Keep fake-GCS sanity tests fast by disabling gcsfs HNS/Zonal bucket detection for `test-gcs`.

## Context
- #3560 bumped `gcsfs` from 2026.5.0 to 2026.6.0, updating `google-cloud-storage` to 3.12.0.
- #3580 reverted that bump because `integration-test-gcs` took about 54 minutes instead of about 1 minute.
- This PR keeps the dependency bump and adds the documented gcsfs workaround for fake-gcs-server.

## CI Timing
- Current PR #3582 `integration-test-gcs`: [1m19s total, 39s in the GCS test step](https://github.com/apache/iceberg-python/actions/runs/28351942304/job/83986464548?pr=3582).
- Previous #3560 `integration-test-gcs`: [54m45s total, 54m00s in the GCS test step](https://github.com/apache/iceberg-python/actions/runs/28267846530/job/83758623520).

## Testing
- `env UV_CACHE_DIR=.cache/uv uv lock --check`
- `make -n test-gcs`
- `env UV_CACHE_DIR=.cache/uv uv sync --all-extras --locked`
- Verified `GCSFS_EXPERIMENTAL_ZB_HNS_SUPPORT=false` imports `gcsfs` 2026.6.0 with `gcsfs.core.GCSFileSystem`