### PR TITLE
Build: Bump github/codeql-action/init and github/codeql-action/analyze from 4.36.2 to 4.36.3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,11 +46,11 @@ jobs:
         persist-credentials: false
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
       with:
         languages: actions
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
       with:
         category: "/language:actions"


### PR DESCRIPTION
# Rationale for this change

`github/codeql-action*` require the same version.

I've opened another #3648 to improve the grouping in dependabot setting.

- Closes https://github.com/apache/iceberg-python/pull/3640
- Closes https://github.com/apache/iceberg-python/pull/3636

## Are these changes tested?

N/A

## Are there any user-facing changes?

No