### PR TITLE
Docs: Remove stale reference to closed #2152 in streaming write docstrings

### DIFF
--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -2881,8 +2881,7 @@ def _dataframe_to_data_files(
     For a ``pa.RecordBatchReader`` batches are streamed and microbatched into
     target-sized files using bounded memory (see :func:`bin_pack_record_batches`).
     Streaming writes are currently only supported on unpartitioned tables;
-    partitioned support is tracked in
-    https://github.com/apache/iceberg-python/issues/2152.
+    partitioned streaming support is not yet implemented.
 
     Returns:
         An iterable that supplies datafiles that represent the input data.
@@ -2909,8 +2908,7 @@ def _dataframe_to_data_files(
         if not table_metadata.spec().is_unpartitioned():
             raise NotImplementedError(
                 "Writing a pa.RecordBatchReader to a partitioned table is not yet supported. "
-                "Materialise the reader as a pa.Table first, or follow "
-                "https://github.com/apache/iceberg-python/issues/2152 for partitioned streaming support."
+                "Materialise the reader as a pa.Table first."
             )
         yield from write_file(
             io=io,

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -473,8 +473,7 @@ class Transaction:
 
         Streaming writes are currently only supported on unpartitioned tables;
         passing a ``pa.RecordBatchReader`` for a partitioned table raises
-        ``NotImplementedError``. See
-        https://github.com/apache/iceberg-python/issues/2152.
+        ``NotImplementedError``.
 
         Note:
             When ``df`` is a ``pa.RecordBatchReader`` the reader is consumed
@@ -621,8 +620,7 @@ class Transaction:
 
         Streaming writes are currently only supported on unpartitioned tables;
         passing a ``pa.RecordBatchReader`` for a partitioned table raises
-        ``NotImplementedError``. See
-        https://github.com/apache/iceberg-python/issues/2152.
+        ``NotImplementedError``.
 
         Note:
             When ``df`` is a ``pa.RecordBatchReader`` the reader is consumed

--- a/tests/catalog/test_catalog_behaviors.py
+++ b/tests/catalog/test_catalog_behaviors.py
@@ -1216,7 +1216,7 @@ def test_drop_namespace_raises_error_when_namespace_not_empty(
 # RecordBatchReader streaming append/overwrite tests
 #
 # Streaming writes accept a pa.RecordBatchReader and microbatch it into target-sized
-# Parquet files instead of materialising the full Arrow Table in memory. Tracks
+# Parquet files instead of materialising the full Arrow Table in memory. Introduced in
 # https://github.com/apache/iceberg-python/issues/2152.
 
 


### PR DESCRIPTION
# Rationale for this change

Issue #2152 was closed by #3335 (commit 706390fc) which added pa.RecordBatchReader support for unpartitioned streaming writes. However, the docstrings in _dataframe_to_data_files, Transaction.append, and Transaction.overwrite still reference #2152 as if it tracks future partitioned streaming support. Since the issue is closed, these references are stale and misleading.

This PR removes the now-incorrect `tracked in #2152` / `See #2152` links from docstrings and the NotImplementedError message, replacing them with a simple statement that partitioned streaming is not yet implemented.

## Are these changes tested?

Docstring-only changes; no behavioral changes. Existing tests pass as-is.

## Are there any user-facing changes?

The NotImplementedError message when passing a pa.RecordBatchReader to a partitioned table is slightly shorter (no longer includes the closed issue URL). No API or behavioral changes.