### PR TITLE
Fix truncate transform ordering comparison

### DIFF
--- a/pyiceberg/transforms.py
+++ b/pyiceberg/transforms.py
@@ -895,16 +895,7 @@ class TruncateTransform(Transform[S, S]):
         return lambda v: truncate_func(v) if v is not None else None
 
     def satisfies_order_of(self, other: Transform[S, T]) -> bool:
-        if self == other:
-            return True
-        elif (
-            isinstance(self.source_type, StringType)
-            and isinstance(other, TruncateTransform)
-            and isinstance(other.source_type, StringType)
-        ):
-            return self.width >= other.width
-
-        return False
+        return isinstance(other, TruncateTransform) and self.width >= other.width
 
     def to_human_string(self, _: IcebergType, value: S | None) -> str:
         if value is None:

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -512,6 +512,11 @@ def test_truncate_method(type_var: PrimitiveType, value: Any, expected_human_str
     assert truncate_transform.satisfies_order_of(truncate_transform)
 
 
+def test_truncate_satisfies_order_of() -> None:
+    assert TruncateTransform(5).satisfies_order_of(TruncateTransform(3))
+    assert not TruncateTransform(3).satisfies_order_of(TruncateTransform(5))
+
+
 def test_unknown_transform() -> None:
     unknown_transform = UnknownTransform("unknown")  # type: ignore
     assert str(unknown_transform) == str(eval(repr(unknown_transform)))


### PR DESCRIPTION
Closes #3680

# Rationale for this change

`TruncateTransform.satisfies_order_of` accessed the uninitialized `_source_type` attribute when comparing truncate transforms with different widths, raising `AttributeError` instead of returning a boolean.

Compare truncate widths directly, consistent with the Apache Iceberg Java implementation.

## Are these changes tested?

Yes. Added regression coverage for both wider-to-narrower and narrower-to-wider comparisons.

- `uv run python -m pytest tests/test_transforms.py -q` (283 passed)
- `make lint`
- `make test PYTEST_ARGS=-q` (3,768 passed; 1,560 deselected)

## Are there any user-facing changes?

Yes. Comparing truncate transforms with different widths now returns the expected boolean instead of raising `AttributeError`.
