### PR TITLE
Core: Preserve null operations in inspect.snapshots

### DIFF
--- a/pyiceberg/table/inspect.py
+++ b/pyiceberg/table/inspect.py
@@ -92,7 +92,7 @@ class InspectTable:
                     "committed_at": datetime.fromtimestamp(snapshot.timestamp_ms / 1000.0, tz=timezone.utc),
                     "snapshot_id": snapshot.snapshot_id,
                     "parent_id": snapshot.parent_snapshot_id,
-                    "operation": str(operation),
+                    "operation": operation,
                     "manifest_list": snapshot.manifest_list,
                     "summary": additional_properties,
                 }

--- a/tests/table/test_inspect.py
+++ b/tests/table/test_inspect.py
@@ -85,7 +85,7 @@ def test_inspect_snapshots_preserves_null_operation(catalog: InMemoryCatalog) ->
 
     assert tbl.inspect.snapshots().to_pydict()["operation"] == [None]
 
-    
+
 @pytest.mark.parametrize("newest_first", [False, True])
 def test_partitions_last_updated_uses_latest_snapshot_regardless_of_order(newest_first: bool) -> None:
     # Manifest entries are visited in manifest order, which is not chronological, so the

--- a/tests/table/test_inspect.py
+++ b/tests/table/test_inspect.py
@@ -68,3 +68,15 @@ def test_inspect_entries_and_files_render_null_bound(catalog: InMemoryCatalog) -
     files_metrics = tbl.inspect.files().to_pydict()["readable_metrics"][0]["s"]
     assert files_metrics["lower_bound"] is None
     assert files_metrics["upper_bound"] is None
+
+
+def test_inspect_snapshots_preserves_null_operation(catalog: InMemoryCatalog) -> None:
+    schema = Schema(NestedField(1, "s", StringType()))
+    tbl = catalog.create_table("default.snapshot_without_summary", schema)
+    tbl.append(pa.table({"s": ["value"]}, schema=pa.schema([pa.field("s", pa.large_string())])))
+
+    snapshots = list(tbl.metadata.snapshots)
+    snapshots[0] = snapshots[0].model_copy(update={"summary": None})
+    tbl.metadata = tbl.metadata.model_copy(update={"snapshots": snapshots})
+
+    assert tbl.inspect.snapshots().to_pydict()["operation"] == [None]


### PR DESCRIPTION
# Rationale for this change

The `snapshots` metadata table declares `operation` as nullable because snapshots without a summary do not have an operation. However, `InspectTable.snapshots()` converted the missing value with `str(None)`, returning the literal string `"None"` instead of null.

This change passes the operation directly to PyArrow, preserving null semantics and matching Apache Iceberg Java's snapshots metadata table.

## Are these changes tested?

Yes. A regression test creates a snapshot without a summary and verifies that `table.inspect.snapshots()` returns a null operation.

The following checks pass locally:

- `PYTHONPATH=. uv run pytest tests/table/test_inspect.py -q` (5 passed)
- `PYTHONPATH=. uv run --extra datafusion --extra pyiceberg-core pytest tests/table -q` (328 passed)
- `make lint`

## Are there any user-facing changes?

Yes. For snapshots without a summary, `table.inspect.snapshots()` now returns null in the `operation` column instead of the string `"None"`. There are no API changes.
