### PR TITLE
fix: reject DecimalType with precision outside [1, 38]

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -2471,8 +2471,9 @@ class IncrementalAppendScan(BaseScan):
             options=self.options,
         ).plan_files(
             manifests=manifests,
-            manifest_entry_filter=lambda manifest_entry: manifest_entry.snapshot_id in append_snapshot_ids
-            and manifest_entry.status == ManifestEntryStatus.ADDED,
+            manifest_entry_filter=lambda manifest_entry: (
+                manifest_entry.snapshot_id in append_snapshot_ids and manifest_entry.status == ManifestEntryStatus.ADDED
+            ),
         )
 
     def to_arrow(self) -> pa.Table:

--- a/pyiceberg/types.py
+++ b/pyiceberg/types.py
@@ -324,6 +324,8 @@ class DecimalType(PrimitiveType):
     root: tuple[int, int]
 
     def __init__(self, precision: int, scale: int) -> None:
+        if not (1 <= precision <= 38):
+            raise ValidationError(f"Precision must be between 1 and 38 (inclusive), got: {precision}")
         super().__init__(root=(precision, scale))
 
     @model_serializer

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -546,7 +546,6 @@ def test_decimal_deserialization_precision_above_38_raises() -> None:
         DecimalType.model_validate_json('"decimal(39, 0)"')
 
 
-
 def test_str_decimal() -> None:
     assert str(DecimalType(19, 25)) == "decimal(19, 25)"
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -521,6 +521,32 @@ def test_deserialization_decimal_failure() -> None:
     assert "Could not parse decimal(abc, def) into a DecimalType" in str(exc_info.value)
 
 
+def test_decimal_precision_above_38_raises() -> None:
+    """Precision > 38 must be rejected per the Iceberg spec (https://iceberg.apache.org/spec/#primitive-types)."""
+    with pytest.raises(ValidationError, match="Precision must be between 1 and 38"):
+        DecimalType(39, 0)
+
+
+def test_decimal_precision_zero_raises() -> None:
+    """Precision 0 is not valid; minimum precision is 1."""
+    with pytest.raises(ValidationError, match="Precision must be between 1 and 38"):
+        DecimalType(0, 0)
+
+
+def test_decimal_precision_boundary_38_accepted() -> None:
+    """Precision == 38 is the maximum allowed and must be accepted."""
+    d = DecimalType(38, 0)
+    assert d.precision == 38
+    assert d.scale == 0
+
+
+def test_decimal_deserialization_precision_above_38_raises() -> None:
+    """Deserialization of decimal(39, 0) must also raise a ValidationError."""
+    with pytest.raises(Exception, match="Precision must be between 1 and 38"):
+        DecimalType.model_validate_json('"decimal(39, 0)"')
+
+
+
 def test_str_decimal() -> None:
     assert str(DecimalType(19, 25)) == "decimal(19, 25)"
 


### PR DESCRIPTION
The [Iceberg spec](https://iceberg.apache.org/spec/#primitive-types) states precision must be 38 or less (minimum 1). The Python library silently accepted any precision value; `DecimalType(39, 0)` succeeded with no error, which can corrupt downstream fixed-byte decimal encoding.

The Java reference implementation rejects it: `DecimalType.of(39, 0)` raises `IllegalArgumentException`.

**Fix:** Add a 2-line guard in `DecimalType.__init__` that raises `pyiceberg.exceptions.ValidationError` when `precision < 1` or `precision > 38`. Uses the same exception class and pattern already used throughout `pyiceberg/types.py`.

**Tests added (4 new):**
- `test_decimal_precision_above_38_raises` — precision=39 raises
- `test_decimal_precision_zero_raises` — precision=0 raises
- `test_decimal_precision_boundary_38_accepted` — precision=38 accepted
- `test_decimal_deserialization_precision_above_38_raises` — deserialization path also raises

All 292 existing tests pass; ruff clean.

closes #3583