### PR TITLE
fix: return flat namespace properties from BigQueryMetastoreCatalog.load_namespace_properties

### DIFF
--- a/pyiceberg/catalog/bigquery_metastore.py
+++ b/pyiceberg/catalog/bigquery_metastore.py
@@ -341,7 +341,7 @@ class BigQueryMetastoreCatalog(MetastoreCatalog):
             dataset = self.client.get_dataset(DatasetReference(project=self.project_id, dataset_id=dataset_name))
 
             if dataset and dataset.external_catalog_dataset_options:
-                return dataset.external_catalog_dataset_options.to_api_repr()
+                return dict(dataset.external_catalog_dataset_options.parameters or {})
         except NotFound as e:
             raise NoSuchNamespaceError(f"Namespace {namespace} not found") from e
         return {}

--- a/tests/catalog/test_bigquery_metastore.py
+++ b/tests/catalog/test_bigquery_metastore.py
@@ -123,6 +123,47 @@ def test_drop_namespace(mocker: MockFixture, gcp_dataset_name: str) -> None:
     assert args[0].dataset_id == gcp_dataset_name
 
 
+def test_load_namespace_properties_returns_flat_parameters(mocker: MockFixture, gcp_dataset_name: str) -> None:
+    client_mock = MagicMock()
+
+    # Round-trip the Dataset that create_namespace persists back through get_dataset,
+    # mimicking how BigQuery stores and returns the namespace.
+    def create_dataset(dataset: Dataset) -> Dataset:
+        client_mock.get_dataset.return_value = dataset
+        return dataset
+
+    client_mock.create_dataset.side_effect = create_dataset
+
+    mocker.patch("pyiceberg.catalog.bigquery_metastore.Client", return_value=client_mock)
+    mocker.patch.dict(os.environ, values={"PYICEBERG_LEGACY_CURRENT_SNAPSHOT_ID": "True"})
+
+    test_catalog = BigQueryMetastoreCatalog(
+        "test_catalog", **{"gcp.bigquery.project-id": "my-project", "warehouse": "gs://test-bucket/"}
+    )
+
+    properties = {"owner": "anas", "comment": "namespace comment"}
+    test_catalog.create_namespace(namespace=gcp_dataset_name, properties=properties)
+
+    # The stored, flat property map must be returned as-is, not the nested BigQuery API
+    # representation (which would bury the values under a "parameters" key and add
+    # "defaultStorageLocationUri").
+    assert test_catalog.load_namespace_properties(gcp_dataset_name) == properties
+
+
+def test_load_namespace_properties_without_parameters(mocker: MockFixture, gcp_dataset_name: str) -> None:
+    client_mock = MagicMock()
+    client_mock.get_dataset.return_value = dataset_mock()
+
+    mocker.patch("pyiceberg.catalog.bigquery_metastore.Client", return_value=client_mock)
+    mocker.patch.dict(os.environ, values={"PYICEBERG_LEGACY_CURRENT_SNAPSHOT_ID": "True"})
+
+    test_catalog = BigQueryMetastoreCatalog("test_catalog", **{"gcp.bigquery.project-id": "my-project"})
+
+    # A dataset whose external_catalog_dataset_options carries no parameters yields an
+    # empty property map, not None or a nested dict.
+    assert test_catalog.load_namespace_properties(gcp_dataset_name) == {}
+
+
 def test_list_tables(mocker: MockFixture, gcp_dataset_name: str) -> None:
     client_mock = MagicMock()
 


### PR DESCRIPTION

```markdown
# Rationale for this change

`BigQueryMetastoreCatalog.create_namespace` stores user-supplied namespace
properties in the `parameters` map of `ExternalCatalogDatasetOptions`
(via `_create_external_catalog_dataset_options`). But
`load_namespace_properties` returned
`dataset.external_catalog_dataset_options.to_api_repr()`, which is the nested
BigQuery REST representation: it buries the properties under a `"parameters"`
key and adds a `"defaultStorageLocationUri"` key.

As a result, a simple round-trip does not behave like the other catalogs:

```python
catalog.create_namespace(("db",), {"owner": "alice"})
catalog.load_namespace_properties(("db",))["owner"]  # KeyError
# actually returns {"defaultStorageLocationUri": "...", "parameters": {"owner": "alice"}}
```

The base `MetastoreCatalog` contract types this method as `-> Properties` (a flat
`Dict[str, str]`), and the Glue and DynamoDB catalogs both return the flat map
(`dict(database.get("Parameters", {}))`). BigQuery was the outlier. This changes
it to return the flat `parameters` map, using the same `.parameters` accessor
already used on the table path in this file. The `parameters` field is `None`
when unset, so it is guarded to yield an empty dict for a namespace with no
properties.

# Are these changes tested?

Yes. Two regression tests were added to
`tests/catalog/test_bigquery_metastore.py`:

- `test_load_namespace_properties_returns_flat_parameters`: creates a namespace
  with `{"owner": ..., "comment": ...}`, then asserts `load_namespace_properties`
  returns exactly that flat map (the mock feeds the persisted `Dataset` back
  through `get_dataset`). This fails on the old `to_api_repr()` code (returns the
  nested dict) and passes with the fix.
- `test_load_namespace_properties_without_parameters`: asserts a dataset whose
  options carry no parameters yields `{}` rather than `None` or a nested dict.

`python -m pytest tests/catalog/test_bigquery_metastore.py` -> 7 passed. Lint
(`ruff`, `ruff-format`, `mypy`, `pydocstyle`, `codespell`) passes on both files.
The BigQuery integration tests need Docker + Spark, which were not available in
this environment; the behavior is covered by the unit tests above.

# Are there any user-facing changes?

Yes. `BigQueryMetastoreCatalog.load_namespace_properties` now returns the flat
namespace property map, consistent with the other catalogs, instead of the nested
BigQuery API representation. Code that relied on the previous nested shape
(reading `["parameters"][...]` or `["defaultStorageLocationUri"]`) would need to
read the properties directly; the previous shape did not match the documented
`Properties` return type.

<!-- In the case of user-facing changes, please add the changelog label. -->
```
