### PR TITLE
fix: convert nano timestamps to nanoseconds in partition representation

### DIFF
--- a/pyiceberg/partitioning.py
+++ b/pyiceberg/partitioning.py
@@ -54,13 +54,15 @@ from pyiceberg.types import (
     NestedField,
     PrimitiveType,
     StructType,
+    TimestampNanoType,
     TimestampType,
+    TimestamptzNanoType,
     TimestamptzType,
     TimeType,
     UnknownType,
     UUIDType,
 )
-from pyiceberg.utils.datetime import date_to_days, datetime_to_micros, time_to_micros
+from pyiceberg.utils.datetime import date_to_days, datetime_to_micros, datetime_to_nanos, time_to_micros
 
 INITIAL_PARTITION_SPEC_ID = 0
 PARTITION_FIELD_ID_START: int = 1000
@@ -512,6 +514,19 @@ def _(type: IcebergType, value: int | datetime | None) -> int | None:
         return value
     elif isinstance(value, datetime):
         return datetime_to_micros(value)
+    else:
+        raise ValueError(f"Type not recognized: {value}")
+
+
+@_to_partition_representation.register(TimestampNanoType)
+@_to_partition_representation.register(TimestamptzNanoType)
+def _(type: IcebergType, value: int | datetime | None) -> int | None:
+    if value is None:
+        return None
+    elif isinstance(value, int):
+        return value
+    elif isinstance(value, datetime):
+        return datetime_to_nanos(value)
     else:
         raise ValueError(f"Type not recognized: {value}")
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -17,7 +17,7 @@
 # under the License.
 # pylint: disable=eval-used,protected-access,redefined-outer-name
 from collections.abc import Callable
-from datetime import date
+from datetime import date, datetime
 from decimal import Decimal
 from typing import Annotated, Any
 from uuid import UUID
@@ -1623,6 +1623,30 @@ def test_strict_binary(bound_reference_binary: BoundReference) -> None:
         BoundNotIn(term=bound_reference_binary, literals={value, other_value}), transform, EqualTo, "YWJjZGU="
     )
     _assert_projection_strict(BoundIn(term=bound_reference_binary, literals={value, other_value}), transform, NotIn)
+
+
+@pytest.mark.parametrize(
+    "source_type, value, expected",
+    [
+        pytest.param(TimestampType(), None, None, id="timestamp_none"),
+        pytest.param(TimestampType(), 1577836800000000, 1577836800000000, id="timestamp_int_passthrough"),
+        pytest.param(TimestampType(), datetime(2020, 1, 1), 1577836800000000, id="timestamp_datetime"),
+        pytest.param(TimestamptzType(), datetime(2020, 1, 1), 1577836800000000, id="timestamptz_datetime"),
+        pytest.param(TimestampNanoType(), None, None, id="timestamp_nano_none"),
+        pytest.param(TimestampNanoType(), 1577836800000000000, 1577836800000000000, id="timestamp_nano_int_passthrough"),
+        pytest.param(TimestampNanoType(), datetime(2020, 1, 1), 1577836800000000000, id="timestamp_nano_datetime"),
+        pytest.param(TimestamptzNanoType(), datetime(2020, 1, 1), 1577836800000000000, id="timestamptz_nano_datetime"),
+    ],
+)
+def test_to_partition_representation_timestamps(source_type: PrimitiveType, value: Any, expected: Any) -> None:
+    assert _to_partition_representation(source_type, value) == expected
+
+
+def test_to_partition_representation_unrecognized_type_raises() -> None:
+    with pytest.raises(ValueError, match="Type not recognized"):
+        _to_partition_representation(TimestampType(), "not-a-datetime-or-int")
+    with pytest.raises(ValueError, match="Type not recognized"):
+        _to_partition_representation(TimestampNanoType(), "not-a-datetime-or-int")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

`_to_partition_representation()` in `pyiceberg/partitioning.py` has no registered handler for `TimestampNanoType`/`TimestamptzNanoType`. A `datetime` partition value for a nano-precision timestamp column passes through unconverted instead of being converted to nanoseconds since epoch, the same way `TimestampType`/`TimestamptzType` already convert to microseconds.

That unconverted `datetime` object would reach `DataFile.partition`, where `TimestampNanoWriter` calls `write_int` — an int is expected, not a `datetime`.

Fixes #3652

## Changes

- Register a handler for `TimestampNanoType`/`TimestamptzNanoType` in `_to_partition_representation`, using the existing `datetime_to_nanos()` from `pyiceberg/utils/datetime.py` (mirrors the existing micros handler exactly).
- Added `test_to_partition_representation_timestamps` (8 parametrized cases covering `None`, int passthrough, and `datetime` conversion for both the existing micros types and the new nano types) and `test_to_partition_representation_unrecognized_type_raises` (confirms unrecognized input types raise `ValueError` for both micros and nanos types — previously nano types silently fell through to the generic `PrimitiveType` handler, which returns the value unchanged rather than raising).

## Test plan

- New tests verified to fail against pre-fix code (`git stash` the fix in `partitioning.py`, rerun — 3 of 9 new tests fail as expected) and pass post-fix.
- `uv run pytest tests/test_transforms.py`: 274 passed (up from 265 pre-fix, the +9 are the new tests); the 17 pre-existing failures (missing `pyiceberg-core` extension in this environment) are unchanged before/after — confirmed identical failure set on unmodified `main`.
- `uv run pytest tests/table/test_partitioning.py`: 19 passed / 11 pre-existing failures (same extension-availability cause), unchanged before/after.
- `uv run ruff check` / `ruff format --check`: clean on both changed files.
- `uv run mypy pyiceberg/partitioning.py`: no errors attributable to this file (pre-existing unrelated errors in other files are due to optional dependency stubs not installed in this environment).