### PR TITLE
Fix/sqlcatalog iceberg type filter

### DIFF
--- a/pyiceberg/catalog/sql.py
+++ b/pyiceberg/catalog/sql.py
@@ -24,6 +24,7 @@ from typing import (
 )
 
 from sqlalchemy import (
+    ColumnElement,
     String,
     create_engine,
     delete,
@@ -84,6 +85,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_ECHO_VALUE = "false"
 DEFAULT_POOL_PRE_PING_VALUE = "false"
 DEFAULT_INIT_CATALOG_TABLES = "true"
+ICEBERG_TABLE_TYPE = "TABLE"
 
 
 class SqlCatalogBaseTable(MappedAsDataclass, DeclarativeBase):
@@ -209,8 +211,15 @@ class SqlCatalog(MetastoreCatalog):
             "previous_metadata_location": None,
         }
         if self._schema_version == "v1":
-            row["iceberg_type"] = "TABLE"
+            row["iceberg_type"] = ICEBERG_TABLE_TYPE
         return row
+
+    def _iceberg_type_filter(self) -> ColumnElement[bool] | None:
+        # Excludes non-table rows (e.g. views written by iceberg-java or iceberg-rust) from table
+        # lookups. None on v0 schemas, where the iceberg_type column doesn't exist to filter on.
+        if self._schema_version != "v1":
+            return None
+        return (IcebergTables.iceberg_type == ICEBERG_TABLE_TYPE) | (IcebergTables.iceberg_type.is_(None))
 
     def _convert_orm_to_iceberg(self, orm_table: IcebergTables) -> Table:
         # Check for expected properties.
@@ -349,6 +358,8 @@ class SqlCatalog(MetastoreCatalog):
                 IcebergTables.table_namespace == namespace,
                 IcebergTables.table_name == table_name,
             )
+            if (type_filter := self._iceberg_type_filter()) is not None:
+                stmt = stmt.where(type_filter)
             result = session.scalar(stmt)
         if result:
             return self._convert_orm_to_iceberg(result)
@@ -367,20 +378,22 @@ class SqlCatalog(MetastoreCatalog):
         namespace_tuple = Catalog.namespace_from(identifier)
         namespace = Catalog.namespace_to_string(namespace_tuple)
         table_name = Catalog.table_name_from(identifier)
+        type_filter = self._iceberg_type_filter()
         with Session(self.engine) as session:
             if self.engine.dialect.supports_sane_rowcount:
-                res = session.execute(
-                    delete(IcebergTables).where(
-                        IcebergTables.catalog_name == self.name,
-                        IcebergTables.table_namespace == namespace,
-                        IcebergTables.table_name == table_name,
-                    )
+                stmt = delete(IcebergTables).where(
+                    IcebergTables.catalog_name == self.name,
+                    IcebergTables.table_namespace == namespace,
+                    IcebergTables.table_name == table_name,
                 )
+                if type_filter is not None:
+                    stmt = stmt.where(type_filter)
+                res = session.execute(stmt)
                 if res.rowcount < 1:
                     raise NoSuchTableError(f"Table does not exist: {namespace}.{table_name}")
             else:
                 try:
-                    tbl = (
+                    query = (
                         session.query(IcebergTables)
                         .with_for_update(of=IcebergTables)
                         .filter(
@@ -388,8 +401,10 @@ class SqlCatalog(MetastoreCatalog):
                             IcebergTables.table_namespace == namespace,
                             IcebergTables.table_name == table_name,
                         )
-                        .one()
                     )
+                    if type_filter is not None:
+                        query = query.filter(type_filter)
+                    tbl = query.one()
                     session.delete(tbl)
                 except NoResultFound as e:
                     raise NoSuchTableError(f"Table does not exist: {namespace}.{table_name}") from e
@@ -419,6 +434,7 @@ class SqlCatalog(MetastoreCatalog):
         to_table_name = Catalog.table_name_from(to_identifier)
         if not self.namespace_exists(to_namespace):
             raise NoSuchNamespaceError(f"Namespace does not exist: {to_namespace}")
+        type_filter = self._iceberg_type_filter()
         with Session(self.engine) as session:
             try:
                 if self.engine.dialect.supports_sane_rowcount:
@@ -431,12 +447,14 @@ class SqlCatalog(MetastoreCatalog):
                         )
                         .values(table_namespace=to_namespace, table_name=to_table_name)
                     )
+                    if type_filter is not None:
+                        stmt = stmt.where(type_filter)
                     result = session.execute(stmt)
                     if result.rowcount < 1:
                         raise NoSuchTableError(f"Table does not exist: {from_table_name}")
                 else:
                     try:
-                        tbl = (
+                        query = (
                             session.query(IcebergTables)
                             .with_for_update(of=IcebergTables)
                             .filter(
@@ -444,8 +462,10 @@ class SqlCatalog(MetastoreCatalog):
                                 IcebergTables.table_namespace == from_namespace,
                                 IcebergTables.table_name == from_table_name,
                             )
-                            .one()
                         )
+                        if type_filter is not None:
+                            query = query.filter(type_filter)
+                        tbl = query.one()
                         tbl.table_namespace = to_namespace
                         tbl.table_name = to_table_name
                     except NoResultFound as e:
@@ -656,9 +676,8 @@ class SqlCatalog(MetastoreCatalog):
             IcebergTables.table_namespace == namespace,
         )
 
-        # Filter out views only if schema_version is v1
-        if self._schema_version == "v1":
-            stmt = stmt.where((IcebergTables.iceberg_type == "TABLE") | (IcebergTables.iceberg_type.is_(None)))
+        if (type_filter := self._iceberg_type_filter()) is not None:
+            stmt = stmt.where(type_filter)
 
         with Session(self.engine) as session:
             result = session.scalars(stmt)

--- a/tests/catalog/test_sql.py
+++ b/tests/catalog/test_sql.py
@@ -33,6 +33,7 @@ from pyiceberg.catalog.sql import (
 )
 from pyiceberg.exceptions import (
     NoSuchPropertyException,
+    NoSuchTableError,
     TableAlreadyExistsError,
 )
 from pyiceberg.schema import Schema
@@ -331,6 +332,60 @@ def test_list_tables_filters_by_iceberg_type(warehouse: Path) -> None:
     assert "table_V1" in tables
     assert "table_V0" in tables
     assert "some_view" not in tables
+
+
+def _insert_view_row(catalog: SqlCatalog, namespace: str, table_name: str) -> None:
+    # Simulates a view row written by iceberg-java or iceberg-rust, which SqlCatalog table
+    # operations must not treat as a table (issue #3337).
+    with catalog.engine.connect() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO iceberg_tables "
+                "(catalog_name, table_namespace, table_name, metadata_location, previous_metadata_location, iceberg_type) "
+                "VALUES ('test', :namespace, :table_name, 's3://fake/metadata.json', NULL, 'VIEW')"
+            ),
+            {"namespace": namespace, "table_name": table_name},
+        )
+        conn.commit()
+
+
+def test_load_table_ignores_view_rows(warehouse: Path) -> None:
+    catalog = SqlCatalog(name="test", uri="sqlite:///:memory:", warehouse=f"file://{warehouse}")
+    catalog.create_namespace("ns")
+    _insert_view_row(catalog, "ns", "a_view")
+
+    with pytest.raises(NoSuchTableError):
+        catalog.load_table(("ns", "a_view"))
+
+
+def test_drop_table_ignores_view_rows(warehouse: Path) -> None:
+    catalog = SqlCatalog(name="test", uri="sqlite:///:memory:", warehouse=f"file://{warehouse}")
+    catalog.create_namespace("ns")
+    _insert_view_row(catalog, "ns", "a_view")
+
+    with pytest.raises(NoSuchTableError):
+        catalog.drop_table(("ns", "a_view"))
+
+    # The view row must not have been deleted.
+    with catalog.engine.connect() as conn:
+        row = conn.execute(text("SELECT iceberg_type FROM iceberg_tables WHERE table_name = 'a_view'")).fetchone()
+    assert row is not None
+    assert row[0] == "VIEW"
+
+
+def test_rename_table_ignores_view_rows(warehouse: Path) -> None:
+    catalog = SqlCatalog(name="test", uri="sqlite:///:memory:", warehouse=f"file://{warehouse}")
+    catalog.create_namespace("ns")
+    _insert_view_row(catalog, "ns", "a_view")
+
+    with pytest.raises(NoSuchTableError):
+        catalog.rename_table(("ns", "a_view"), ("ns", "renamed_view"))
+
+    # The view row must not have been renamed.
+    with catalog.engine.connect() as conn:
+        row = conn.execute(text("SELECT iceberg_type FROM iceberg_tables WHERE table_name = 'a_view'")).fetchone()
+    assert row is not None
+    assert row[0] == "VIEW"
 
 
 def test_migration_to_v1_with_property_set(warehouse: Path) -> None:


### PR DESCRIPTION

<!-- Closes #3337 #3263  -->

# Rationale for this change

`SqlCatalog`'s `iceberg_tables` table can be shared with iceberg-java/iceberg-rust clients, which
store both tables and views there using an `iceberg_type` column (`TABLE`/`VIEW`), filtering every
lookup with `WHERE (iceberg_type = 'TABLE' OR iceberg_type IS NULL)` (see
[`JdbcUtil.java#L168`](https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/jdbc/JdbcUtil.java#L168)).
PyIceberg had neither the column nor the filter, so a view row written by another implementation
would be silently treated as a table by `load_table`, `drop_table`, `rename_table`, and `commit_table`.

**Before:**
```python
catalog.drop_table(("ns", "sales_summary"))  # 'sales_summary' is actually a VIEW row
# No error — the view's row is silently deleted.
```

**After:**
```python
catalog.drop_table(("ns", "sales_summary"))
# raises NoSuchTableError: Table does not exist: ns.sales_summary
```

This PR builds on #3263 (cherry-picked here, unmerged, authored by @rchowell), which adds the
`iceberg_type` column, an opt-in idempotent v0→v1 migration, and filters `list_tables`. On top of
that, it extracts a small `_iceberg_type_filter()` helper (as suggested in #3337) and applies it to
`load_table`, `drop_table`, and `rename_table`. `commit_table` needed no direct change since it
already delegates its existence check to `load_table`.

Note on scope: a prior attempt at #3337 (#3525) tried to add the column *and* the filtering in one
PR, but was closed after review feedback preferred keeping #3263's column/migration approach
separate from the filtering logic. This PR keeps that separation by adopting #3263's commits as-is
and adding only the filtering on top.

## Are these changes tested?
Yes, i added `test_load_table_ignores_view_rows`, `test_drop_table_ignores_view_rows`, and
`test_rename_table_ignores_view_rows` in `tests/catalog/test_sql.py`, each inserting a raw `VIEW`
row and confirming the affected operation now raises `NoSuchTableError` instead of touching it.
Verified all three fail without the fix. Full suite: 3796 passed, 0 failed.

## Are there any user-facing changes?
Yes! `SqlCatalog.load_table`, `drop_table`, and `rename_table` now correctly ignore `VIEW` rows
written by other Iceberg implementations sharing the same catalog table, instead of silently
reading, deleting, or renaming them. New optional `schema_version` catalog property (from #3263)
controls opt-in migration of existing v0 catalogs. Please apply the `changelog` label.

<!-- In the case of user-facing changes, please add the changelog label. -->
