### PR TITLE
docs: fix undefined variable in schema evolution transaction example

### DIFF
--- a/mkdocs/docs/api.md
+++ b/mkdocs/docs/api.md
@@ -1170,7 +1170,7 @@ You can also initiate a transaction if you want to make more changes than just e
 ```python
 with table.transaction() as transaction:
     with transaction.update_schema() as update_schema:
-        update.add_column("some_other_field", IntegerType(), "doc")
+        update_schema.add_column("some_other_field", IntegerType(), "doc")
     # ... Update properties etc
 ```
 


### PR DESCRIPTION

<!-- Fills .github/pull_request_template.md verbatim (3 H1 sections).
     No tracking issue exists for this docs-only change, so no "Closes #". -->

# Rationale for this change

The "schema evolution" section of the Python API docs shows how to evolve a
schema inside a transaction:

```python
with table.transaction() as transaction:
    with transaction.update_schema() as update_schema:
        update.add_column("some_other_field", IntegerType(), "doc")
    # ... Update properties etc
```

The inner context manager is bound as `update_schema`, but the body calls
`update.add_column(...)`. The name `update` is not defined in that scope; it is
left over from the preceding standalone example just above it
(`with table.update_schema() as update:`). Copy-pasting the transaction snippet
verbatim raises `NameError: name 'update' is not defined`.

This changes the call to use the bound name `update_schema`, so the documented
example runs as written. It also matches the already-correct
`create_table_transaction` example earlier in the same page, which uses
`update_schema.add_column(...)`.

## Are these changes tested?

No automated test: this is a one-line documentation fix with no code change. I
verified it manually against the public API: `Transaction.update_schema()`
returns an `UpdateSchema` context manager whose `add_column(path, field_type,
doc=None, ...)` signature matches the positional call in the example, so the
corrected snippet executes without error. `pre-commit` (markdownlint, codespell,
trailing-whitespace/end-of-file) passes on the changed file.

## Are there any user-facing changes?

No. Documentation only; there are no changes to library behavior or public API.
