### PR TITLE
feat(expressions): add truthiness semantics for constant boolean expressions

### DIFF
--- a/pyiceberg/expressions/__init__.py
+++ b/pyiceberg/expressions/__init__.py
@@ -70,6 +70,20 @@ class BooleanExpression(IcebergBaseModel, ABC):
 
         return Or(self, other)
 
+    def __bool__(self) -> bool:
+        """Reject truthiness checks on non-constant expressions.
+
+        Truthiness is only defined for the constant expressions ``AlwaysTrue`` and
+        ``AlwaysFalse``, which override this method. Evaluating a predicate such as
+        ``if EqualTo("x", 1):`` is almost always a mistake; use ``~expr`` to negate
+        an expression or compare explicitly against ``AlwaysTrue()``/``AlwaysFalse()``.
+        """
+        raise TypeError(
+            f"The truth value of {type(self).__name__} is ambiguous. "
+            "Truthiness is only defined for AlwaysTrue() and AlwaysFalse(); "
+            "use ~expr to negate an expression or compare against AlwaysTrue()/AlwaysFalse()."
+        )
+
     @model_validator(mode="wrap")
     @classmethod
     def handle_primitive_type(cls, v: Any, handler: ValidatorFunctionWrapHandler) -> BooleanExpression:
@@ -455,6 +469,10 @@ class AlwaysTrue(BooleanExpression, Singleton, IcebergRootModel[bool]):
         """Transform the Expression into its negated version."""
         return AlwaysFalse()
 
+    def __bool__(self) -> bool:
+        """Return True, the constant value of this expression."""
+        return True
+
     def __str__(self) -> str:
         """Return the string representation of the AlwaysTrue class."""
         return "AlwaysTrue()"
@@ -472,6 +490,10 @@ class AlwaysFalse(BooleanExpression, Singleton, IcebergRootModel[bool]):
     def __invert__(self) -> AlwaysTrue:
         """Transform the Expression into its negated version."""
         return AlwaysTrue()
+
+    def __bool__(self) -> bool:
+        """Return False, the constant value of this expression."""
+        return False
 
     def __str__(self) -> str:
         """Return the string representation of the AlwaysFalse class."""

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -2103,7 +2103,7 @@ class FileScanTask(ScanTask):
         return FileScanTask(
             data_file=data_file,
             delete_files=resolved_deletes,
-            residual=rest_task.residual_filter if rest_task.residual_filter else ALWAYS_TRUE,
+            residual=rest_task.residual_filter if rest_task.residual_filter is not None else ALWAYS_TRUE,
         )
 
 

--- a/tests/catalog/test_scan_planning_models.py
+++ b/tests/catalog/test_scan_planning_models.py
@@ -39,6 +39,7 @@ from pyiceberg.catalog.rest.scan_planning import (
 )
 from pyiceberg.expressions import AlwaysTrue, EqualTo, Reference
 from pyiceberg.manifest import FileFormat
+from pyiceberg.table import FileScanTask
 
 TEST_URI = "https://iceberg-test-catalog/"
 
@@ -240,6 +241,24 @@ def test_scan_task_with_residual_filter_true() -> None:
     }
     task = RESTFileScanTask.model_validate(data)
     assert isinstance(task.residual_filter, AlwaysTrue)
+
+
+def test_from_rest_response_preserves_non_constant_residual_filter() -> None:
+    data = {
+        "data-file": _rest_data_file(),
+        "residual-filter": {"type": "eq", "term": "x", "value": 1},
+    }
+    rest_task = RESTFileScanTask.model_validate(data)
+    task = FileScanTask.from_rest_response(rest_task, [])
+    assert task.residual == EqualTo(Reference("x"), 1)
+
+
+def test_from_rest_response_defaults_missing_residual_filter_to_always_true() -> None:
+    data = {"data-file": _rest_data_file()}
+    rest_task = RESTFileScanTask.model_validate(data)
+    assert rest_task.residual_filter is None
+    task = FileScanTask.from_rest_response(rest_task, [])
+    assert task.residual == AlwaysTrue()
 
 
 def test_empty_scan_tasks() -> None:

--- a/tests/expressions/test_expressions.py
+++ b/tests/expressions/test_expressions.py
@@ -639,6 +639,33 @@ def test_invert_always() -> None:
     assert ~AlwaysTrue() == AlwaysFalse()
 
 
+def test_always_bool() -> None:
+    assert bool(AlwaysTrue()) is True
+    assert bool(AlwaysFalse()) is False
+
+
+def test_always_bool_control_flow() -> None:
+    assert (1 if AlwaysTrue() else 0) == 1
+    assert (1 if AlwaysFalse() else 0) == 0
+    assert not AlwaysFalse()
+    assert not (not AlwaysTrue())
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        EqualTo("x", 1),
+        IsNull("x"),
+        And(EqualTo("x", 1), IsNull("y")),
+        Or(EqualTo("x", 1), IsNull("y")),
+        Not(EqualTo("x", 1)),
+    ],
+)
+def test_non_constant_expression_bool_raises(expression: BooleanExpression) -> None:
+    with pytest.raises(TypeError, match="truth value"):
+        bool(expression)
+
+
 def test_accessor_base_class() -> None:
     """Test retrieving a value at a position of a container using an accessor"""
 

--- a/tests/io/test_pyarrow.py
+++ b/tests/io/test_pyarrow.py
@@ -1137,7 +1137,7 @@ def project(
         ),
         io=PyArrowFileIO(),
         projected_schema=schema,
-        row_filter=expr or AlwaysTrue(),
+        row_filter=expr if expr is not None else AlwaysTrue(),
         case_sensitive=True,
     ).to_table(
         tasks=[


### PR DESCRIPTION
<!-- Closes #3543 -->
Closes #3543

# Rationale for this change

`AlwaysTrue` and `AlwaysFalse` subclass `IcebergRootModel[bool]` (a Pydantic
`RootModel`) but never defined `__bool__`, so they fell back to default object
truthiness. `bool(AlwaysTrue())` was `True` by accident, but `bool(AlwaysFalse())`
was also `True`, and `bool(EqualTo("x", 1))` was silently `True` as well. So
common patterns like `expr or AlwaysTrue()` or `if not residual:` evaluated a
`FALSE` constant as truthy, which is the opposite of what they read like.

This adds explicit truthiness, as proposed in #3543:

- `AlwaysTrue.__bool__` returns `True`, `AlwaysFalse.__bool__` returns `False`.
- The base `BooleanExpression.__bool__` raises `TypeError`, so accidental
  `if predicate:` on a non-constant expression is a clear error pointing to `~expr`
  or an explicit `AlwaysTrue()`/`AlwaysFalse()` comparison, instead of a silent
  always-true. Only the two constants override it.

Auditing optional-expression checks (called out in the issue) surfaced one latent
production bug: `FileScanTask.from_rest_response` used
`residual=... if rest_task.residual_filter else ALWAYS_TRUE`, so an explicit
`AlwaysFalse()` residual from a REST catalog was discarded to `ALWAYS_TRUE` because
`bool(AlwaysFalse())` was `True`. Switched to an `is not None` presence check, which
both fixes that and is required once a non-constant residual no longer coerces to
bool. One test helper used the same `expr or AlwaysTrue()` pattern and got the same
fix. No other call site relies on bare truthiness; all use `is` / `==` / `isinstance`.

One design note for reviewers: @rambleraptor raised on the issue that making the
base class raise might be more than needed ("users shouldn't need to understand
`BooleanExpression` internals... only really a problem for `AlwaysFalse()`"). This
PR implements the base-class-raises design @kevinjqliu described in the issue. If
you would rather keep it minimal, the smaller alternative is to define `__bool__`
only on `AlwaysTrue`/`AlwaysFalse` and drop the base `TypeError` (and its test);
the residual fix is still needed either way. Happy to trim it down if preferred.

## Are these changes tested?

Yes. `bool(AlwaysTrue()) is True`, `bool(AlwaysFalse()) is False`, control-flow over
both, and `TypeError` for non-constant predicates (`EqualTo`, `IsNull`, `And`, `Or`,
`Not`); plus REST scan-planning tests that a non-constant residual is preserved and a
missing one defaults to `AlwaysTrue`. Integration tests (Docker + Spark) were not
run locally; the change is pure expression logic and is fully covered by unit tests.

## Are there any user-facing changes?

Yes (small, intentional): `bool(AlwaysFalse())` now returns `False`, and
`bool(<non-constant expression>)` now raises `TypeError` instead of returning `True`.
