### PR TITLE
Validate decimal precision limit

### DIFF
--- a/pyiceberg/types.py
+++ b/pyiceberg/types.py
@@ -58,6 +58,7 @@ from pyiceberg.utils.parsing import ParseNumberFromBrackets
 from pyiceberg.utils.singleton import Singleton
 
 DECIMAL_REGEX = re.compile(r"decimal\((\d+),\s*(\d+)\)")
+DECIMAL_MAX_PRECISION = 38
 FIXED = "fixed"
 FIXED_PARSER = ParseNumberFromBrackets(FIXED)
 
@@ -324,6 +325,10 @@ class DecimalType(PrimitiveType):
     root: tuple[int, int]
 
     def __init__(self, precision: int, scale: int) -> None:
+        if precision > DECIMAL_MAX_PRECISION:
+            raise ValidationError(
+                f"Cannot construct decimal with precision {precision}. Max precision is {DECIMAL_MAX_PRECISION}"
+            )
         super().__init__(root=(precision, scale))
 
     @model_serializer

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -67,7 +67,7 @@ TEST_PRIMITIVE_TYPES = [
     FloatType(),
     DoubleType(),
     DecimalType(10, 2),
-    DecimalType(100, 2),
+    DecimalType(38, 2),
     StringType(),
     DateType(),
     TimeType(),

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -514,6 +514,16 @@ def test_deserialization_decimal() -> None:
     assert decimal.scale == 25
 
 
+def test_decimal_precision_greater_than_max_precision() -> None:
+    with pytest.raises(ValidationError, match="Cannot construct decimal with precision 39"):
+        DecimalType(39, 0)
+
+
+def test_deserialization_decimal_precision_greater_than_max_precision() -> None:
+    with pytest.raises(ValidationError, match="Cannot construct decimal with precision 39"):
+        DecimalType.model_validate_json('"decimal(39, 0)"')
+
+
 def test_deserialization_decimal_failure() -> None:
     with pytest.raises(ValidationError) as exc_info:
         _ = DecimalType.model_validate_json('"decimal(abc, def)"')


### PR DESCRIPTION
Closes #3583.

This validates that Iceberg decimal precision does not exceed the spec maximum of 38. The check is applied at DecimalType construction so both direct construction and JSON deserialization reject invalid precision.

Testing:
- pytest tests/test_types.py -q
- pytest tests/test_schema.py -q