### PR TITLE
Docs: Add missing _downcast_ns_timestamp_to_us to ArrowScan docstring

### DIFF
--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -1743,6 +1743,7 @@ class ArrowScan:
         _bound_row_filter: Schema bound row expression to filter the data with
         _case_sensitive: Case sensitivity when looking up column names
         _limit: Limit the number of records.
+        _downcast_ns_timestamp_to_us: Whether to downcast nanosecond timestamps to microseconds on read.
         _dictionary_columns: Column names to read as dictionary-encoded arrays.
     """
 


### PR DESCRIPTION
## Which issue does this PR close?

Minor documentation gap (no issue).

## Rationale for this change

The `ArrowScan` class declares `_downcast_ns_timestamp_to_us: bool | None` as a class-level type annotation and documents all other attributes in the docstring, but this attribute was missing from the Attributes section.

## What changes are included in this PR?

Adds one line to the `ArrowScan` class docstring documenting the `_downcast_ns_timestamp_to_us` attribute.

## Are there any user-facing changes?

No.