### PR TITLE
fix: format identity partition paths for nanosecond timestamps

### DIFF
--- a/pyiceberg/transforms.py
+++ b/pyiceberg/transforms.py
@@ -969,6 +969,16 @@ def _(_type: IcebergType, value: int) -> str:
     return datetime.to_human_timestamptz(value)
 
 
+@_int_to_human_string.register(TimestampNanoType)
+def _(_type: IcebergType, value: int) -> str:
+    return datetime.to_human_timestamp_ns(value)
+
+
+@_int_to_human_string.register(TimestamptzNanoType)
+def _(_type: IcebergType, value: int) -> str:
+    return datetime.to_human_timestamptz_ns(value)
+
+
 class UnknownTransform(Transform[S, T]):
     """A transform that represents when an unknown transform is provided.
 

--- a/pyiceberg/utils/datetime.py
+++ b/pyiceberg/utils/datetime.py
@@ -218,6 +218,26 @@ def to_human_timestamp(timestamp_micros: int) -> str:
     return (EPOCH_TIMESTAMP + timedelta(microseconds=timestamp_micros)).isoformat()
 
 
+def to_human_timestamp_ns(timestamp_nanos: int) -> str:
+    """Convert a TimestampNanoType value to human string with nanosecond precision."""
+    # Python datetime only supports microsecond precision, so render the
+    # microsecond timestamp with a fixed 6 fractional digits and append the
+    # remaining 3 sub-microsecond nanosecond digits for full 9-digit precision.
+    micros = nanos_to_micros(timestamp_nanos)
+    sub_micros = timestamp_nanos - micros * 1_000
+    return (EPOCH_TIMESTAMP + timedelta(microseconds=micros)).isoformat(timespec="microseconds") + f"{sub_micros:03d}"
+
+
+def to_human_timestamptz_ns(timestamp_nanos: int) -> str:
+    """Convert a TimestamptzNanoType value to human string with nanosecond precision."""
+    micros = nanos_to_micros(timestamp_nanos)
+    sub_micros = timestamp_nanos - micros * 1_000
+    iso = (EPOCH_TIMESTAMPTZ + timedelta(microseconds=micros)).isoformat(timespec="microseconds")
+    # Insert the sub-microsecond nanosecond digits before the "+00:00" zone offset.
+    timestamp_part, _, offset = iso.rpartition("+")
+    return f"{timestamp_part}{sub_micros:03d}+{offset}"
+
+
 def micros_to_hours(micros: int) -> int:
     """Convert a timestamp in microseconds to hours from 1970-01-01T00:00."""
     return micros // 3_600_000_000

--- a/tests/table/test_partitioning.py
+++ b/tests/table/test_partitioning.py
@@ -45,7 +45,9 @@ from pyiceberg.types import (
     PrimitiveType,
     StringType,
     StructType,
+    TimestampNanoType,
     TimestampType,
+    TimestamptzNanoType,
     TimestamptzType,
     TimeType,
     UnknownType,
@@ -170,6 +172,26 @@ def test_partition_spec_to_path() -> None:
     # Both partition field names and values should be URL encoded, with spaces mapping to plus signs, to match the Java
     # behaviour: https://github.com/apache/iceberg/blob/ca3db931b0f024f0412084751ac85dd4ef2da7e7/api/src/main/java/org/apache/iceberg/PartitionSpec.java#L198-L204
     assert spec.partition_to_path(record, schema) == "my%23str%25bucket=my%2Bstr/other+str%2Bbucket=%28+%29/my%21int%3Abucket=10"
+
+
+@pytest.mark.parametrize(
+    "field_type, expected_path",
+    [
+        (TimestampType(), "ts=2025-02-23T20%3A21%3A44.375612"),
+        (TimestamptzType(), "ts=2025-02-23T20%3A21%3A44.375612%2B00%3A00"),
+        (TimestampNanoType(), "ts=2025-02-23T20%3A21%3A44.375612001"),
+        (TimestamptzNanoType(), "ts=2025-02-23T20%3A21%3A44.375612001%2B00%3A00"),
+    ],
+)
+def test_partition_spec_to_path_timestamp(field_type: PrimitiveType, expected_path: str) -> None:
+    schema = Schema(NestedField(field_id=1, name="ts", field_type=field_type, required=False))
+    spec = PartitionSpec(PartitionField(source_id=1, field_id=1000, transform=IdentityTransform(), name="ts"))
+
+    # Nanosecond timestamps carry three extra sub-microsecond digits; the microsecond
+    # value 1740342104375612 is the same instant as 1740342104375612001 nanoseconds.
+    value = 1740342104375612001 if isinstance(field_type, (TimestampNanoType, TimestamptzNanoType)) else 1740342104375612
+
+    assert spec.partition_to_path(Record(value), schema) == expected_path
 
 
 def test_partition_spec_to_path_dropped_source_id() -> None:

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -416,6 +416,8 @@ def test_satisfies_order_of_method(transform: TimeTransform[Any], other_transfor
         (TimeType(), 36775038194, "10:12:55.038194"),
         (TimestamptzType(), 1512151975038194, "2017-12-01T18:12:55.038194+00:00"),
         (TimestampType(), 1512151975038194, "2017-12-01T18:12:55.038194"),
+        (TimestampNanoType(), 1740342104375612001, "2025-02-23T20:21:44.375612001"),
+        (TimestamptzNanoType(), 1740342104375612001, "2025-02-23T20:21:44.375612001+00:00"),
         (LongType(), -1234567890000, "-1234567890000"),
         (StringType(), "a/b/c=d", "a/b/c=d"),
         (DecimalType(9, 2), Decimal("-1.50"), "-1.50"),

--- a/tests/utils/test_datetime.py
+++ b/tests/utils/test_datetime.py
@@ -29,6 +29,8 @@ from pyiceberg.utils.datetime import (
     time_to_nanos,
     timestamp_to_nanos,
     timestamptz_to_nanos,
+    to_human_timestamp_ns,
+    to_human_timestamptz_ns,
 )
 
 timezones = [
@@ -154,3 +156,35 @@ def test_nanos_to_micros(nanos: int, micros: int) -> None:
 )
 def test_nanos_to_hours(nanos: int, hours: int) -> None:
     assert hours == nanos_to_hours(nanos)
+
+
+@pytest.mark.parametrize(
+    "nanos, human_str",
+    [
+        (0, "1970-01-01T00:00:00.000000000"),
+        (1, "1970-01-01T00:00:00.000000001"),
+        (999, "1970-01-01T00:00:00.000000999"),
+        (1000, "1970-01-01T00:00:00.000001000"),
+        (1740342104375612001, "2025-02-23T20:21:44.375612001"),
+        (1510871468000001001, "2017-11-16T22:31:08.000001001"),
+        (1740342104000000001, "2025-02-23T20:21:44.000000001"),
+    ],
+)
+def test_to_human_timestamp_ns(nanos: int, human_str: str) -> None:
+    assert human_str == to_human_timestamp_ns(nanos)
+
+
+@pytest.mark.parametrize(
+    "nanos, human_str",
+    [
+        (0, "1970-01-01T00:00:00.000000000+00:00"),
+        (1, "1970-01-01T00:00:00.000000001+00:00"),
+        (999, "1970-01-01T00:00:00.000000999+00:00"),
+        (1000, "1970-01-01T00:00:00.000001000+00:00"),
+        (1740342104375612001, "2025-02-23T20:21:44.375612001+00:00"),
+        (1510871468000001001, "2017-11-16T22:31:08.000001001+00:00"),
+        (1740342104000000001, "2025-02-23T20:21:44.000000001+00:00"),
+    ],
+)
+def test_to_human_timestamptz_ns(nanos: int, human_str: str) -> None:
+    assert human_str == to_human_timestamptz_ns(nanos)


### PR DESCRIPTION

# Rationale for this change

An identity transform on a `timestamp_ns` / `timestamptz_ns` column renders the
raw integer value in its human string, so identity partition directory paths
come out as `ts=1740342104375612001` instead of an ISO-8601 timestamp. The
microsecond `timestamp` / `timestamptz` types render correctly (e.g.
`ts=2025-02-23T20:21:44.375612`), so this is an inconsistency in the nanosecond
timestamp types added for the v3 spec.

The cause is in `_int_to_human_string` (`pyiceberg/transforms.py`): it dispatches
`DateType`, `TimeType`, `TimestampType`, and `TimestamptzType`, but has no
registration for `TimestampNanoType` / `TimestamptzNanoType`, so those values
fall through to the base handler `str(value)`. Because
`IdentityTransform.to_human_string` and `PartitionSpec.partition_to_path`
(`pyiceberg/partitioning.py`) both route through `_int_to_human_string`, an
identity-partitioned nanosecond timestamp column produces a raw-integer
partition path.

This change adds `to_human_timestamp_ns` / `to_human_timestamptz_ns` helpers in
`pyiceberg/utils/datetime.py` and registers them for the two nanosecond
timestamp types. Python's `datetime` only supports microsecond precision, so the
helpers render the microsecond instant at a fixed 6 fractional digits and append
the remaining 3 sub-microsecond digits, yielding a full 9 fractional-digit
ISO-8601 string with no trailing-zero trimming. This matches the Java
`DateTimeUtil.nanosToIsoTimestamp` / `nanosToIsoTimestamptz` behaviour used by
`Transforms.identity().toHumanString()` (for example
`1510871468000001001 -> 2017-11-16T22:31:08.000001001`, with the zone offset kept
after the fraction for the tz variant).

## Are these changes tested?

Yes.

- `tests/utils/test_datetime.py`: new `test_to_human_timestamp_ns` and
  `test_to_human_timestamptz_ns` cover the epoch boundary and the
  sub-microsecond digit boundaries (0, 1, 999, 1000), a whole-second-plus-1ns
  case (where the microsecond fraction is zero), and the Java reference value.
- `tests/test_transforms.py::test_identity_human_string`: adds `timestamp_ns`
  and `timestamptz_ns` rows alongside the existing type rows.
- `tests/table/test_partitioning.py::test_partition_spec_to_path_timestamp`: an
  end-to-end `PartitionSpec.partition_to_path` check for the microsecond and
  nanosecond timestamp/timestamptz types (the user-facing symptom).

The targeted subset passes (14 passed). Running the full `tests/test_transforms.py`,
`tests/utils/test_datetime.py`, and `tests/table/test_partitioning.py` files
shows only the pre-existing failures that require the optional `pyiceberg_core`
extension; these new tests do not touch that path. Integration tests
(Docker + Spark) were not run in this environment; the behaviour is covered by
the unit tests end-to-end through `partition_to_path`.

## Are there any user-facing changes?

Yes. Identity partition paths for `timestamp_ns` and `timestamptz_ns` columns are
now ISO-8601 strings (matching the microsecond timestamp types and the Java
implementation) instead of raw integers. `IdentityTransform.to_human_string` for
these types changes correspondingly.

<!-- This is a user-facing behaviour fix; maintainers may want the changelog label. -->
