### PR TITLE
Build: Add .venv/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ __pycache__/
 .tox/
 env/
 venv/
+.venv/
 *.egg-info/
 test-reports
 build/


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

`.venv/` is the default directory name created by `python -m venv .venv` and is the convention recommended by the Python docs and modern tooling like `uv`. Currently `.gitignore` only ignores `venv/` but not `.venv/`, so contributors using the dotted convention could accidentally stage their virtualenv.

## Are these changes tested?

N/A — this is a `.gitignore`-only change.

## Are there any user-facing changes?

No.
