### PR TITLE
fix: compare timestamps for partitions metadata last_updated_at

### DIFF
--- a/pyiceberg/table/inspect.py
+++ b/pyiceberg/table/inspect.py
@@ -352,7 +352,7 @@ class InspectTable:
         partition_row = partitions_map[partition_record_key]
 
         if snapshot is not None:
-            if partition_row["last_updated_at"] is None or partition_row["last_updated_snapshot_id"] < snapshot.timestamp_ms:
+            if partition_row["last_updated_at"] is None or partition_row["last_updated_at"] < snapshot.timestamp_ms:
                 partition_row["last_updated_at"] = snapshot.timestamp_ms
                 partition_row["last_updated_snapshot_id"] = snapshot.snapshot_id
 

--- a/tests/table/test_inspect.py
+++ b/tests/table/test_inspect.py
@@ -16,13 +16,17 @@
 # under the License.
 
 from pathlib import PosixPath
+from typing import Any
 
 import pyarrow as pa
 import pytest
 
 from pyiceberg.conversions import to_bytes
+from pyiceberg.manifest import DataFile, DataFileContent
 from pyiceberg.schema import Schema
-from pyiceberg.table.inspect import _readable_bound
+from pyiceberg.table.inspect import InspectTable, _readable_bound
+from pyiceberg.table.snapshots import Snapshot
+from pyiceberg.typedef import Record
 from pyiceberg.types import NestedField, StringType
 from tests.catalog.test_base import InMemoryCatalog
 
@@ -68,3 +72,26 @@ def test_inspect_entries_and_files_render_null_bound(catalog: InMemoryCatalog) -
     files_metrics = tbl.inspect.files().to_pydict()["readable_metrics"][0]["s"]
     assert files_metrics["lower_bound"] is None
     assert files_metrics["upper_bound"] is None
+
+
+@pytest.mark.parametrize("newest_first", [False, True])
+def test_partitions_last_updated_uses_latest_snapshot_regardless_of_order(newest_first: bool) -> None:
+    # Manifest entries are visited in manifest order, which is not chronological, so the
+    # `partitions` metadata table must keep the snapshot with the highest commit timestamp
+    # per partition regardless of the order in which the entries are aggregated.
+    older = Snapshot(snapshot_id=6446744073709551000, timestamp_ms=1000, manifest_list="file:///dev/null")
+    newer = Snapshot(snapshot_id=8446744073709551111, timestamp_ms=5000, manifest_list="file:///dev/null")
+
+    def _data_file() -> DataFile:
+        file = DataFile.from_args(content=DataFileContent.DATA, record_count=1, file_size_in_bytes=1, partition=Record("a"))
+        file.spec_id = 0
+        return file
+
+    inspect = InspectTable.__new__(InspectTable)
+    partitions_map: dict[tuple[str, Any], Any] = {}
+    for snapshot in [newer, older] if newest_first else [older, newer]:
+        inspect._update_partitions_map_from_manifest_entry(partitions_map, _data_file(), {"part": "a"}, snapshot)
+
+    (partition_row,) = partitions_map.values()
+    assert partition_row["last_updated_at"] == newer.timestamp_ms
+    assert partition_row["last_updated_snapshot_id"] == newer.snapshot_id

--- a/tests/table/test_inspect.py
+++ b/tests/table/test_inspect.py
@@ -82,15 +82,13 @@ def test_partitions_last_updated_uses_latest_snapshot_regardless_of_order(newest
     older = Snapshot(snapshot_id=6446744073709551000, timestamp_ms=1000, manifest_list="file:///dev/null")
     newer = Snapshot(snapshot_id=8446744073709551111, timestamp_ms=5000, manifest_list="file:///dev/null")
 
-    def _data_file() -> DataFile:
-        file = DataFile.from_args(content=DataFileContent.DATA, record_count=1, file_size_in_bytes=1, partition=Record("a"))
-        file.spec_id = 0
-        return file
+    data_file = DataFile.from_args(content=DataFileContent.DATA, record_count=1, file_size_in_bytes=1, partition=Record("a"))
+    data_file.spec_id = 0
 
     inspect = InspectTable.__new__(InspectTable)
     partitions_map: dict[tuple[str, Any], Any] = {}
     for snapshot in [newer, older] if newest_first else [older, newer]:
-        inspect._update_partitions_map_from_manifest_entry(partitions_map, _data_file(), {"part": "a"}, snapshot)
+        inspect._update_partitions_map_from_manifest_entry(partitions_map, data_file, {"part": "a"}, snapshot)
 
     (partition_row,) = partitions_map.values()
     assert partition_row["last_updated_at"] == newer.timestamp_ms


### PR DESCRIPTION

# Rationale for this change

`Table.inspect.partitions()` reports the wrong `last_updated_at` and
`last_updated_snapshot_id` for any partition that has been touched by more than
one snapshot (for example repeated inserts into the same partition value).

`InspectTable._update_partitions_map_from_manifest_entry` aggregates per-partition
stats across manifest entries. Those entries are iterated in manifest order, which
is not chronological, so the aggregation has to keep the entry with the most recent
commit timestamp per partition. The overwrite guard did:

```python
if partition_row["last_updated_at"] is None or partition_row["last_updated_snapshot_id"] < snapshot.timestamp_ms:
```

The second clause compares the stored `last_updated_snapshot_id` (a snapshot id)
against `snapshot.timestamp_ms` (a commit timestamp) - two unrelated quantities.
Snapshot ids are large positive 63-bit integers (order 1e18), while millisecond
timestamps are order 1e12, so `id < timestamp_ms` is effectively always false. The
row therefore keeps whichever manifest entry happened to be visited first rather
than the newest snapshot, so the two `last_updated_*` columns can point at an older
snapshot.

This mirrors the Java implementation, where
`PartitionsTable.Partition.update` decides the last-updated snapshot by comparing
commit timestamps (`this.lastUpdatedAt == null || snapshotCommitTime > this.lastUpdatedAt`).

The fix compares the stored timestamp against the incoming timestamp:

```python
if partition_row["last_updated_at"] is None or partition_row["last_updated_at"] < snapshot.timestamp_ms:
```

This only affects the read-only `partitions` metadata table output; it does not
change any table data or metadata on disk.

## Are these changes tested?

Yes. A new parametrized unit test in `tests/table/test_inspect.py`
(`test_partitions_last_updated_uses_latest_snapshot_regardless_of_order`) calls
`_update_partitions_map_from_manifest_entry` directly for the same partition with
an older and a newer snapshot, in both visitation orders, and asserts that
`last_updated_at` / `last_updated_snapshot_id` reflect the newer snapshot in both
cases. It fails on the previous code (the older-first order keeps
`last_updated_at = 1000` instead of `5000`) and passes with the fix.

`make lint` (ruff, ruff-format, mypy) and `pytest tests/table/test_inspect.py`
both pass. The Spark-parity coverage in
`tests/integration/test_inspect_table.py::test_inspect_partitions_partitioned`
exercises this column against Spark but requires Docker + Spark, so the added
unit test provides a deterministic, order-independent regression check.

## Are there any user-facing changes?

Yes. `Table.inspect.partitions()` now reports the correct `last_updated_at` and
`last_updated_snapshot_id` for partitions modified by multiple snapshots. There
are no API or schema changes.