### PR TITLE
Add `--purge` option to drop table CLI

### DIFF
--- a/mkdocs/docs/cli.md
+++ b/mkdocs/docs/cli.md
@@ -240,3 +240,17 @@ Property write.metadata.delete-after-commit.enabled removed from nyc.taxis
 ➜  pyiceberg properties get table nyc.taxis write.metadata.delete-after-commit.enabled
 Could not find property write.metadata.delete-after-commit.enabled on nyc.taxis
 ```
+
+You can drop a table from the catalog:
+
+```sh
+➜  pyiceberg drop table nyc.taxis
+Dropped table: nyc.taxis
+```
+
+To also purge the table files through the configured catalog, pass `--purge`:
+
+```sh
+➜  pyiceberg drop table nyc.taxis --purge
+Dropped table: nyc.taxis
+```

--- a/mkdocs/docs/cli.md
+++ b/mkdocs/docs/cli.md
@@ -248,7 +248,7 @@ You can drop a table from the catalog:
 Dropped table: nyc.taxis
 ```
 
-To also purge the table files through the configured catalog, pass `--purge`:
+To request purge for the underlying table files through the configured catalog, pass `--purge`:
 
 ```sh
 ➜  pyiceberg drop table nyc.taxis --purge

--- a/mkdocs/docs/cli.md
+++ b/mkdocs/docs/cli.md
@@ -252,5 +252,5 @@ To also purge the table files through the configured catalog, pass `--purge`:
 
 ```sh
 ➜  pyiceberg drop table nyc.taxis --purge
-Dropped table: nyc.taxis
+Dropped table: nyc.taxis (purge requested)
 ```

--- a/pyiceberg/cli/console.py
+++ b/pyiceberg/cli/console.py
@@ -269,13 +269,17 @@ def drop() -> None:
 
 @drop.command()
 @click.argument("identifier")
+@click.option("--purge", is_flag=True, help="Physically delete all table files.")
 @click.pass_context
 @catch_exception()
-def table(ctx: Context, identifier: str) -> None:  # noqa: F811
+def table(ctx: Context, identifier: str, purge: bool) -> None:  # noqa: F811
     """Drop a table."""
     catalog, output = _catalog_and_output(ctx)
 
-    catalog.drop_table(identifier)
+    if purge:
+        catalog.purge_table(identifier)
+    else:
+        catalog.drop_table(identifier)
     output.text(f"Dropped table: {identifier}")
 
 

--- a/pyiceberg/cli/console.py
+++ b/pyiceberg/cli/console.py
@@ -280,7 +280,8 @@ def table(ctx: Context, identifier: str, purge: bool) -> None:  # noqa: F811
         catalog.purge_table(identifier)
     else:
         catalog.drop_table(identifier)
-    output.text(f"Dropped table: {identifier}")
+    purge_message = " (purge requested)" if purge else ""
+    output.text(f"Dropped table: {identifier}{purge_message}")
 
 
 @drop.command()  # type: ignore

--- a/pyiceberg/cli/console.py
+++ b/pyiceberg/cli/console.py
@@ -269,7 +269,7 @@ def drop() -> None:
 
 @drop.command()
 @click.argument("identifier")
-@click.option("--purge", is_flag=True, help="Physically delete all table files.", default=False)
+@click.option("--purge", is_flag=True, help="Request that the catalog purge all table files.", default=False)
 @click.pass_context
 @catch_exception()
 def table(ctx: Context, identifier: str, purge: bool) -> None:  # noqa: F811

--- a/pyiceberg/cli/console.py
+++ b/pyiceberg/cli/console.py
@@ -269,7 +269,7 @@ def drop() -> None:
 
 @drop.command()
 @click.argument("identifier")
-@click.option("--purge", is_flag=True, help="Physically delete all table files.")
+@click.option("--purge", is_flag=True, help="Physically delete all table files.", default=False)
 @click.pass_context
 @catch_exception()
 def table(ctx: Context, identifier: str, purge: bool) -> None:  # noqa: F811

--- a/tests/cli/test_console.py
+++ b/tests/cli/test_console.py
@@ -352,7 +352,7 @@ def test_drop_table_with_purge(catalog: InMemoryCatalog, mocker: MockFixture) ->
     runner = CliRunner()
     result = runner.invoke(run, ["drop", "table", "default.my_table", "--purge"])
     assert result.exit_code == 0
-    assert result.output == """Dropped table: default.my_table\n"""
+    assert result.output == """Dropped table: default.my_table (purge requested)\n"""
     purge_table.assert_called_once_with("default.my_table")
 
 

--- a/tests/cli/test_console.py
+++ b/tests/cli/test_console.py
@@ -340,6 +340,22 @@ def test_drop_table(catalog: InMemoryCatalog) -> None:
     assert result.output == """Dropped table: default.my_table\n"""
 
 
+def test_drop_table_with_purge(catalog: InMemoryCatalog, mocker: MockFixture) -> None:
+    catalog.create_namespace(TEST_TABLE_NAMESPACE)
+    catalog.create_table(
+        identifier=TEST_TABLE_IDENTIFIER,
+        schema=TEST_TABLE_SCHEMA,
+        partition_spec=TEST_TABLE_PARTITION_SPEC,
+    )
+    purge_table = mocker.spy(catalog, "purge_table")
+
+    runner = CliRunner()
+    result = runner.invoke(run, ["drop", "table", "default.my_table", "--purge"])
+    assert result.exit_code == 0
+    assert result.output == """Dropped table: default.my_table\n"""
+    purge_table.assert_called_once_with("default.my_table")
+
+
 def test_drop_table_does_not_exists(catalog: InMemoryCatalog) -> None:
     # pylint: disable=unused-argument
 


### PR DESCRIPTION
 # Rationale for this change

PyIceberg already exposes `Catalog.purge_table`, but the CLI only supports dropping a table through `catalog.drop_table`.

This adds a `--purge` option to `pyiceberg drop table` so users can request the existing catalog purge behavior from the CLI. The default behavior remains unchanged: without `--purge`, the command still calls `catalog.drop_table`.

  ## Are these changes tested?

Yes.

- `make test PYTEST_ARGS="tests/cli/test_console.py -v -k 'drop_table'"`
- `uv run prek run ruff --files pyiceberg/cli/console.py tests/cli/test_console.py`
- `uv run prek run ruff-format --files pyiceberg/cli/console.py tests/cli/
  test_console.py`

## Are there any user-facing changes?

Yes. `pyiceberg drop table <identifier> --purge` is now available and calls `catalog.purge_table(identifier)`.