### PR TITLE
fix(ci): correct stale-issue-label and exempt security issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -35,8 +35,8 @@ jobs:
       - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
           # stale issues
-          stale-issue-label: 'stale,security'
-          exempt-issue-labels: 'not-stale'
+          stale-issue-label: 'stale'
+          exempt-issue-labels: 'not-stale,security'
           days-before-issue-stale: 180
           days-before-issue-close: 14
           stale-issue-message: >


### PR DESCRIPTION

# Rationale for this change

The stale-bot workflow (`.github/workflows/stale.yml`) configures the issue side
incorrectly:

```yaml
stale-issue-label: 'stale,security'
exempt-issue-labels: 'not-stale'
```

`stale-issue-label` takes a **single** label and `actions/stale` applies it
verbatim (it is not comma-split, unlike the `*-labels` inputs). So instead of
tagging stale issues with `stale`, the workflow tags them with one bogus label
literally named `stale,security`. That breaks the workflow's own
`stale-issue-message` (which tells users to add `not-stale`, keyed on the stale
state) and anything else that relies on a plain `stale` label.

It also leaves `security` out of `exempt-issue-labels`, so `security`-labeled
issues are still marked stale and auto-closed after 180+14 days. This is
inconsistent with the **PR** side of the same file, which already exempts
`security`:

```yaml
stale-pr-label: 'stale'
exempt-pr-labels: 'not-stale,security'
```

The value was introduced in #3125, which changed `stale-issue-label: 'stale'` to
`'stale,security'` in the same change that added
`exempt-pr-labels: 'not-stale,security'`, i.e. `security` was meant as an
exemption on both sides but landed in the wrong key on the issue side.

This change makes the issue side mirror the (already correct) PR side:

```yaml
stale-issue-label: 'stale'
exempt-issue-labels: 'not-stale,security'
```

## Are these changes tested?

There is no test harness for GitHub Actions workflow semantics in this repo, so
this was validated by inspection against the pinned action's contract and source:

- Against `actions/stale`'s `action.yml` at the pinned SHA
  (`eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899`, v10.3.0): `stale-issue-label` is
  documented as "The label to apply when an issue is stale" (single value,
  default `Stale`), while `exempt-issue-labels` documents "Separate multiple
  labels with commas". In the action source, the stale label is applied verbatim
  and only the exempt labels are comma-split, confirming both effects above.
- `stale-issue-label: 'stale'` matches the PR side of this same file and the
  Java `apache/iceberg` `stale.yml`.
- Repo linters pass on the changed file (`check-yaml`, `codespell`,
  trailing-whitespace, end-of-file-fixer).

## Are there any user-facing changes?

No. This only affects the repository's stale-bot automation (issue labeling and
which issues are exempt from auto-close). No changelog label needed.
