### PR TITLE
Fix residual NotNaN for null partition values

### DIFF
--- a/pyiceberg/expressions/visitors.py
+++ b/pyiceberg/expressions/visitors.py
@@ -1874,10 +1874,10 @@ class ResidualVisitor(BoundBooleanExpressionVisitor[BooleanExpression], ABC):
 
     def visit_not_nan(self, term: BoundTerm) -> BooleanExpression:
         val = term.eval(self.struct)
-        if isinstance(val, SupportsFloat) and not math.isnan(val):
-            return self.visit_true()
-        else:
+        if isinstance(val, SupportsFloat) and math.isnan(val):
             return self.visit_false()
+        else:
+            return self.visit_true()
 
     def visit_less_than(self, term: BoundTerm, literal: LiteralValue) -> BooleanExpression:
         if term.eval(self.struct) < literal.value:

--- a/pyiceberg/expressions/visitors.py
+++ b/pyiceberg/expressions/visitors.py
@@ -1852,10 +1852,10 @@ class ResidualVisitor(BoundBooleanExpressionVisitor[BooleanExpression], ABC):
 
     def visit_not_nan(self, term: BoundTerm) -> BooleanExpression:
         val = term.eval(self.struct)
-        if isinstance(val, SupportsFloat) and not math.isnan(val):
-            return self.visit_true()
-        else:
+        if isinstance(val, SupportsFloat) and math.isnan(val):
             return self.visit_false()
+        else:
+            return self.visit_true()
 
     def visit_less_than(self, term: BoundTerm, literal: LiteralValue) -> BooleanExpression:
         if term.eval(self.struct) < literal.value:

--- a/tests/expressions/test_residual_evaluator.py
+++ b/tests/expressions/test_residual_evaluator.py
@@ -213,6 +213,9 @@ def test_is_not_nan() -> None:
     residual = res_eval.residual_for(Record(None))
     assert residual == AlwaysTrue()
 
+    residual = res_eval.residual_for(Record(float("nan")))
+    assert residual == AlwaysFalse()
+
     residual = res_eval.residual_for(Record(2))
     assert residual == AlwaysTrue()
 
@@ -224,6 +227,9 @@ def test_is_not_nan() -> None:
 
     residual = res_eval.residual_for(Record(None))
     assert residual == AlwaysTrue()
+
+    residual = res_eval.residual_for(Record(float("nan")))
+    assert residual == AlwaysFalse()
 
     residual = res_eval.residual_for(Record(2))
     assert residual == AlwaysTrue()

--- a/tests/expressions/test_residual_evaluator.py
+++ b/tests/expressions/test_residual_evaluator.py
@@ -211,7 +211,7 @@ def test_is_not_nan() -> None:
     res_eval = residual_evaluator_of(spec=spec, expr=predicate, case_sensitive=True, schema=schema)
 
     residual = res_eval.residual_for(Record(None))
-    assert residual == AlwaysFalse()
+    assert residual == AlwaysTrue()
 
     residual = res_eval.residual_for(Record(2))
     assert residual == AlwaysTrue()
@@ -223,7 +223,7 @@ def test_is_not_nan() -> None:
     res_eval = residual_evaluator_of(spec=spec, expr=predicate, case_sensitive=True, schema=schema)
 
     residual = res_eval.residual_for(Record(None))
-    assert residual == AlwaysFalse()
+    assert residual == AlwaysTrue()
 
     residual = res_eval.residual_for(Record(2))
     assert residual == AlwaysTrue()


### PR DESCRIPTION
<!-- Closes #3498 -->

# Rationale for this change

`ResidualVisitor.visit_not_nan` currently treats a partition value of `None` as `AlwaysFalse()`. That is inconsistent with the normal evaluator behavior and with Iceberg Java semantics: `None` is not NaN, so `NotNaN(None)` should evaluate to true.

This PR addresses only that residual-evaluator edge case from #3498. The stricter metrics-evaluator items discussed in the issue are already covered by other active work.

## Are these changes tested?

Yes. I updated the existing residual evaluator expectations for both double and float identity partitions and ran the targeted test file in a WSL-native checkout:

```bash
pytest tests/expressions/test_residual_evaluator.py -q
```

Result:

```text
11 passed in 0.05s
```

Additional checks:

```bash
ruff check pyiceberg/expressions/visitors.py tests/expressions/test_residual_evaluator.py
git diff --check
```

Both passed.

## Are there any user-facing changes?

Yes. Residual evaluation for `NotNaN` now treats null partition values as not-NaN instead of false. Please add the changelog label if this behavior change should appear in release notes.
