### PR TITLE
fix: build StaticTable version-hint metadata locations with forward slashes

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import itertools
 import logging
-import os
 import random
 import time
 import uuid
@@ -1958,7 +1957,8 @@ class StaticTable(Table):
 
     @classmethod
     def _metadata_location_from_version_hint(cls, metadata_location: str, properties: Properties = EMPTY_DICT) -> str:
-        version_hint_location = os.path.join(metadata_location, "metadata", "version-hint.text")
+        metadata_dir = f"{metadata_location.rstrip('/')}/metadata"
+        version_hint_location = f"{metadata_dir}/version-hint.text"
         io = load_file_io(properties=properties, location=version_hint_location)
         file = io.new_input(version_hint_location)
 
@@ -1966,11 +1966,11 @@ class StaticTable(Table):
             content = stream.read().decode("utf-8")
 
         if content.endswith(".metadata.json"):
-            return os.path.join(metadata_location, "metadata", content)
+            return f"{metadata_dir}/{content}"
         elif content.isnumeric():
-            return os.path.join(metadata_location, "metadata", f"v{content}.metadata.json")
+            return f"{metadata_dir}/v{content}.metadata.json"
         else:
-            return os.path.join(metadata_location, "metadata", f"{content}.metadata.json")
+            return f"{metadata_dir}/{content}.metadata.json"
 
     @classmethod
     def from_metadata(cls, metadata_location: str, properties: Properties = EMPTY_DICT) -> StaticTable:

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import itertools
-import os
 import uuid
 import warnings
 from abc import ABC, abstractmethod
@@ -1788,7 +1787,8 @@ class StaticTable(Table):
 
     @classmethod
     def _metadata_location_from_version_hint(cls, metadata_location: str, properties: Properties = EMPTY_DICT) -> str:
-        version_hint_location = os.path.join(metadata_location, "metadata", "version-hint.text")
+        metadata_dir = f"{metadata_location.rstrip('/')}/metadata"
+        version_hint_location = f"{metadata_dir}/version-hint.text"
         io = load_file_io(properties=properties, location=version_hint_location)
         file = io.new_input(version_hint_location)
 
@@ -1796,11 +1796,11 @@ class StaticTable(Table):
             content = stream.read().decode("utf-8")
 
         if content.endswith(".metadata.json"):
-            return os.path.join(metadata_location, "metadata", content)
+            return f"{metadata_dir}/{content}"
         elif content.isnumeric():
-            return os.path.join(metadata_location, "metadata", f"v{content}.metadata.json")
+            return f"{metadata_dir}/v{content}.metadata.json"
         else:
-            return os.path.join(metadata_location, "metadata", f"{content}.metadata.json")
+            return f"{metadata_dir}/{content}.metadata.json"
 
     @classmethod
     def from_metadata(cls, metadata_location: str, properties: Properties = EMPTY_DICT) -> StaticTable:

--- a/tests/table/test_init.py
+++ b/tests/table/test_init.py
@@ -589,6 +589,49 @@ def test_static_table_version_hint_same_as_table(
         assert static_table.metadata == table_v2.metadata
 
 
+@pytest.mark.parametrize(
+    "version_hint_content, expected_metadata_file",
+    [
+        ("v3.metadata.json", "v3.metadata.json"),
+        ("3", "v3.metadata.json"),
+        ("some-uuid", "some-uuid.metadata.json"),
+    ],
+)
+def test_static_table_version_hint_location_uses_forward_slashes(
+    version_hint_content: str, expected_metadata_file: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Iceberg locations are URIs and must always be forward-slash separated, regardless of the host OS.
+    table_root = "s3://warehouse/wh/nyc.db/taxis"
+    requested_locations: list[str] = []
+
+    class _FakeStream:
+        def __enter__(self) -> "_FakeStream":
+            return self
+
+        def __exit__(self, *args: Any) -> None:
+            return None
+
+        def read(self, size: int = 0) -> bytes:
+            return version_hint_content.encode("utf-8")
+
+    class _FakeInputFile:
+        def open(self, seekable: bool = True) -> "_FakeStream":
+            return _FakeStream()
+
+    class _FakeFileIO:
+        def new_input(self, location: str) -> "_FakeInputFile":
+            requested_locations.append(location)
+            return _FakeInputFile()
+
+    monkeypatch.setattr("pyiceberg.table.load_file_io", lambda *args, **kwargs: _FakeFileIO())
+
+    resolved_location = StaticTable._metadata_location_from_version_hint(table_root)
+
+    assert requested_locations == [f"{table_root}/metadata/version-hint.text"]
+    assert resolved_location == f"{table_root}/metadata/{expected_metadata_file}"
+    assert "\\" not in resolved_location
+
+
 def test_static_table_io_does_not_exist(metadata_location: str) -> None:
     with pytest.raises(ValueError):
         StaticTable.from_metadata(metadata_location, {PY_IO_IMPL: "pyiceberg.does.not.exist.FileIO"})

--- a/tests/table/test_init.py
+++ b/tests/table/test_init.py
@@ -16,6 +16,8 @@
 # under the License.
 # pylint:disable=redefined-outer-name
 import json
+import ntpath
+import os
 import uuid
 from copy import copy
 from typing import Any
@@ -587,6 +589,53 @@ def test_static_table_version_hint_same_as_table(
         static_table = StaticTable.from_metadata(table_location)
         assert isinstance(static_table, Table)
         assert static_table.metadata == table_v2.metadata
+
+
+@pytest.mark.parametrize(
+    "version_hint_content, expected_metadata_file",
+    [
+        ("v3.metadata.json", "v3.metadata.json"),
+        ("3", "v3.metadata.json"),
+        ("some-uuid", "some-uuid.metadata.json"),
+    ],
+)
+def test_static_table_version_hint_location_uses_forward_slashes(
+    version_hint_content: str, expected_metadata_file: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Iceberg locations are URIs and must always be forward-slash separated, regardless of the
+    # host OS. Swapping in the Windows path join makes an OS-separator join emit backslashes, so
+    # this asserts the resolved metadata location stays a valid forward-slash URI on any platform.
+    monkeypatch.setattr(os.path, "join", ntpath.join)
+
+    table_root = "s3://warehouse/wh/nyc.db/taxis"
+    requested_locations: list[str] = []
+
+    class _FakeStream:
+        def __enter__(self) -> "_FakeStream":
+            return self
+
+        def __exit__(self, *args: Any) -> None:
+            return None
+
+        def read(self, size: int = 0) -> bytes:
+            return version_hint_content.encode("utf-8")
+
+    class _FakeInputFile:
+        def open(self, seekable: bool = True) -> "_FakeStream":
+            return _FakeStream()
+
+    class _FakeFileIO:
+        def new_input(self, location: str) -> "_FakeInputFile":
+            requested_locations.append(location)
+            return _FakeInputFile()
+
+    monkeypatch.setattr("pyiceberg.table.load_file_io", lambda *args, **kwargs: _FakeFileIO())
+
+    resolved_location = StaticTable._metadata_location_from_version_hint(table_root)
+
+    assert requested_locations == [f"{table_root}/metadata/version-hint.text"]
+    assert resolved_location == f"{table_root}/metadata/{expected_metadata_file}"
+    assert "\\" not in resolved_location
 
 
 def test_static_table_io_does_not_exist(metadata_location: str) -> None:


### PR DESCRIPTION

# Rationale for this change

`StaticTable._metadata_location_from_version_hint` builds the `version-hint.text`
location and the resolved metadata-file location with `os.path.join`:

```python
version_hint_location = os.path.join(metadata_location, "metadata", "version-hint.text")
...
return os.path.join(metadata_location, "metadata", content)
```

Iceberg locations are URIs (`s3://`, `gs://`, `abfss://`, `file://`, ...) and are
always forward-slash separated. `os.path.join` uses the host OS separator, so on
Windows it produces backslash-separated keys such as
`s3://warehouse/wh/nyc.db/taxis\metadata\version-hint.text`. That is an invalid
object-store key, so `FileIO.new_input(...)` cannot find the file and the lookup
fails.

This breaks the documented "pass the table root path" usage of
`StaticTable.from_metadata` on Windows. The API docs advertise exactly this path:

> If your table metadata directory contains a `version-hint.text` file, you can
> just specify the table root path, and PyIceberg will read the version hint file
> and load the latest metadata file.
> `StaticTable.from_metadata("s3://warehouse/wh/nyc.db/taxis")`

This is the only place in the codebase that builds a table/metadata *location*
with `os.path.join`; every other location builder already uses explicit forward
slashes (for example `pyiceberg/table/locations.py`, and the metadata-path helpers
in `pyiceberg/catalog/__init__.py`). This change makes
`_metadata_location_from_version_hint` consistent with them:

```python
metadata_dir = f"{metadata_location.rstrip('/')}/metadata"
version_hint_location = f"{metadata_dir}/version-hint.text"
```

Behavior is unchanged on POSIX. The now-unused `os` import (this was its only use
in the module) is removed to keep the linter happy.

## Are these changes tested?

Yes. `tests/table/test_init.py` gains
`test_static_table_version_hint_location_uses_forward_slashes`, a regression test
that is deliberately OS-independent: it swaps `os.path.join` for `ntpath.join`
(the Windows join) via `monkeypatch`, stubs `load_file_io` with a small fake
`FileIO`, and asserts the resolved metadata location stays a valid forward-slash
URI (`.../metadata/version-hint.text` and `.../metadata/<file>.metadata.json`,
with no backslash). It is parametrized over the three version-hint content forms
the method handles (full `*.metadata.json` filename, a numeric version, and a
non-numeric value). It fails on the old `os.path.join` code (backslash separators)
and passes after this change, on any platform.

The pre-existing `test_static_table_version_hint_same_as_table` only exercises a
local temp path, where the separator is already `/` on Linux CI, so it never
caught this. Windows is not yet in CI (tracked separately in #2477), which is why
the OS-independent approach is used here.

- `pytest tests/table/test_init.py -k version_hint` -> passes (existing + 3 new cases).
- `pytest tests/table/test_init.py` -> passes.
- `pytest tests/test_serializers.py` -> passes (exercises the real
  `from_metadata` -> `_metadata_location_from_version_hint` path over local files).
- `make lint` -> clean.

The integration suite (Docker + Spark) was not run locally; this change is covered
by the unit tests above and does not alter POSIX behavior.

## Are there any user-facing changes?

No API or signature changes. This is a bug fix: `StaticTable.from_metadata(<table
root>)` and `StaticTable._metadata_location_from_version_hint` now build correct
forward-slash metadata URIs on Windows. POSIX behavior is unchanged.

Related: #2477 (infra: run tests for windows).
