### PR TITLE
Reject DecimalType with precision larger than 38

### DIFF
--- a/pyiceberg/types.py
+++ b/pyiceberg/types.py
@@ -324,6 +324,8 @@ class DecimalType(PrimitiveType):
     root: tuple[int, int]
 
     def __init__(self, precision: int, scale: int) -> None:
+        if precision > 38:
+            raise ValueError(f"Decimals with precision larger than 38 are not supported: {precision}")
         super().__init__(root=(precision, scale))
 
     @model_serializer

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -67,7 +67,7 @@ TEST_PRIMITIVE_TYPES = [
     FloatType(),
     DoubleType(),
     DecimalType(10, 2),
-    DecimalType(100, 2),
+    DecimalType(38, 2),
     StringType(),
     DateType(),
     TimeType(),

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -147,6 +147,15 @@ def test_decimal_type() -> None:
     assert type_var == pickle.loads(pickle.dumps(type_var))
 
 
+def test_decimal_type_rejects_precision_over_38() -> None:
+    # The Iceberg spec requires decimal precision to be 38 or less; the Java
+    # reference implementation raises for precision > 38. See issue #3583.
+    with pytest.raises(ValueError, match="precision larger than 38 are not supported: 39"):
+        DecimalType(39, 0)
+    # Boundary: precision exactly 38 is still valid.
+    assert DecimalType(38, 0).precision == 38
+
+
 def test_struct_type() -> None:
     type_var = StructType(
         NestedField(1, "optional_field", IntegerType(), required=True),


### PR DESCRIPTION
## Summary

The Iceberg [spec](https://iceberg.apache.org/spec/#primitive-types) requires decimal precision to be **38 or less** ("Scale is fixed, precision must be 38 or less"). Currently `DecimalType(39, 0)` — and parsing the type string `"decimal(39, 0)"` — is accepted silently, producing `DecimalType(precision=39, scale=0)`. Precision above 38 isn't representable in decimal's fixed-byte storage, so silently accepting it can corrupt downstream encoding.

The Java reference implementation rejects this: `DecimalType.of(39, 0)` raises `IllegalArgumentException: Decimals with precision larger than 38 are not supported: 39`.

Closes #3583.

## Change

Validate `precision <= 38` in `DecimalType.__init__`, raising `ValueError` with the same message as the Java reference. This covers both direct construction and the string-parse path (`_parse_decimal_type` constructs `DecimalType(precision, scale)`, which routes through `__init__`).

## Test

Added `test_decimal_type_rejects_precision_over_38`: `DecimalType(39, 0)` raises, and the boundary `DecimalType(38, 0)` remains valid.