### PR TITLE
Fix TruncateTransform.satisfies_order_of crashing on different widths

### DIFF
--- a/pyiceberg/transforms.py
+++ b/pyiceberg/transforms.py
@@ -897,11 +897,7 @@ class TruncateTransform(Transform[S, S]):
     def satisfies_order_of(self, other: Transform[S, T]) -> bool:
         if self == other:
             return True
-        elif (
-            isinstance(self.source_type, StringType)
-            and isinstance(other, TruncateTransform)
-            and isinstance(other.source_type, StringType)
-        ):
+        elif isinstance(other, TruncateTransform):
             return self.width >= other.width
 
         return False

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -512,6 +512,12 @@ def test_truncate_method(type_var: PrimitiveType, value: Any, expected_human_str
     assert truncate_transform.satisfies_order_of(truncate_transform)
 
 
+def test_truncate_satisfies_order_of_different_widths() -> None:
+    assert TruncateTransform(5).satisfies_order_of(TruncateTransform(3))
+    assert not TruncateTransform(3).satisfies_order_of(TruncateTransform(5))
+    assert not TruncateTransform(5).satisfies_order_of(BucketTransform(3))
+
+
 def test_unknown_transform() -> None:
     unknown_transform = UnknownTransform("unknown")  # type: ignore
     assert str(unknown_transform) == str(eval(repr(unknown_transform)))


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
Closes #3680

# Rationale for this change

`TruncateTransform.satisfies_order_of` reads `self.source_type` (and `other.source_type`) when the two transforms are not equal, but `TruncateTransform.__init__` only sets `_width` and never sets `_source_type`. Comparing two truncate transforms of different widths therefore raises `AttributeError: 'TruncateTransform' object has no attribute '_source_type'` instead of returning a boolean, because same-width comparisons only work by taking the early `self == other` return. Two truncate transforms are ordered by width, so the comparison can be decided from the widths alone.

## Are these changes tested?

Yes. Added `test_truncate_satisfies_order_of_different_widths` and confirmed the existing transform tests still pass (`pytest tests/test_transforms.py -k "truncate or satisfies_order"`). The two `test_truncate_pyarrow_transforms` cases that fail locally require the optional `pyiceberg-core` extra and are unrelated to this change.

## Are there any user-facing changes?

No.

<!-- In the case of user-facing changes, please add the changelog label. -->
