### PR TITLE
Infra: Group github/codeql-action bumps into a single dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,3 +34,10 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      # The codeql-action init/autobuild/analyze steps must all run the
+      # same version - split PRs cause a version mismatch that fails the
+      # Analyze jobs. Group them so a single PR bumps all of them together.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"


### PR DESCRIPTION
# Rationale for this change

Thus, dependabot can update these two jobs in a single PR:

https://github.com/apache/iceberg-python/blob/2c7552324800f40adbeda844bbc40d3420c05a84/.github/workflows/codeql.yml#L48-L54

- https://github.com/apache/infrastructure-actions/pull/1028

## Are these changes tested?

N/A

## Are there any user-facing changes?

No