### PR TITLE
fix(partitioning): convert nano timestamp partition values to nanoseconds

### DIFF
--- a/pyiceberg/partitioning.py
+++ b/pyiceberg/partitioning.py
@@ -54,13 +54,15 @@ from pyiceberg.types import (
     NestedField,
     PrimitiveType,
     StructType,
+    TimestampNanoType,
     TimestampType,
+    TimestamptzNanoType,
     TimestamptzType,
     TimeType,
     UnknownType,
     UUIDType,
 )
-from pyiceberg.utils.datetime import date_to_days, datetime_to_micros, time_to_micros
+from pyiceberg.utils.datetime import date_to_days, datetime_to_micros, datetime_to_nanos, time_to_micros
 
 INITIAL_PARTITION_SPEC_ID = 0
 PARTITION_FIELD_ID_START: int = 1000
@@ -512,6 +514,19 @@ def _(type: IcebergType, value: int | datetime | None) -> int | None:
         return value
     elif isinstance(value, datetime):
         return datetime_to_micros(value)
+    else:
+        raise ValueError(f"Type not recognized: {value}")
+
+
+@_to_partition_representation.register(TimestampNanoType)
+@_to_partition_representation.register(TimestamptzNanoType)
+def _(type: IcebergType, value: int | datetime | None) -> int | None:
+    if value is None:
+        return None
+    elif isinstance(value, int):
+        return value
+    elif isinstance(value, datetime):
+        return datetime_to_nanos(value)
     else:
         raise ValueError(f"Type not recognized: {value}")
 

--- a/tests/table/test_partitioning.py
+++ b/tests/table/test_partitioning.py
@@ -22,7 +22,12 @@ from uuid import UUID
 import pytest
 
 from pyiceberg.exceptions import ValidationError
-from pyiceberg.partitioning import UNPARTITIONED_PARTITION_SPEC, PartitionField, PartitionSpec
+from pyiceberg.partitioning import (
+    UNPARTITIONED_PARTITION_SPEC,
+    PartitionField,
+    PartitionSpec,
+    _to_partition_representation,
+)
 from pyiceberg.schema import Schema
 from pyiceberg.transforms import (
     BucketTransform,
@@ -45,7 +50,9 @@ from pyiceberg.types import (
     PrimitiveType,
     StringType,
     StructType,
+    TimestampNanoType,
     TimestampType,
+    TimestamptzNanoType,
     TimestamptzType,
     TimeType,
     UnknownType,
@@ -251,6 +258,30 @@ def test_transform_consistency_with_pyarrow_transform(source_type: PrimitiveType
     for t in all_transforms:
         if t.can_transform(source_type):
             assert t.transform(source_type)(value) == t.pyarrow_transform(source_type)(pa.array([value])).to_pylist()[0]
+
+
+@pytest.mark.parametrize(
+    "timestamp_type",
+    [TimestampType(), TimestamptzType()],
+)
+def test_to_partition_representation_timestamp(timestamp_type: PrimitiveType) -> None:
+    value = datetime.datetime(2020, 1, 1, 12, 30, 45, 123456)
+
+    assert _to_partition_representation(timestamp_type, value) == 1577881845123456
+    assert _to_partition_representation(timestamp_type, 1577881845123456) == 1577881845123456
+    assert _to_partition_representation(timestamp_type, None) is None
+
+
+@pytest.mark.parametrize(
+    "timestamp_nano_type",
+    [TimestampNanoType(), TimestamptzNanoType()],
+)
+def test_to_partition_representation_timestamp_nano(timestamp_nano_type: PrimitiveType) -> None:
+    value = datetime.datetime(2020, 1, 1, 12, 30, 45, 123456)
+
+    assert _to_partition_representation(timestamp_nano_type, value) == 1577881845123456000
+    assert _to_partition_representation(timestamp_nano_type, 1577881845123456789) == 1577881845123456789
+    assert _to_partition_representation(timestamp_nano_type, None) is None
 
 
 def test_deserialize_partition_field_v2() -> None:


### PR DESCRIPTION
Closes #3652
  
  # Rationale for this change

  `_to_partition_representation` has no handler for `TimestampNanoType` / `TimestamptzNanoType`, so a `datetime` partition value
  passes through unchanged instead of being converted to nanoseconds since epoch. The manifest writer expects an int there, so
  identity-partitioned writes on `timestamp_ns` columns would fail once v3 writing lands (#1551).
  
  This adds a handler for the two nano types, mirroring the existing microsecond one with `datetime_to_nanos`.

  Happy to rework this or fold it into the v3 write effort if that's preferred.

  ## Are these changes tested?
  
  Yes, added unit tests covering `datetime`, int passthrough and `None` for both nano types, plus the same cases for the microsecond
  types which weren't covered before.

  ## Are there any user-facing changes?
  
  No. Writing v3 tables is still gated, this just makes partitioned v3 writes work correctly once it's enabled.