### PR TITLE
test(datetime): cover invalid timestamp errors in nanos conversions

### DIFF
--- a/tests/utils/test_datetime.py
+++ b/tests/utils/test_datetime.py
@@ -123,6 +123,11 @@ def test_timestamp_to_nanos_unexpected_zone_offset() -> None:
         timestamp_to_nanos("2025-02-23T16:21:44.375612001-04:00")
 
 
+def test_timestamp_to_nanos_invalid_timestamp() -> None:
+    with pytest.raises(ValueError, match="Invalid timestamp without zone: invalid"):
+        timestamp_to_nanos("invalid")
+
+
 @pytest.mark.parametrize(
     "timestamp, nanos",
     [
@@ -138,6 +143,11 @@ def test_timestamptz_to_nanos(timestamp: str, nanos: int) -> None:
 def test_timestamptz_to_nanos_missing_zone_offset() -> None:
     with pytest.raises(ValueError, match="Missing zone offset: 2025-02-23T20:21:44.375612001"):
         timestamptz_to_nanos("2025-02-23T20:21:44.375612001")
+
+
+def test_timestamptz_to_nanos_invalid_timestamp() -> None:
+    with pytest.raises(ValueError, match="Invalid timestamp with zone: invalid"):
+        timestamptz_to_nanos("invalid")
 
 
 @pytest.mark.parametrize("nanos, micros", [(1510871468000001001, 1510871468000001), (-1510871468000001001, -1510871468000002)])

--- a/tests/utils/test_datetime.py
+++ b/tests/utils/test_datetime.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import re
 from datetime import datetime, time, timezone, tzinfo
 
 import pytest
@@ -124,7 +125,7 @@ def test_timestamp_to_nanos_unexpected_zone_offset() -> None:
 
 
 def test_timestamp_to_nanos_invalid_timestamp() -> None:
-    with pytest.raises(ValueError, match="Invalid timestamp without zone: invalid"):
+    with pytest.raises(ValueError, match=re.escape("Invalid timestamp without zone: invalid (must be ISO-8601)")):
         timestamp_to_nanos("invalid")
 
 
@@ -146,7 +147,7 @@ def test_timestamptz_to_nanos_missing_zone_offset() -> None:
 
 
 def test_timestamptz_to_nanos_invalid_timestamp() -> None:
-    with pytest.raises(ValueError, match="Invalid timestamp with zone: invalid"):
+    with pytest.raises(ValueError, match=re.escape("Invalid timestamp with zone: invalid (must be ISO-8601)")):
         timestamptz_to_nanos("invalid")
 
 


### PR DESCRIPTION
# Rationale for this change

  Follow-up to #3505, addressing @ebyhr's suggestion to cover the untested error branches:
   `Invalid timestamp without zone` in `timestamp_to_nanos` 
   `Invalid timestamp with zone` in `timestamptz_to_nanos`.

  ## Are these changes tested?
  
  Yes this PR is tests only.

  ## Are there any user-facing changes?

  No.