### PR TITLE
Read tables with multi-argument transforms as unknown transforms

### DIFF
--- a/pyiceberg/partitioning.py
+++ b/pyiceberg/partitioning.py
@@ -117,9 +117,11 @@ class PartitionField(IcebergBaseModel):
                     if len(source_ids) == 0:
                         raise ValueError("Empty source-ids is not allowed")
                     if len(source_ids) > 1:
+                        if data.get("transform") is None:
+                            raise ValueError("Transform is required for a multi-argument field")
                         # Multi-argument transforms cannot be evaluated; per the spec, v3 readers
                         # must read tables with such transforms, ignoring them
-                        data["transform"] = UnknownTransform(transform=str(data.get("transform")))
+                        data["transform"] = UnknownTransform(transform=str(data["transform"]))
                     else:
                         data.pop("source-ids", None)
                     data["source-id"] = source_ids[0]
@@ -140,7 +142,10 @@ class PartitionField(IcebergBaseModel):
 
     def __str__(self) -> str:
         """Return the string representation of the PartitionField class."""
-        sources = ", ".join(str(s) for s in self.source_ids) if self.source_ids else self.source_id
+        if self.source_ids is not None and len(self.source_ids) > 1:
+            sources = ", ".join(str(s) for s in self.source_ids)
+        else:
+            sources = str(self.source_id)
         return f"{self.field_id}: {self.name}: {self.transform}({sources})"
 
 

--- a/pyiceberg/partitioning.py
+++ b/pyiceberg/partitioning.py
@@ -134,10 +134,8 @@ class PartitionField(IcebergBaseModel):
         # multi-argument transforms write only source-ids
         if self.source_ids is not None and len(self.source_ids) > 1:
             serialized.pop("source-id", None)
-            serialized.pop("source_id", None)
         else:
             serialized.pop("source-ids", None)
-            serialized.pop("source_ids", None)
         return serialized
 
     def __str__(self) -> str:

--- a/pyiceberg/partitioning.py
+++ b/pyiceberg/partitioning.py
@@ -29,6 +29,7 @@ from pydantic import (
     Field,
     PlainSerializer,
     WithJsonSchema,
+    model_serializer,
     model_validator,
 )
 
@@ -77,6 +78,7 @@ class PartitionField(IcebergBaseModel):
     """
 
     source_id: int = Field(alias="source-id")
+    source_ids: list[int] | None = Field(alias="source-ids", default=None, repr=False)
     field_id: int = Field(alias="field-id")
     transform: Annotated[  # type: ignore
         Transform,
@@ -115,13 +117,31 @@ class PartitionField(IcebergBaseModel):
                     if len(source_ids) == 0:
                         raise ValueError("Empty source-ids is not allowed")
                     if len(source_ids) > 1:
-                        raise ValueError("Multi argument transforms are not yet supported")
+                        # Multi-argument transforms cannot be evaluated; per the spec, v3 readers
+                        # must read tables with such transforms, ignoring them
+                        data["transform"] = UnknownTransform(transform=str(data.get("transform")))
+                    else:
+                        data.pop("source-ids", None)
                     data["source-id"] = source_ids[0]
         return data
 
+    @model_serializer(mode="wrap")
+    def _serialize_source_ids(self, handler: Any) -> Any:
+        serialized = handler(self)
+        # Per the spec, single-argument transforms write only source-id and
+        # multi-argument transforms write only source-ids
+        if self.source_ids is not None and len(self.source_ids) > 1:
+            serialized.pop("source-id", None)
+            serialized.pop("source_id", None)
+        else:
+            serialized.pop("source-ids", None)
+            serialized.pop("source_ids", None)
+        return serialized
+
     def __str__(self) -> str:
         """Return the string representation of the PartitionField class."""
-        return f"{self.field_id}: {self.name}: {self.transform}({self.source_id})"
+        sources = ", ".join(str(s) for s in self.source_ids) if self.source_ids else self.source_id
+        return f"{self.field_id}: {self.name}: {self.transform}({sources})"
 
 
 class PartitionSpec(IcebergBaseModel):

--- a/pyiceberg/partitioning.py
+++ b/pyiceberg/partitioning.py
@@ -29,6 +29,7 @@ from pydantic import (
     Field,
     PlainSerializer,
     WithJsonSchema,
+    model_serializer,
     model_validator,
 )
 
@@ -79,6 +80,7 @@ class PartitionField(IcebergBaseModel):
     """
 
     source_id: int = Field(alias="source-id")
+    source_ids: list[int] | None = Field(alias="source-ids", default=None, repr=False)
     field_id: int = Field(alias="field-id")
     transform: Annotated[  # type: ignore
         Transform,
@@ -119,13 +121,31 @@ class PartitionField(IcebergBaseModel):
                     if len(source_ids) == 0:
                         raise ValueError("Empty source-ids is not allowed")
                     if len(source_ids) > 1:
-                        raise ValueError("Multi argument transforms are not yet supported")
+                        # Multi-argument transforms cannot be evaluated; per the spec, v3 readers
+                        # must read tables with such transforms, ignoring them
+                        data["transform"] = UnknownTransform(transform=str(data.get("transform")))
+                    else:
+                        data.pop("source-ids", None)
                     data["source-id"] = source_ids[0]
         return data
 
+    @model_serializer(mode="wrap")
+    def _serialize_source_ids(self, handler: Any) -> Any:
+        serialized = handler(self)
+        # Per the spec, single-argument transforms write only source-id and
+        # multi-argument transforms write only source-ids
+        if self.source_ids is not None and len(self.source_ids) > 1:
+            serialized.pop("source-id", None)
+            serialized.pop("source_id", None)
+        else:
+            serialized.pop("source-ids", None)
+            serialized.pop("source_ids", None)
+        return serialized
+
     def __str__(self) -> str:
         """Return the string representation of the PartitionField class."""
-        return f"{self.field_id}: {self.name}: {self.transform}({self.source_id})"
+        sources = ", ".join(str(s) for s in self.source_ids) if self.source_ids else self.source_id
+        return f"{self.field_id}: {self.name}: {self.transform}({sources})"
 
 
 class PartitionSpec(IcebergBaseModel):

--- a/pyiceberg/partitioning.py
+++ b/pyiceberg/partitioning.py
@@ -29,8 +29,6 @@ from pydantic import (
     Field,
     PlainSerializer,
     WithJsonSchema,
-    model_serializer,
-    model_validator,
 )
 
 from pyiceberg.exceptions import ValidationError
@@ -42,6 +40,7 @@ from pyiceberg.transforms import (
     IdentityTransform,
     MonthTransform,
     Transform,
+    TransformSourceMixin,
     TruncateTransform,
     UnknownTransform,
     VoidTransform,
@@ -69,18 +68,17 @@ INITIAL_PARTITION_SPEC_ID = 0
 PARTITION_FIELD_ID_START: int = 1000
 
 
-class PartitionField(IcebergBaseModel):
+class PartitionField(TransformSourceMixin):
     """PartitionField represents how one partition value is derived from the source column via transformation.
 
     Attributes:
-        source_id(int): The source column id of table's schema.
         field_id(int): The partition field id across all the table partition specs.
         transform(Transform): The transform used to produce partition values from source column.
         name(str): The name of this partition field.
+
+    The source columns are carried by `TransformSourceMixin`.
     """
 
-    source_id: int = Field(alias="source-id")
-    source_ids: list[int] | None = Field(alias="source-ids", default=None, repr=False)
     field_id: int = Field(alias="field-id")
     transform: Annotated[  # type: ignore
         Transform,
@@ -109,45 +107,9 @@ class PartitionField(IcebergBaseModel):
 
         super().__init__(**data)
 
-    @model_validator(mode="before")
-    @classmethod
-    def map_source_ids_onto_source_id(cls, data: Any) -> Any:
-        if isinstance(data, dict):
-            if "source-ids" in data:
-                if "source-id" in data:
-                    raise ValueError("source-id and source-ids are mutually exclusive")
-                source_ids = data["source-ids"]
-                if isinstance(source_ids, list):
-                    if len(source_ids) == 0:
-                        raise ValueError("Empty source-ids is not allowed")
-                    if len(source_ids) > 1:
-                        if data.get("transform") is None:
-                            raise ValueError("Transform is required for a multi-argument field")
-                        # Multi-argument transforms cannot be evaluated; per the spec, v3 readers
-                        # must read tables with such transforms, ignoring them
-                        data["transform"] = UnknownTransform(transform=str(data["transform"]))
-                    else:
-                        data.pop("source-ids", None)
-                    data["source-id"] = source_ids[0]
-        return data
-
-    @model_serializer(mode="wrap")
-    def _serialize_source_ids(self, handler: Any) -> Any:
-        serialized = handler(self)
-        # Per the spec, single-argument transforms write only source-id and
-        # multi-argument transforms write only source-ids
-        if self.source_ids is not None and len(self.source_ids) > 1:
-            serialized.pop("source-id", None)
-        else:
-            serialized.pop("source-ids", None)
-        return serialized
-
     def __str__(self) -> str:
         """Return the string representation of the PartitionField class."""
-        if self.source_ids is not None and len(self.source_ids) > 1:
-            sources = ", ".join(str(s) for s in self.source_ids)
-        else:
-            sources = str(self.source_id)
+        sources = ", ".join(str(source_id) for source_id in self.transform_arguments)
         return f"{self.field_id}: {self.name}: {self.transform}({sources})"
 
 

--- a/pyiceberg/partitioning.py
+++ b/pyiceberg/partitioning.py
@@ -191,7 +191,7 @@ class PartitionSpec(IcebergBaseModel):
         if len(self.fields) != len(other.fields):
             return False
         return all(
-            this_field.source_id == that_field.source_id
+            this_field.transform_arguments == that_field.transform_arguments
             and this_field.transform == that_field.transform
             and this_field.name == that_field.name
             for this_field, that_field in zip(self.fields, other.fields, strict=True)

--- a/pyiceberg/partitioning.py
+++ b/pyiceberg/partitioning.py
@@ -121,9 +121,11 @@ class PartitionField(IcebergBaseModel):
                     if len(source_ids) == 0:
                         raise ValueError("Empty source-ids is not allowed")
                     if len(source_ids) > 1:
+                        if data.get("transform") is None:
+                            raise ValueError("Transform is required for a multi-argument field")
                         # Multi-argument transforms cannot be evaluated; per the spec, v3 readers
                         # must read tables with such transforms, ignoring them
-                        data["transform"] = UnknownTransform(transform=str(data.get("transform")))
+                        data["transform"] = UnknownTransform(transform=str(data["transform"]))
                     else:
                         data.pop("source-ids", None)
                     data["source-id"] = source_ids[0]
@@ -144,7 +146,10 @@ class PartitionField(IcebergBaseModel):
 
     def __str__(self) -> str:
         """Return the string representation of the PartitionField class."""
-        sources = ", ".join(str(s) for s in self.source_ids) if self.source_ids else self.source_id
+        if self.source_ids is not None and len(self.source_ids) > 1:
+            sources = ", ".join(str(s) for s in self.source_ids)
+        else:
+            sources = str(self.source_id)
         return f"{self.field_id}: {self.name}: {self.transform}({sources})"
 
 

--- a/pyiceberg/partitioning.py
+++ b/pyiceberg/partitioning.py
@@ -138,10 +138,8 @@ class PartitionField(IcebergBaseModel):
         # multi-argument transforms write only source-ids
         if self.source_ids is not None and len(self.source_ids) > 1:
             serialized.pop("source-id", None)
-            serialized.pop("source_id", None)
         else:
             serialized.pop("source-ids", None)
-            serialized.pop("source_ids", None)
         return serialized
 
     def __str__(self) -> str:

--- a/pyiceberg/table/sorting.py
+++ b/pyiceberg/table/sorting.py
@@ -125,10 +125,8 @@ class SortField(IcebergBaseModel):
         # multi-argument transforms write only source-ids
         if self.source_ids is not None and len(self.source_ids) > 1:
             serialized.pop("source-id", None)
-            serialized.pop("source_id", None)
         else:
             serialized.pop("source-ids", None)
-            serialized.pop("source_ids", None)
         return serialized
 
     source_id: int = Field(alias="source-id")
@@ -147,8 +145,11 @@ class SortField(IcebergBaseModel):
         if isinstance(self.transform, IdentityTransform):
             # In the case of an identity transform, we can omit the transform
             return f"{self.source_id} {self.direction} {self.null_order}"
+        if self.source_ids is not None and len(self.source_ids) > 1:
+            sources = ", ".join(str(s) for s in self.source_ids)
         else:
-            return f"{self.transform}({self.source_id}) {self.direction} {self.null_order}"
+            sources = str(self.source_id)
+        return f"{self.transform}({sources}) {self.direction} {self.null_order}"
 
 
 INITIAL_SORT_ORDER_ID = 1

--- a/pyiceberg/table/sorting.py
+++ b/pyiceberg/table/sorting.py
@@ -108,9 +108,11 @@ class SortField(IcebergBaseModel):
                     if len(source_ids) == 0:
                         raise ValueError("Empty source-ids is not allowed")
                     if len(source_ids) > 1:
+                        if data.get("transform") is None:
+                            raise ValueError("Transform is required for a multi-argument field")
                         # Multi-argument transforms cannot be evaluated; per the spec, v3 readers
                         # must read tables with such transforms, ignoring them
-                        data["transform"] = UnknownTransform(transform=str(data.get("transform")))
+                        data["transform"] = UnknownTransform(transform=str(data["transform"]))
                     else:
                         data.pop("source-ids", None)
                     data["source-id"] = source_ids[0]

--- a/pyiceberg/table/sorting.py
+++ b/pyiceberg/table/sorting.py
@@ -24,12 +24,13 @@ from pydantic import (
     Field,
     PlainSerializer,
     WithJsonSchema,
+    model_serializer,
     model_validator,
 )
 
 from pyiceberg.exceptions import ValidationError
 from pyiceberg.schema import Schema
-from pyiceberg.transforms import IdentityTransform, Transform, parse_transform
+from pyiceberg.transforms import IdentityTransform, Transform, UnknownTransform, parse_transform
 from pyiceberg.typedef import IcebergBaseModel
 from pyiceberg.types import IcebergType
 
@@ -107,11 +108,29 @@ class SortField(IcebergBaseModel):
                     if len(source_ids) == 0:
                         raise ValueError("Empty source-ids is not allowed")
                     if len(source_ids) > 1:
-                        raise ValueError("Multi argument transforms are not yet supported")
+                        # Multi-argument transforms cannot be evaluated; per the spec, v3 readers
+                        # must read tables with such transforms, ignoring them
+                        data["transform"] = UnknownTransform(transform=str(data.get("transform")))
+                    else:
+                        data.pop("source-ids", None)
                     data["source-id"] = source_ids[0]
         return data
 
+    @model_serializer(mode="wrap")
+    def _serialize_source_ids(self, handler: Any) -> Any:
+        serialized = handler(self)
+        # Per the spec, single-argument transforms write only source-id and
+        # multi-argument transforms write only source-ids
+        if self.source_ids is not None and len(self.source_ids) > 1:
+            serialized.pop("source-id", None)
+            serialized.pop("source_id", None)
+        else:
+            serialized.pop("source-ids", None)
+            serialized.pop("source_ids", None)
+        return serialized
+
     source_id: int = Field(alias="source-id")
+    source_ids: list[int] | None = Field(alias="source-ids", default=None, repr=False)
     transform: Annotated[  # type: ignore
         Transform,
         BeforeValidator(parse_transform),

--- a/pyiceberg/table/sorting.py
+++ b/pyiceberg/table/sorting.py
@@ -24,13 +24,12 @@ from pydantic import (
     Field,
     PlainSerializer,
     WithJsonSchema,
-    model_serializer,
     model_validator,
 )
 
 from pyiceberg.exceptions import ValidationError
 from pyiceberg.schema import Schema
-from pyiceberg.transforms import IdentityTransform, Transform, UnknownTransform, parse_transform
+from pyiceberg.transforms import IdentityTransform, Transform, TransformSourceMixin, parse_transform
 from pyiceberg.typedef import IcebergBaseModel
 from pyiceberg.types import IcebergType
 
@@ -61,11 +60,12 @@ class NullOrder(Enum):
         return f"NullOrder.{self.name}"
 
 
-class SortField(IcebergBaseModel):
+class SortField(TransformSourceMixin):
     """Sort order field.
 
+    The source columns are carried by `TransformSourceMixin`.
+
     Args:
-      source_id (int): Source column id from the table’s schema.
       transform (str): Transform that is used to produce values to be sorted on from the source column.
                        This is the same transform as described in partition transforms.
       direction (SortDirection): Sort direction, that can only be either asc or desc.
@@ -98,41 +98,6 @@ class SortField(IcebergBaseModel):
             values["null-order"] = NullOrder.NULLS_FIRST if values["direction"] == SortDirection.ASC else NullOrder.NULLS_LAST
         return values
 
-    @model_validator(mode="before")
-    @classmethod
-    def map_source_ids_onto_source_id(cls, data: Any) -> Any:
-        if isinstance(data, dict):
-            if "source-ids" in data:
-                if "source-id" in data:
-                    raise ValueError("source-id and source-ids are mutually exclusive")
-                source_ids = data["source-ids"]
-                if isinstance(source_ids, list):
-                    if len(source_ids) == 0:
-                        raise ValueError("Empty source-ids is not allowed")
-                    if len(source_ids) > 1:
-                        if data.get("transform") is None:
-                            raise ValueError("Transform is required for a multi-argument field")
-                        # Multi-argument transforms cannot be evaluated; per the spec, v3 readers
-                        # must read tables with such transforms, ignoring them
-                        data["transform"] = UnknownTransform(transform=str(data["transform"]))
-                    else:
-                        data.pop("source-ids", None)
-                    data["source-id"] = source_ids[0]
-        return data
-
-    @model_serializer(mode="wrap")
-    def _serialize_source_ids(self, handler: Any) -> Any:
-        serialized = handler(self)
-        # Per the spec, single-argument transforms write only source-id and
-        # multi-argument transforms write only source-ids
-        if self.source_ids is not None and len(self.source_ids) > 1:
-            serialized.pop("source-id", None)
-        else:
-            serialized.pop("source-ids", None)
-        return serialized
-
-    source_id: int = Field(alias="source-id")
-    source_ids: list[int] | None = Field(alias="source-ids", default=None, repr=False)
     transform: Annotated[  # type: ignore
         Transform,
         BeforeValidator(parse_transform),
@@ -147,10 +112,7 @@ class SortField(IcebergBaseModel):
         if isinstance(self.transform, IdentityTransform):
             # In the case of an identity transform, we can omit the transform
             return f"{self.source_id} {self.direction} {self.null_order}"
-        if self.source_ids is not None and len(self.source_ids) > 1:
-            sources = ", ".join(str(s) for s in self.source_ids)
-        else:
-            sources = str(self.source_id)
+        sources = ", ".join(str(source_id) for source_id in self.transform_arguments)
         return f"{self.transform}({sources}) {self.direction} {self.null_order}"
 
 

--- a/pyiceberg/table/sorting.py
+++ b/pyiceberg/table/sorting.py
@@ -24,12 +24,13 @@ from pydantic import (
     Field,
     PlainSerializer,
     WithJsonSchema,
+    model_serializer,
     model_validator,
 )
 
 from pyiceberg.exceptions import ValidationError
 from pyiceberg.schema import Schema
-from pyiceberg.transforms import IdentityTransform, Transform, parse_transform
+from pyiceberg.transforms import IdentityTransform, Transform, UnknownTransform, parse_transform
 from pyiceberg.typedef import IcebergBaseModel
 from pyiceberg.types import IcebergType
 
@@ -109,11 +110,29 @@ class SortField(IcebergBaseModel):
                     if len(source_ids) == 0:
                         raise ValueError("Empty source-ids is not allowed")
                     if len(source_ids) > 1:
-                        raise ValueError("Multi argument transforms are not yet supported")
+                        # Multi-argument transforms cannot be evaluated; per the spec, v3 readers
+                        # must read tables with such transforms, ignoring them
+                        data["transform"] = UnknownTransform(transform=str(data.get("transform")))
+                    else:
+                        data.pop("source-ids", None)
                     data["source-id"] = source_ids[0]
         return data
 
+    @model_serializer(mode="wrap")
+    def _serialize_source_ids(self, handler: Any) -> Any:
+        serialized = handler(self)
+        # Per the spec, single-argument transforms write only source-id and
+        # multi-argument transforms write only source-ids
+        if self.source_ids is not None and len(self.source_ids) > 1:
+            serialized.pop("source-id", None)
+            serialized.pop("source_id", None)
+        else:
+            serialized.pop("source-ids", None)
+            serialized.pop("source_ids", None)
+        return serialized
+
     source_id: int = Field(alias="source-id")
+    source_ids: list[int] | None = Field(alias="source-ids", default=None, repr=False)
     transform: Annotated[  # type: ignore
         Transform,
         BeforeValidator(parse_transform),

--- a/pyiceberg/table/sorting.py
+++ b/pyiceberg/table/sorting.py
@@ -110,9 +110,11 @@ class SortField(IcebergBaseModel):
                     if len(source_ids) == 0:
                         raise ValueError("Empty source-ids is not allowed")
                     if len(source_ids) > 1:
+                        if data.get("transform") is None:
+                            raise ValueError("Transform is required for a multi-argument field")
                         # Multi-argument transforms cannot be evaluated; per the spec, v3 readers
                         # must read tables with such transforms, ignoring them
-                        data["transform"] = UnknownTransform(transform=str(data.get("transform")))
+                        data["transform"] = UnknownTransform(transform=str(data["transform"]))
                     else:
                         data.pop("source-ids", None)
                     data["source-id"] = source_ids[0]

--- a/pyiceberg/table/sorting.py
+++ b/pyiceberg/table/sorting.py
@@ -127,10 +127,8 @@ class SortField(IcebergBaseModel):
         # multi-argument transforms write only source-ids
         if self.source_ids is not None and len(self.source_ids) > 1:
             serialized.pop("source-id", None)
-            serialized.pop("source_id", None)
         else:
             serialized.pop("source-ids", None)
-            serialized.pop("source_ids", None)
         return serialized
 
     source_id: int = Field(alias="source-id")
@@ -149,8 +147,11 @@ class SortField(IcebergBaseModel):
         if isinstance(self.transform, IdentityTransform):
             # In the case of an identity transform, we can omit the transform
             return f"{self.source_id} {self.direction} {self.null_order}"
+        if self.source_ids is not None and len(self.source_ids) > 1:
+            sources = ", ".join(str(s) for s in self.source_ids)
         else:
-            return f"{self.transform}({self.source_id}) {self.direction} {self.null_order}"
+            sources = str(self.source_id)
+        return f"{self.transform}({sources}) {self.direction} {self.null_order}"
 
 
 INITIAL_SORT_ORDER_ID = 1

--- a/pyiceberg/transforms.py
+++ b/pyiceberg/transforms.py
@@ -29,7 +29,7 @@ from typing import Literal as LiteralType
 from uuid import UUID
 
 import mmh3
-from pydantic import Field, PositiveInt, PrivateAttr
+from pydantic import Field, PositiveInt, PrivateAttr, model_serializer, model_validator
 
 from pyiceberg.exceptions import NotInstalledError, ValidationError
 from pyiceberg.expressions import (
@@ -67,7 +67,7 @@ from pyiceberg.expressions.literals import (
     TimestampLiteral,
     literal,
 )
-from pyiceberg.typedef import IcebergRootModel, L
+from pyiceberg.typedef import IcebergBaseModel, IcebergRootModel, L
 from pyiceberg.types import (
     BinaryType,
     DateType,
@@ -1052,6 +1052,73 @@ class VoidTransform(Transform[S, None], Singleton):
             raise ModuleNotFoundError("For partition transforms, PyArrow needs to be installed") from e
 
         return lambda arr: pa.nulls(len(arr), type=arr.type)
+
+
+class TransformSourceMixin(IcebergBaseModel):
+    """Shared `source-id` and `source-ids` handling for fields that apply a transform to source columns.
+
+    Both partition fields and sort fields carry this pair, and the spec writes only one of the
+    two: `source-id` for a transform with a single argument, `source-ids` for a multi-argument
+    transform. This mixin owns reading, serializing and reporting them, so that neither field
+    type has to reach into the raw keys.
+
+    Attributes:
+        source_id(int): The source column id of the table's schema.
+        source_ids(list[int] | None): The source column ids of a multi-argument transform.
+    """
+
+    source_id: int = Field(alias="source-id")
+    source_ids: list[int] | None = Field(alias="source-ids", default=None, repr=False)
+
+    @property
+    def transform_arguments(self) -> list[int]:
+        """Return the source column ids that the transform is applied to."""
+        source_ids = self.source_ids
+        if source_ids is not None and len(source_ids) > 1:
+            return list(source_ids)
+        return [self.source_id]
+
+    @property
+    def is_multi_argument(self) -> bool:
+        """Return True if the transform takes more than one source column."""
+        return len(self.transform_arguments) > 1
+
+    @model_validator(mode="before")
+    @classmethod
+    def map_source_ids_onto_source_id(cls, data: Any) -> Any:
+        if not isinstance(data, dict) or "source-ids" not in data:
+            return data
+
+        source_ids = data["source-ids"]
+        if not isinstance(source_ids, list):
+            return data
+        if len(source_ids) == 0:
+            raise ValueError("Empty source-ids is not allowed")
+
+        # The spec writes only one of the two keys, so a source-id next to source-ids comes
+        # from a non-conformant writer; source-ids is the one that carries the arity
+        data["source-id"] = source_ids[0]
+        if len(source_ids) == 1:
+            data.pop("source-ids", None)
+            return data
+
+        if data.get("transform") is None:
+            raise ValueError("Transform is required for a multi-argument field")
+        # Multi-argument transforms cannot be evaluated; per the spec, v3 readers
+        # must read tables with such transforms, ignoring them
+        data["transform"] = UnknownTransform(transform=str(data["transform"]))
+        return data
+
+    @model_serializer(mode="wrap")
+    def _serialize_source_ids(self, handler: Any) -> Any:
+        serialized = handler(self)
+        # Per the spec, single-argument transforms write only source-id and
+        # multi-argument transforms write only source-ids
+        if self.is_multi_argument:
+            serialized.pop("source-id", None)
+        else:
+            serialized.pop("source-ids", None)
+        return serialized
 
 
 def _truncate_number(

--- a/pyiceberg/transforms.py
+++ b/pyiceberg/transforms.py
@@ -31,7 +31,7 @@ from uuid import UUID
 import mmh3
 from pydantic import Field, PositiveInt, PrivateAttr
 
-from pyiceberg.exceptions import NotInstalledError
+from pyiceberg.exceptions import NotInstalledError, ValidationError
 from pyiceberg.expressions import (
     BoundEqualTo,
     BoundGreaterThan,
@@ -226,9 +226,15 @@ def parse_transform(v: Any) -> Transform[Any, Any]:
         elif v == VOID:
             return VoidTransform()
         elif v.startswith(BUCKET):
-            return BucketTransform(num_buckets=BUCKET_PARSER.match(v))
+            try:
+                return BucketTransform(num_buckets=BUCKET_PARSER.match(v))
+            except ValidationError:
+                return UnknownTransform(transform=v)
         elif v.startswith(TRUNCATE):
-            return TruncateTransform(width=TRUNCATE_PARSER.match(v))
+            try:
+                return TruncateTransform(width=TRUNCATE_PARSER.match(v))
+            except ValidationError:
+                return UnknownTransform(transform=v)
         elif v == YEAR:
             return YearTransform()
         elif v == MONTH:
@@ -1000,6 +1006,10 @@ class UnknownTransform(Transform[S, T]):
 
     def strict_project(self, name: str, pred: BoundPredicate) -> UnboundPredicate | None:
         return None
+
+    def __str__(self) -> str:
+        """Return the original transform name so it round-trips through serialization."""
+        return self._transform
 
     def __repr__(self) -> str:
         """Return the string representation of the UnknownTransform class."""

--- a/pyiceberg/transforms.py
+++ b/pyiceberg/transforms.py
@@ -31,7 +31,7 @@ from uuid import UUID
 import mmh3
 from pydantic import Field, PositiveInt, PrivateAttr
 
-from pyiceberg.exceptions import NotInstalledError
+from pyiceberg.exceptions import NotInstalledError, ValidationError
 from pyiceberg.expressions import (
     BoundEqualTo,
     BoundGreaterThan,
@@ -226,9 +226,15 @@ def parse_transform(v: Any) -> Transform[Any, Any]:
         elif v == VOID:
             return VoidTransform()
         elif v.startswith(BUCKET):
-            return BucketTransform(num_buckets=BUCKET_PARSER.match(v))
+            try:
+                return BucketTransform(num_buckets=BUCKET_PARSER.match(v))
+            except ValidationError:
+                return UnknownTransform(transform=v)
         elif v.startswith(TRUNCATE):
-            return TruncateTransform(width=TRUNCATE_PARSER.match(v))
+            try:
+                return TruncateTransform(width=TRUNCATE_PARSER.match(v))
+            except ValidationError:
+                return UnknownTransform(transform=v)
         elif v == YEAR:
             return YearTransform()
         elif v == MONTH:
@@ -999,6 +1005,10 @@ class UnknownTransform(Transform[S, T]):
 
     def strict_project(self, name: str, pred: BoundPredicate) -> UnboundPredicate | None:
         return None
+
+    def __str__(self) -> str:
+        """Return the original transform name so it round-trips through serialization."""
+        return self._transform
 
     def __repr__(self) -> str:
         """Return the string representation of the UnknownTransform class."""

--- a/pyiceberg/transforms.py
+++ b/pyiceberg/transforms.py
@@ -1014,6 +1014,16 @@ class UnknownTransform(Transform[S, T]):
         """Return the string representation of the UnknownTransform class."""
         return f"UnknownTransform(transform={repr(self._transform)})"
 
+    def __eq__(self, other: Any) -> bool:
+        """Compare the preserved transform name, since every unknown transform shares one root value."""
+        if isinstance(other, UnknownTransform):
+            return self._transform == other._transform
+        return False
+
+    def __hash__(self) -> int:
+        """Hash the preserved transform name so distinct unknown transforms do not collide."""
+        return hash((self.root, self._transform))
+
     def pyarrow_transform(self, source: IcebergType) -> "Callable[[pa.Array], pa.Array]":
         raise NotImplementedError()
 

--- a/pyiceberg/transforms.py
+++ b/pyiceberg/transforms.py
@@ -1099,14 +1099,15 @@ class TransformSourceMixin(IcebergBaseModel):
         if not isinstance(data, dict) or "source-ids" not in data:
             return data
 
+        if "source-id" in data:
+            raise ValueError("source-id and source-ids are mutually exclusive")
+
         source_ids = data["source-ids"]
         if not isinstance(source_ids, list):
             return data
         if len(source_ids) == 0:
             raise ValueError("Empty source-ids is not allowed")
 
-        # The spec writes only one of the two keys, so a source-id next to source-ids comes
-        # from a non-conformant writer; source-ids is the one that carries the arity
         data["source-id"] = source_ids[0]
         if len(source_ids) == 1:
             data.pop("source-ids", None)

--- a/pyiceberg/utils/parsing.py
+++ b/pyiceberg/utils/parsing.py
@@ -28,7 +28,8 @@ class ParseNumberFromBrackets:
 
     def __init__(self, prefix: str):
         self.prefix = prefix
-        self.regex = re.compile(rf"{prefix}\[(\d+)\]")
+        # anchored: a name such as truncate[8]v2 is a different transform, not truncate[8]
+        self.regex = re.compile(rf"^{prefix}\[(\d+)\]$")
 
     def match(self, str_repr: str) -> int:
         matches = self.regex.search(str_repr)

--- a/tests/table/test_partitioning.py
+++ b/tests/table/test_partitioning.py
@@ -292,6 +292,8 @@ def test_deserialize_partition_field_multi_arg() -> None:
     assert "source-id" not in serialized
     assert serialized["transform"] == "bucket[4]"
 
+    assert str(field) == "1000: multi_bucket: bucket[4](1, 2)"
+
 
 def test_serialize_partition_field_single_source_id_only() -> None:
     import json as json_lib

--- a/tests/table/test_partitioning.py
+++ b/tests/table/test_partitioning.py
@@ -273,6 +273,48 @@ def test_deserialize_partition_field_empty_source_ids_rejected() -> None:
         PartitionField.model_validate_json(json_partition_spec)
 
 
+def test_deserialize_partition_field_multi_arg() -> None:
+    import json as json_lib
+
+    from pyiceberg.transforms import UnknownTransform
+
+    json_partition_spec = """{"source-ids": [1, 2], "field-id": 1000, "transform": "bucket[4]", "name": "multi_bucket"}"""
+    field = PartitionField.model_validate_json(json_partition_spec)
+
+    # v3 readers must read tables with multi-argument transforms, treating them as unknown
+    assert isinstance(field.transform, UnknownTransform)
+    assert field.source_id == 1
+    assert field.source_ids == [1, 2]
+
+    # the field must round-trip: source-ids only, with the original transform name
+    serialized = json_lib.loads(field.model_dump_json())
+    assert serialized["source-ids"] == [1, 2]
+    assert "source-id" not in serialized
+    assert serialized["transform"] == "bucket[4]"
+
+
+def test_serialize_partition_field_single_source_id_only() -> None:
+    import json as json_lib
+
+    json_partition_spec = """{"source-ids": [1], "field-id": 1000, "transform": "truncate[19]", "name": "str_truncate"}"""
+    field = PartitionField.model_validate_json(json_partition_spec)
+    serialized = json_lib.loads(field.model_dump_json())
+    assert serialized["source-id"] == 1
+    assert "source-ids" not in serialized
+
+
+def test_partition_type_with_multi_arg_field() -> None:
+    from pyiceberg.types import StringType
+
+    schema = Schema(NestedField(1, "a", IntegerType()), NestedField(2, "b", IntegerType()))
+    field = PartitionField.model_validate_json(
+        """{"source-ids": [1, 2], "field-id": 1000, "transform": "bucket[4]", "name": "m"}"""
+    )
+    spec = PartitionSpec(field)
+    struct = spec.partition_type(schema)
+    assert struct.fields[0].field_type == StringType()
+
+
 def test_incompatible_source_column_not_found() -> None:
     schema = Schema(NestedField(1, "foo", IntegerType()), NestedField(2, "bar", IntegerType()))
 

--- a/tests/table/test_partitioning.py
+++ b/tests/table/test_partitioning.py
@@ -301,6 +301,8 @@ def test_serialize_partition_field_single_source_id_only() -> None:
     serialized = json_lib.loads(field.model_dump_json())
     assert serialized["source-id"] == 1
     assert "source-ids" not in serialized
+    # a single-element source-ids is normalized onto source-id
+    assert field.source_ids is None
 
 
 def test_partition_type_with_multi_arg_field() -> None:
@@ -346,3 +348,9 @@ def test_incompatible_transform_source_type() -> None:
         spec.check_compatible(schema)
 
     assert "Invalid source field foo with type int for transform: year" in str(exc.value)
+
+
+def test_deserialize_partition_field_multi_arg_requires_transform() -> None:
+    json_partition_spec = """{"source-ids": [1, 2], "field-id": 1000, "name": "m"}"""
+    with pytest.raises(Exception, match="Transform is required for a multi-argument field"):
+        PartitionField.model_validate_json(json_partition_spec)

--- a/tests/table/test_partitioning.py
+++ b/tests/table/test_partitioning.py
@@ -389,48 +389,6 @@ def test_deserialize_partition_field_multi_arg_requires_transform() -> None:
         PartitionField.model_validate_json(json_partition_spec)
 
 
-def test_deserialize_partition_field_both_source_id_and_source_ids_multi_arg() -> None:
-    import json as json_lib
-
-    from pyiceberg.transforms import UnknownTransform
-
-    # a non-conformant writer emitted both keys; source-ids carries the arity, so it wins
-    json_partition_spec = (
-        """{"source-id": 9, "source-ids": [1, 2], "field-id": 1000, "transform": "bucket[4]", "name": "multi_bucket"}"""
-    )
-    field = PartitionField.model_validate_json(json_partition_spec)
-
-    assert isinstance(field.transform, UnknownTransform)
-    assert field.source_id == 1
-    assert field.source_ids == [1, 2]
-
-    serialized = json_lib.loads(field.model_dump_json())
-    assert serialized["source-ids"] == [1, 2]
-    assert "source-id" not in serialized
-
-
-def test_deserialize_partition_field_both_source_id_and_source_ids_single_arg() -> None:
-    import json as json_lib
-
-    json_partition_spec = (
-        """{"source-id": 9, "source-ids": [1], "field-id": 1000, "transform": "truncate[19]", "name": "str_truncate"}"""
-    )
-    field = PartitionField.model_validate_json(json_partition_spec)
-
-    assert field.source_id == 1
-    assert field.source_ids is None
-
-    serialized = json_lib.loads(field.model_dump_json())
-    assert serialized["source-id"] == 1
-    assert "source-ids" not in serialized
-
-
-def test_deserialize_partition_field_empty_source_ids_rejected_next_to_source_id() -> None:
-    json_partition_spec = """{"source-id": 1, "source-ids": [], "field-id": 1000, "transform": "identity", "name": "x"}"""
-    with pytest.raises(Exception, match="Empty source-ids is not allowed"):
-        PartitionField.model_validate_json(json_partition_spec)
-
-
 def test_partition_field_transform_arguments() -> None:
     single = PartitionField(source_id=1, field_id=1000, transform=TruncateTransform(width=19), name="str_truncate")
     assert single.transform_arguments == [1]

--- a/tests/table/test_partitioning.py
+++ b/tests/table/test_partitioning.py
@@ -105,6 +105,31 @@ def test_partition_compatible_with() -> None:
     assert not lhs.compatible_with(rhs)
 
 
+def test_partition_compatible_with_compares_every_source_id() -> None:
+    # multi-argument fields differ in their later source ids, which the first one cannot show
+    lhs = PartitionSpec.model_validate(
+        {"spec-id": 0, "fields": [{"field-id": 1000, "name": "p", "source-ids": [1, 2], "transform": "zorder(a,b)"}]}
+    )
+    rhs = PartitionSpec.model_validate(
+        {"spec-id": 0, "fields": [{"field-id": 1000, "name": "p", "source-ids": [1, 3], "transform": "zorder(a,c)"}]}
+    )
+
+    assert not lhs.compatible_with(rhs)
+    assert lhs.compatible_with(lhs)
+
+
+def test_partition_compatible_with_compares_unknown_transform_names() -> None:
+    # same source ids, different transform: the names are all that separates them
+    lhs = PartitionSpec.model_validate(
+        {"spec-id": 0, "fields": [{"field-id": 1000, "name": "p", "source-ids": [1, 2], "transform": "zorder(a,b)"}]}
+    )
+    rhs = PartitionSpec.model_validate(
+        {"spec-id": 0, "fields": [{"field-id": 1000, "name": "p", "source-ids": [1, 2], "transform": "somethingelse(a,b)"}]}
+    )
+
+    assert not lhs.compatible_with(rhs)
+
+
 def test_unpartitioned() -> None:
     assert len(UNPARTITIONED_PARTITION_SPEC.fields) == 0
     assert UNPARTITIONED_PARTITION_SPEC.is_unpartitioned()

--- a/tests/table/test_partitioning.py
+++ b/tests/table/test_partitioning.py
@@ -298,6 +298,8 @@ def test_deserialize_partition_field_multi_arg() -> None:
     assert "source-id" not in serialized
     assert serialized["transform"] == "bucket[4]"
 
+    assert str(field) == "1000: multi_bucket: bucket[4](1, 2)"
+
 
 def test_serialize_partition_field_single_source_id_only() -> None:
     import json as json_lib

--- a/tests/table/test_partitioning.py
+++ b/tests/table/test_partitioning.py
@@ -279,6 +279,48 @@ def test_deserialize_partition_field_source_id_and_source_ids_rejected() -> None
         PartitionField.model_validate_json(json_partition_spec)
 
 
+def test_deserialize_partition_field_multi_arg() -> None:
+    import json as json_lib
+
+    from pyiceberg.transforms import UnknownTransform
+
+    json_partition_spec = """{"source-ids": [1, 2], "field-id": 1000, "transform": "bucket[4]", "name": "multi_bucket"}"""
+    field = PartitionField.model_validate_json(json_partition_spec)
+
+    # v3 readers must read tables with multi-argument transforms, treating them as unknown
+    assert isinstance(field.transform, UnknownTransform)
+    assert field.source_id == 1
+    assert field.source_ids == [1, 2]
+
+    # the field must round-trip: source-ids only, with the original transform name
+    serialized = json_lib.loads(field.model_dump_json())
+    assert serialized["source-ids"] == [1, 2]
+    assert "source-id" not in serialized
+    assert serialized["transform"] == "bucket[4]"
+
+
+def test_serialize_partition_field_single_source_id_only() -> None:
+    import json as json_lib
+
+    json_partition_spec = """{"source-ids": [1], "field-id": 1000, "transform": "truncate[19]", "name": "str_truncate"}"""
+    field = PartitionField.model_validate_json(json_partition_spec)
+    serialized = json_lib.loads(field.model_dump_json())
+    assert serialized["source-id"] == 1
+    assert "source-ids" not in serialized
+
+
+def test_partition_type_with_multi_arg_field() -> None:
+    from pyiceberg.types import StringType
+
+    schema = Schema(NestedField(1, "a", IntegerType()), NestedField(2, "b", IntegerType()))
+    field = PartitionField.model_validate_json(
+        """{"source-ids": [1, 2], "field-id": 1000, "transform": "bucket[4]", "name": "m"}"""
+    )
+    spec = PartitionSpec(field)
+    struct = spec.partition_type(schema)
+    assert struct.fields[0].field_type == StringType()
+
+
 def test_incompatible_source_column_not_found() -> None:
     schema = Schema(NestedField(1, "foo", IntegerType()), NestedField(2, "bar", IntegerType()))
 

--- a/tests/table/test_partitioning.py
+++ b/tests/table/test_partitioning.py
@@ -307,6 +307,8 @@ def test_serialize_partition_field_single_source_id_only() -> None:
     serialized = json_lib.loads(field.model_dump_json())
     assert serialized["source-id"] == 1
     assert "source-ids" not in serialized
+    # a single-element source-ids is normalized onto source-id
+    assert field.source_ids is None
 
 
 def test_partition_type_with_multi_arg_field() -> None:
@@ -352,3 +354,9 @@ def test_incompatible_transform_source_type() -> None:
         spec.check_compatible(schema)
 
     assert "Invalid source field foo with type int for transform: year" in str(exc.value)
+
+
+def test_deserialize_partition_field_multi_arg_requires_transform() -> None:
+    json_partition_spec = """{"source-ids": [1, 2], "field-id": 1000, "name": "m"}"""
+    with pytest.raises(Exception, match="Transform is required for a multi-argument field"):
+        PartitionField.model_validate_json(json_partition_spec)

--- a/tests/table/test_partitioning.py
+++ b/tests/table/test_partitioning.py
@@ -362,3 +362,57 @@ def test_deserialize_partition_field_multi_arg_requires_transform() -> None:
     json_partition_spec = """{"source-ids": [1, 2], "field-id": 1000, "name": "m"}"""
     with pytest.raises(Exception, match="Transform is required for a multi-argument field"):
         PartitionField.model_validate_json(json_partition_spec)
+
+
+def test_deserialize_partition_field_both_source_id_and_source_ids_multi_arg() -> None:
+    import json as json_lib
+
+    from pyiceberg.transforms import UnknownTransform
+
+    # a non-conformant writer emitted both keys; source-ids carries the arity, so it wins
+    json_partition_spec = (
+        """{"source-id": 9, "source-ids": [1, 2], "field-id": 1000, "transform": "bucket[4]", "name": "multi_bucket"}"""
+    )
+    field = PartitionField.model_validate_json(json_partition_spec)
+
+    assert isinstance(field.transform, UnknownTransform)
+    assert field.source_id == 1
+    assert field.source_ids == [1, 2]
+
+    serialized = json_lib.loads(field.model_dump_json())
+    assert serialized["source-ids"] == [1, 2]
+    assert "source-id" not in serialized
+
+
+def test_deserialize_partition_field_both_source_id_and_source_ids_single_arg() -> None:
+    import json as json_lib
+
+    json_partition_spec = (
+        """{"source-id": 9, "source-ids": [1], "field-id": 1000, "transform": "truncate[19]", "name": "str_truncate"}"""
+    )
+    field = PartitionField.model_validate_json(json_partition_spec)
+
+    assert field.source_id == 1
+    assert field.source_ids is None
+
+    serialized = json_lib.loads(field.model_dump_json())
+    assert serialized["source-id"] == 1
+    assert "source-ids" not in serialized
+
+
+def test_deserialize_partition_field_empty_source_ids_rejected_next_to_source_id() -> None:
+    json_partition_spec = """{"source-id": 1, "source-ids": [], "field-id": 1000, "transform": "identity", "name": "x"}"""
+    with pytest.raises(Exception, match="Empty source-ids is not allowed"):
+        PartitionField.model_validate_json(json_partition_spec)
+
+
+def test_partition_field_transform_arguments() -> None:
+    single = PartitionField(source_id=1, field_id=1000, transform=TruncateTransform(width=19), name="str_truncate")
+    assert single.transform_arguments == [1]
+    assert single.is_multi_argument is False
+
+    multi = PartitionField.model_validate_json(
+        """{"source-ids": [1, 2], "field-id": 1000, "transform": "bucket[4]", "name": "m"}"""
+    )
+    assert multi.transform_arguments == [1, 2]
+    assert multi.is_multi_argument is True

--- a/tests/table/test_sorting.py
+++ b/tests/table/test_sorting.py
@@ -192,3 +192,9 @@ def test_deserialize_sort_field_multi_arg() -> None:
     assert serialized["source-ids"] == [19, 20]
     assert "source-id" not in serialized
     assert serialized["transform"] == "bucket[4]"
+
+
+def test_deserialize_sort_field_multi_arg_requires_transform() -> None:
+    payload = '{"source-ids":[19,20],"direction":"asc","null-order":"nulls-first"}'
+    with pytest.raises(Exception, match="Transform is required for a multi-argument field"):
+        SortField.model_validate_json(payload)

--- a/tests/table/test_sorting.py
+++ b/tests/table/test_sorting.py
@@ -193,6 +193,8 @@ def test_deserialize_sort_field_multi_arg() -> None:
     assert "source-id" not in serialized
     assert serialized["transform"] == "bucket[4]"
 
+    assert str(field) == "bucket[4](19, 20) ASC NULLS FIRST"
+
 
 def test_deserialize_sort_field_multi_arg_requires_transform() -> None:
     payload = '{"source-ids":[19,20],"direction":"asc","null-order":"nulls-first"}'

--- a/tests/table/test_sorting.py
+++ b/tests/table/test_sorting.py
@@ -175,3 +175,20 @@ def test_incompatible_transform_source_type() -> None:
         sort_order.check_compatible(schema)
 
     assert "Invalid source field foo with type int for transform: year" in str(exc.value)
+
+
+def test_deserialize_sort_field_multi_arg() -> None:
+    from pyiceberg.transforms import UnknownTransform
+
+    payload = '{"source-ids":[19,20],"transform":"bucket[4]","direction":"asc","null-order":"nulls-first"}'
+    field = SortField.model_validate_json(payload)
+
+    # v3 readers must read tables with multi-argument transforms, treating them as unknown
+    assert isinstance(field.transform, UnknownTransform)
+    assert field.source_id == 19
+    assert field.source_ids == [19, 20]
+
+    serialized = json.loads(field.model_dump_json())
+    assert serialized["source-ids"] == [19, 20]
+    assert "source-id" not in serialized
+    assert serialized["transform"] == "bucket[4]"

--- a/tests/table/test_sorting.py
+++ b/tests/table/test_sorting.py
@@ -198,3 +198,9 @@ def test_deserialize_sort_field_multi_arg() -> None:
     assert serialized["source-ids"] == [19, 20]
     assert "source-id" not in serialized
     assert serialized["transform"] == "bucket[4]"
+
+
+def test_deserialize_sort_field_multi_arg_requires_transform() -> None:
+    payload = '{"source-ids":[19,20],"direction":"asc","null-order":"nulls-first"}'
+    with pytest.raises(Exception, match="Transform is required for a multi-argument field"):
+        SortField.model_validate_json(payload)

--- a/tests/table/test_sorting.py
+++ b/tests/table/test_sorting.py
@@ -206,3 +206,43 @@ def test_deserialize_sort_field_multi_arg_requires_transform() -> None:
     payload = '{"source-ids":[19,20],"direction":"asc","null-order":"nulls-first"}'
     with pytest.raises(Exception, match="Transform is required for a multi-argument field"):
         SortField.model_validate_json(payload)
+
+
+def test_deserialize_sort_field_both_source_id_and_source_ids_multi_arg() -> None:
+    from pyiceberg.transforms import UnknownTransform
+
+    # a non-conformant writer emitted both keys; source-ids carries the arity, so it wins
+    payload = '{"source-id":9,"source-ids":[19,20],"transform":"bucket[4]","direction":"asc","null-order":"nulls-first"}'
+    field = SortField.model_validate_json(payload)
+
+    assert isinstance(field.transform, UnknownTransform)
+    assert field.source_id == 19
+    assert field.source_ids == [19, 20]
+
+    serialized = json.loads(field.model_dump_json())
+    assert serialized["source-ids"] == [19, 20]
+    assert "source-id" not in serialized
+
+
+def test_deserialize_sort_field_both_source_id_and_source_ids_single_arg() -> None:
+    payload = '{"source-id":9,"source-ids":[19],"transform":"identity","direction":"asc","null-order":"nulls-first"}'
+    field = SortField.model_validate_json(payload)
+
+    assert field.source_id == 19
+    assert field.source_ids is None
+
+    serialized = json.loads(field.model_dump_json())
+    assert serialized["source-id"] == 19
+    assert "source-ids" not in serialized
+
+
+def test_sort_field_transform_arguments() -> None:
+    single = SortField(source_id=19, transform=BucketTransform(num_buckets=4), null_order=NullOrder.NULLS_FIRST)
+    assert single.transform_arguments == [19]
+    assert single.is_multi_argument is False
+
+    multi = SortField.model_validate_json(
+        '{"source-ids":[19,20],"transform":"bucket[4]","direction":"asc","null-order":"nulls-first"}'
+    )
+    assert multi.transform_arguments == [19, 20]
+    assert multi.is_multi_argument is True

--- a/tests/table/test_sorting.py
+++ b/tests/table/test_sorting.py
@@ -199,6 +199,8 @@ def test_deserialize_sort_field_multi_arg() -> None:
     assert "source-id" not in serialized
     assert serialized["transform"] == "bucket[4]"
 
+    assert str(field) == "bucket[4](19, 20) ASC NULLS FIRST"
+
 
 def test_deserialize_sort_field_multi_arg_requires_transform() -> None:
     payload = '{"source-ids":[19,20],"direction":"asc","null-order":"nulls-first"}'

--- a/tests/table/test_sorting.py
+++ b/tests/table/test_sorting.py
@@ -181,3 +181,20 @@ def test_incompatible_transform_source_type() -> None:
         sort_order.check_compatible(schema)
 
     assert "Invalid source field foo with type int for transform: year" in str(exc.value)
+
+
+def test_deserialize_sort_field_multi_arg() -> None:
+    from pyiceberg.transforms import UnknownTransform
+
+    payload = '{"source-ids":[19,20],"transform":"bucket[4]","direction":"asc","null-order":"nulls-first"}'
+    field = SortField.model_validate_json(payload)
+
+    # v3 readers must read tables with multi-argument transforms, treating them as unknown
+    assert isinstance(field.transform, UnknownTransform)
+    assert field.source_id == 19
+    assert field.source_ids == [19, 20]
+
+    serialized = json.loads(field.model_dump_json())
+    assert serialized["source-ids"] == [19, 20]
+    assert "source-id" not in serialized
+    assert serialized["transform"] == "bucket[4]"

--- a/tests/table/test_sorting.py
+++ b/tests/table/test_sorting.py
@@ -208,34 +208,6 @@ def test_deserialize_sort_field_multi_arg_requires_transform() -> None:
         SortField.model_validate_json(payload)
 
 
-def test_deserialize_sort_field_both_source_id_and_source_ids_multi_arg() -> None:
-    from pyiceberg.transforms import UnknownTransform
-
-    # a non-conformant writer emitted both keys; source-ids carries the arity, so it wins
-    payload = '{"source-id":9,"source-ids":[19,20],"transform":"bucket[4]","direction":"asc","null-order":"nulls-first"}'
-    field = SortField.model_validate_json(payload)
-
-    assert isinstance(field.transform, UnknownTransform)
-    assert field.source_id == 19
-    assert field.source_ids == [19, 20]
-
-    serialized = json.loads(field.model_dump_json())
-    assert serialized["source-ids"] == [19, 20]
-    assert "source-id" not in serialized
-
-
-def test_deserialize_sort_field_both_source_id_and_source_ids_single_arg() -> None:
-    payload = '{"source-id":9,"source-ids":[19],"transform":"identity","direction":"asc","null-order":"nulls-first"}'
-    field = SortField.model_validate_json(payload)
-
-    assert field.source_id == 19
-    assert field.source_ids is None
-
-    serialized = json.loads(field.model_dump_json())
-    assert serialized["source-id"] == 19
-    assert "source-ids" not in serialized
-
-
 def test_sort_field_transform_arguments() -> None:
     single = SortField(source_id=19, transform=BucketTransform(num_buckets=4), null_order=NullOrder.NULLS_FIRST)
     assert single.transform_arguments == [19]

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -574,6 +574,22 @@ def test_unknown_transform_str() -> None:
     assert str(UnknownTransform("unknown")) == "unknown"
 
 
+def test_unknown_transform_str_preserves_original_name() -> None:
+    # serializing metadata with an unknown transform must not rewrite its name
+    assert str(UnknownTransform("zorder")) == "zorder"
+    assert str(UnknownTransform("bucketv2[4]")) == "bucketv2[4]"
+
+
+def test_parse_transform_unknown_with_known_prefix() -> None:
+    # unknown transforms that share a prefix with known ones must not fail parsing
+    from pyiceberg.transforms import parse_transform
+
+    for name in ("bucketv2[4]", "truncatev2[8]", "bucket", "truncate[x]"):
+        transform = parse_transform(name)
+        assert isinstance(transform, UnknownTransform), name
+        assert str(transform) == name
+
+
 def test_unknown_transform_repr() -> None:
     assert repr(UnknownTransform("unknown")) == "UnknownTransform(transform='unknown')"
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -575,6 +575,22 @@ def test_unknown_transform_str() -> None:
     assert str(UnknownTransform("unknown")) == "unknown"
 
 
+def test_unknown_transform_str_preserves_original_name() -> None:
+    # serializing metadata with an unknown transform must not rewrite its name
+    assert str(UnknownTransform("zorder")) == "zorder"
+    assert str(UnknownTransform("bucketv2[4]")) == "bucketv2[4]"
+
+
+def test_parse_transform_unknown_with_known_prefix() -> None:
+    # unknown transforms that share a prefix with known ones must not fail parsing
+    from pyiceberg.transforms import parse_transform
+
+    for name in ("bucketv2[4]", "truncatev2[8]", "bucket", "truncate[x]"):
+        transform = parse_transform(name)
+        assert isinstance(transform, UnknownTransform), name
+        assert str(transform) == name
+
+
 def test_unknown_transform_repr() -> None:
     assert repr(UnknownTransform("unknown")) == "UnknownTransform(transform='unknown')"
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -591,6 +591,24 @@ def test_parse_transform_unknown_with_known_prefix() -> None:
         assert str(transform) == name
 
 
+def test_parse_transform_rejects_trailing_text_after_brackets() -> None:
+    # a name that merely starts with a known transform is a different transform, so it has to be
+    # preserved rather than silently rewritten to the known one
+    from pyiceberg.transforms import parse_transform
+
+    for name in ("bucket[4]garbage", "truncate[8]v2"):
+        transform = parse_transform(name)
+        assert isinstance(transform, UnknownTransform), name
+        assert str(transform) == name
+
+
+def test_unknown_transforms_compare_by_name() -> None:
+    # every unknown transform shares the same root value, so equality has to use the preserved name
+    assert UnknownTransform("zorder(x,y)") == UnknownTransform("zorder(x,y)")
+    assert UnknownTransform("zorder(x,y)") != UnknownTransform("bucketv2[4]")
+    assert len({UnknownTransform("zorder(x,y)"), UnknownTransform("bucketv2[4]")}) == 2
+
+
 def test_unknown_transform_repr() -> None:
     assert repr(UnknownTransform("unknown")) == "UnknownTransform(transform='unknown')"
 


### PR DESCRIPTION
Closes #3628 (part of #1818)

# Rationale for this change

The V3 spec requires readers to read tables with unknown transforms, ignoring them. PyIceberg raised (`Multi argument transforms are not yet supported`) on partition or sort fields with more than one entry in `source-ids`, so loading such tables failed entirely.

- Model `source-ids` on `PartitionField` / `SortField` and treat multi-argument transforms as `UnknownTransform`, which already gives the spec behavior (no partition pruning: `project` returns None).
- Serialize per spec: `source-id` only for single-argument transforms, `source-ids` only for multi-argument ones, so specs round-trip faithfully instead of being silently rewritten on the next commit.
- Fix two latent tolerance bugs found along the way: unknown transform names sharing a prefix with known ones (e.g. `bucketv2[4]`) failed parsing instead of becoming `UnknownTransform`, and `str(UnknownTransform)` returned `"unknown"` instead of the original name, corrupting the transform name when metadata is rewritten.

Evaluating multi-argument transforms on write stays out of scope until the spec defines concrete ones.

Note on other implementations: none currently satisfies the spec's tolerance requirement in full. Java has not implemented `source-ids` (its parser requires `source-id`), though its transform parsing already matches names exactly and `UnknownTransform.toString()` preserves the original name — the two tolerance fixes here align PyIceberg with that behavior. iceberg-rust and iceberg-cpp reject unrecognized transform names outright. The `source-ids` handling here follows the spec text directly (partition/sort field JSON: single-argument transforms write only `source-id`, multi-argument only `source-ids`).

## Are these changes tested?

Yes: eight new tests covering multi-argument parse tolerance (partition and sort), round-trip serialization (`source-ids` preserved, `source-id` omitted, transform name intact), single-element normalization, `partition_type` resolution, prefix-colliding unknown transform names, and `str(UnknownTransform)` name preservation. All fail without the fix. No new failures in `tests/table`, `tests/catalog`, `tests/utils`.

## Are there any user-facing changes?

Yes: tables using multi-argument transforms now load and scan (without pruning on those fields) instead of raising.

This pull request and its description were written by Claude Fable 5.
