### PR TITLE
Core: Preserve empty partition bounds in inspect.manifests

### DIFF
--- a/pyiceberg/table/inspect.py
+++ b/pyiceberg/table/inspect.py
@@ -423,7 +423,7 @@ class InspectTable:
                             partition_field_type, from_bytes(partition_field_type, field_summary.lower_bound)
                         )
                     )
-                    if field_summary.lower_bound
+                    if field_summary.lower_bound is not None
                     else None
                 )
                 upper_bound = (
@@ -432,7 +432,7 @@ class InspectTable:
                             partition_field_type, from_bytes(partition_field_type, field_summary.upper_bound)
                         )
                     )
-                    if field_summary.upper_bound
+                    if field_summary.upper_bound is not None
                     else None
                 )
                 rows.append(

--- a/pyiceberg/table/inspect.py
+++ b/pyiceberg/table/inspect.py
@@ -560,7 +560,7 @@ class InspectTable:
                             partition_field_type, from_bytes(partition_field_type, field_summary.lower_bound)
                         )
                     )
-                    if field_summary.lower_bound
+                    if field_summary.lower_bound is not None
                     else None
                 )
                 upper_bound = (
@@ -569,7 +569,7 @@ class InspectTable:
                             partition_field_type, from_bytes(partition_field_type, field_summary.upper_bound)
                         )
                     )
-                    if field_summary.upper_bound
+                    if field_summary.upper_bound is not None
                     else None
                 )
                 rows.append(

--- a/tests/table/test_inspect.py
+++ b/tests/table/test_inspect.py
@@ -21,8 +21,10 @@ import pyarrow as pa
 import pytest
 
 from pyiceberg.conversions import to_bytes
+from pyiceberg.partitioning import PartitionField, PartitionSpec
 from pyiceberg.schema import Schema
 from pyiceberg.table.inspect import _readable_bound
+from pyiceberg.transforms import IdentityTransform
 from pyiceberg.types import NestedField, StringType
 from tests.catalog.test_base import InMemoryCatalog
 
@@ -68,3 +70,14 @@ def test_inspect_entries_and_files_render_null_bound(catalog: InMemoryCatalog) -
     files_metrics = tbl.inspect.files().to_pydict()["readable_metrics"][0]["s"]
     assert files_metrics["lower_bound"] is None
     assert files_metrics["upper_bound"] is None
+
+
+def test_inspect_manifests_preserves_empty_string_bounds(catalog: InMemoryCatalog) -> None:
+    schema = Schema(NestedField(1, "s", StringType()))
+    spec = PartitionSpec(PartitionField(1, 1000, IdentityTransform(), "s"))
+    tbl = catalog.create_table("default.empty_string_partition", schema, partition_spec=spec)
+    tbl.append(pa.table({"s": [""]}, schema=pa.schema([pa.field("s", pa.large_string())])))
+
+    partition_summary = tbl.inspect.manifests().to_pydict()["partition_summaries"][0][0]
+    assert partition_summary["lower_bound"] == ""
+    assert partition_summary["upper_bound"] == ""

--- a/tests/table/test_inspect.py
+++ b/tests/table/test_inspect.py
@@ -23,9 +23,11 @@ import pytest
 
 from pyiceberg.conversions import to_bytes
 from pyiceberg.manifest import DataFile, DataFileContent
+from pyiceberg.partitioning import PartitionField, PartitionSpec
 from pyiceberg.schema import Schema
 from pyiceberg.table.inspect import InspectTable, _readable_bound
 from pyiceberg.table.snapshots import Snapshot
+from pyiceberg.transforms import IdentityTransform
 from pyiceberg.typedef import Record
 from pyiceberg.types import NestedField, StringType
 from tests.catalog.test_base import InMemoryCatalog
@@ -93,3 +95,14 @@ def test_partitions_last_updated_uses_latest_snapshot_regardless_of_order(newest
     (partition_row,) = partitions_map.values()
     assert partition_row["last_updated_at"] == newer.timestamp_ms
     assert partition_row["last_updated_snapshot_id"] == newer.snapshot_id
+
+
+def test_inspect_manifests_preserves_empty_string_bounds(catalog: InMemoryCatalog) -> None:
+    schema = Schema(NestedField(1, "s", StringType()))
+    spec = PartitionSpec(PartitionField(1, 1000, IdentityTransform(), "s"))
+    tbl = catalog.create_table("default.empty_string_partition", schema, partition_spec=spec)
+    tbl.append(pa.table({"s": [""]}, schema=pa.schema([pa.field("s", pa.large_string())])))
+
+    partition_summary = tbl.inspect.manifests().to_pydict()["partition_summaries"][0][0]
+    assert partition_summary["lower_bound"] == ""
+    assert partition_summary["upper_bound"] == ""


### PR DESCRIPTION
# Rationale for this change

Manifest partition summaries encode string bounds as bytes. An empty string is represented by `b""`, but `InspectTable.manifests()` checked encoded bounds by truthiness. As a result, valid empty-string lower and upper bounds were returned as null.

This change checks whether each bound is absent instead, preserving empty values while continuing to return null for missing bounds. This matches Apache Iceberg Java's manifests metadata table.

## Are these changes tested?

Yes. A regression test writes a table partitioned by an identity-transformed string containing an empty value and verifies that both manifest partition bounds remain empty strings.

The following checks pass locally:

- `PYTHONPATH=. uv run pytest tests/table/test_inspect.py -q` (5 passed)
- `PYTHONPATH=. uv run --extra datafusion --extra pyiceberg-core pytest -p no:cacheprovider tests/table -q` (328 passed)
- `make lint`

## Are there any user-facing changes?

Yes. `table.inspect.manifests()` now reports empty-string partition bounds as empty strings instead of null. There are no API changes.
