### PR TITLE
CI: Pass args through docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 .cache
 tmp/
 site
+.env
+dev/.env
 
 # intellij files
 .idea

--- a/dev/docker-compose-integration.yml
+++ b/dev/docker-compose-integration.yml
@@ -18,7 +18,10 @@
 services:
   spark-iceberg:
     image: pyiceberg-spark:latest
-    build: spark/
+    build:
+      context: spark/
+      args:
+        MAVEN_MIRROR: ${MAVEN_MIRROR:-https://repo.maven.apache.org/maven2}
     container_name: pyiceberg-spark
     networks:
       iceberg_net:
@@ -93,7 +96,10 @@ services:
       "
   hive:
     image: pyiceberg-hive:latest
-    build: hive/
+    build:
+      context: hive/
+      args:
+        MAVEN_MIRROR: ${MAVEN_MIRROR:-https://repo1.maven.org/maven2}
     container_name: pyiceberg-hive
     hostname: hive
     networks:


### PR DESCRIPTION
# Rationale for this change

This way we pass in the MIRROR from docker-compose to the Dockerfile as well. Also git-ignore the `.env` file to avoid checking in this file.

## Are these changes tested?

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
