### PR TITLE
fix: correct class name in Long{AboveMax,BelowMin} type-change error

### DIFF
--- a/pyiceberg/expressions/literals.py
+++ b/pyiceberg/expressions/literals.py
@@ -251,7 +251,7 @@ class LongAboveMax(AboveMax[int], Singleton):
 
     @singledispatchmethod
     def to(self, type_var: IcebergType) -> Literal:  # type: ignore
-        raise TypeError("Cannot change the type of IntAboveMax")
+        raise TypeError("Cannot change the type of LongAboveMax")
 
     @to.register(LongType)
     def _(self, _: LongType) -> Literal[int]:
@@ -264,7 +264,7 @@ class LongBelowMin(BelowMin[int], Singleton):
 
     @singledispatchmethod
     def to(self, type_var: IcebergType) -> Literal:  # type: ignore
-        raise TypeError("Cannot change the type of IntBelowMin")
+        raise TypeError("Cannot change the type of LongBelowMin")
 
     @to.register(LongType)
     def _(self, _: LongType) -> Literal[int]:

--- a/tests/expressions/test_literals.py
+++ b/tests/expressions/test_literals.py
@@ -633,6 +633,20 @@ def test_below_min_int() -> None:
     assert b.to(IntegerType()) == IntBelowMin()
 
 
+def test_above_max_long() -> None:
+    a = LongAboveMax()
+    with pytest.raises(TypeError) as e:
+        a.to(IntegerType())
+    assert "Cannot change the type of LongAboveMax" in str(e.value)
+
+
+def test_below_min_long() -> None:
+    b = LongBelowMin()
+    with pytest.raises(TypeError) as e:
+        b.to(IntegerType())
+    assert "Cannot change the type of LongBelowMin" in str(e.value)
+
+
 def test_invalid_boolean_conversions() -> None:
     assert_invalid_conversions(
         literal(True),

--- a/tests/expressions/test_literals.py
+++ b/tests/expressions/test_literals.py
@@ -633,17 +633,15 @@ def test_below_min_int() -> None:
     assert b.to(IntegerType()) == IntBelowMin()
 
 
-def test_above_max_long() -> None:
-    a = LongAboveMax()
+def test_long_above_max_to_error() -> None:
     with pytest.raises(TypeError) as e:
-        a.to(IntegerType())
+        LongAboveMax().to(IntegerType())
     assert "Cannot change the type of LongAboveMax" in str(e.value)
 
 
-def test_below_min_long() -> None:
-    b = LongBelowMin()
+def test_long_below_min_to_error() -> None:
     with pytest.raises(TypeError) as e:
-        b.to(IntegerType())
+        LongBelowMin().to(IntegerType())
     assert "Cannot change the type of LongBelowMin" in str(e.value)
 
 


### PR DESCRIPTION

# Rationale for this change

`LongAboveMax.to()` and `LongBelowMin.to()` fall back to
`raise TypeError("Cannot change the type of ...")` when asked to convert to an
unsupported type, but the class name in each message was left as `IntAboveMax` /
`IntBelowMin`, a copy-paste leftover from the `IntAboveMax` / `IntBelowMin`
singletons defined just above. So when a long overflow sentinel is converted to
an unsupported type, the diagnostic misidentifies it as an int literal, which is
misleading when debugging.

For comparison, the neighbouring sentinels already name themselves correctly:
`FloatAboveMax` / `FloatBelowMin`, `IntAboveMax` / `IntBelowMin`. Only the two
`Long*` messages are wrong.

This is the same class of copy-paste-from-the-`Int`-handler slip that
`DecimalLiteral.to(LongType)` had in #3469 (fixed by #3470, which corrected the
returned sentinel *object*); this PR fixes the remaining instance in the
diagnostic *messages* on the `Long*` singletons themselves.

Change: point each message at its own class:
- `pyiceberg/expressions/literals.py` `LongAboveMax.to`: `IntAboveMax` -> `LongAboveMax`
- `pyiceberg/expressions/literals.py` `LongBelowMin.to`: `IntBelowMin` -> `LongBelowMin`

## Are these changes tested?

Yes. Added `test_above_max_long` and `test_below_min_long` in
`tests/expressions/test_literals.py`, mirroring the existing `test_above_max_int`
/ `test_below_min_int` (singleton identity, `str`/`repr`, `value`, the successful
`.to(LongType())` round-trip) and additionally asserting that `.to(IntegerType())`
raises `TypeError` whose message now names the `Long*` class.

Verified red -> green: reverting only the source change makes both new tests fail
with `'Cannot change the type of LongBelowMin' in 'Cannot change the type of
IntBelowMin'`; with the fix, both pass. `tests/expressions/test_literals.py`: 172
passed. `tests/expressions/`: 566 passed, no regressions. `make lint` (ruff,
ruff-format, mypy, pydocstyle, codespell, license/header) passes on the changed
files.

## Are there any user-facing changes?

No API or behavior change. Only the text of an already-raised `TypeError` is
corrected (the exception type and the conditions under which it is raised are
unchanged). No changelog entry needed.
