### PR TITLE
fix: raise ValidationError for decimal precision outside 1-38 range

### DIFF
--- a/pyiceberg/types.py
+++ b/pyiceberg/types.py
@@ -327,13 +327,11 @@ class DecimalType(PrimitiveType):
         super().__init__(root=(precision, scale))
 
     @model_validator(mode="after")
-    def check_precision(self) -> "DecimalType":
+    def check_precision(self) -> DecimalType:
         precision = getattr(self, "precision", None) or self.root[0]
-        
+
         if not (1 <= precision <= 38):
-            raise ValidationError(
-                f"Decimal precision must be between 1 and 38 (inclusive), got: {precision}"
-            )
+            raise ValidationError(f"Decimal precision must be between 1 and 38 (inclusive), got: {precision}")
         return self
 
     @model_serializer

--- a/pyiceberg/types.py
+++ b/pyiceberg/types.py
@@ -324,10 +324,17 @@ class DecimalType(PrimitiveType):
     root: tuple[int, int]
 
     def __init__(self, precision: int, scale: int) -> None:
-        if precision < 1 or precision > 38:
-            raise ValidationError(f"Decimal precision must be between 1 and 38: {precision}")
-
         super().__init__(root=(precision, scale))
+
+    @model_validator(mode="after")
+    def check_precision(self) -> "DecimalType":
+        precision = getattr(self, "precision", None) or self.root[0]
+        
+        if not (1 <= precision <= 38):
+            raise ValidationError(
+                f"Decimal precision must be between 1 and 38 (inclusive), got: {precision}"
+            )
+        return self
 
     @model_serializer
     def ser_model(self) -> str:

--- a/pyiceberg/types.py
+++ b/pyiceberg/types.py
@@ -324,6 +324,9 @@ class DecimalType(PrimitiveType):
     root: tuple[int, int]
 
     def __init__(self, precision: int, scale: int) -> None:
+        if precision < 1 or precision > 38:
+            raise ValidationError(f"Decimal precision must be between 1 and 38: {precision}")
+
         super().__init__(root=(precision, scale))
 
     @model_serializer

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -67,7 +67,7 @@ TEST_PRIMITIVE_TYPES = [
     FloatType(),
     DoubleType(),
     DecimalType(10, 2),
-    DecimalType(100, 2),
+    DecimalType(38, 2),
     StringType(),
     DateType(),
     TimeType(),

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -920,3 +920,17 @@ def test_nested_field_geography_with_params_as_string() -> None:
     assert isinstance(field.field_type, GeographyType)
     assert field.field_type.crs == "EPSG:4326"
     assert field.field_type.algorithm == "planar"
+
+def test_decimal_precision_validation() -> None:
+    """Test that DecimalType rejects precision outside the [1, 38] range."""
+    decimal_type = DecimalType(38, 2)
+    assert decimal_type.precision == 38
+
+    with pytest.raises(ValidationError, match="Decimal precision must be between 1 and 38"):
+        DecimalType(39, 2)
+
+    with pytest.raises(ValidationError, match="Decimal precision must be between 1 and 38"):
+        DecimalType(0, 2)
+
+    with pytest.raises(ValidationError, match="Decimal precision must be between 1 and 38"):
+        DecimalType(-5, 2)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -921,6 +921,7 @@ def test_nested_field_geography_with_params_as_string() -> None:
     assert field.field_type.crs == "EPSG:4326"
     assert field.field_type.algorithm == "planar"
 
+
 def test_decimal_precision_validation() -> None:
     """Test that DecimalType rejects precision outside the [1, 38] range."""
     decimal_type = DecimalType(38, 2)


### PR DESCRIPTION
Closes #3583

# Rationale for this change
According to the Iceberg specification, decimal precision must be between 1 and 38. Previously, `pyiceberg` silently accepted invalid values (such as `precision=39` or `0`), which could lead to data corruption or crashes downstream when encoding/decoding fixed-byte decimals (matching the Java implementation's `IllegalArgumentException`).

This PR adds a defensive validation guard into `DecimalType.__init__` to raise a `ValidationError` when the precision is out of bounds `[1, 38]`.

Additionally, fixed an existing invalid type definition (`DecimalType(100, 2)`) inside `tests/test_schema.py` which was violating the specification bounds and causing the new validation guard to trip during the integration test suite.

## Are these changes tested?
Yes, added dedicated unit tests in `tests/test_types.py`:
- `test_decimal_precision_validation` covers upper bounds (`precision=39`), lower bounds (`precision=0`, `precision=-5`), and ensures valid boundary values (`precision=38`) work perfectly.

Also updated existing test assertions in `tests/test_schema.py` to use a compliant precision value (`38`).

## Are there any user-facing changes?
Yes, creating a `DecimalType` with an invalid precision will now explicitly raise a `pyiceberg.exceptions.ValidationError` instead of failing silently at runtime.