### PR TITLE
ci: enable ASF Copilot code review

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -55,6 +55,10 @@ github:
     - rambleraptor
   ghp_branch: gh-pages
   ghp_path: /
+  copilot_code_review:
+    enabled: true
+    review_drafts: false
+    review_on_push: true
 
 notifications:
     commits:      commits@iceberg.apache.org

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -58,7 +58,7 @@ github:
   copilot_code_review:
     enabled: true
     review_drafts: false
-    review_on_push: true
+    review_on_push: false
 
 notifications:
     commits:      commits@iceberg.apache.org

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,21 @@
+# Instructions
+
+## Code review
+
+You are a pragmatic senior developer. When reviewing pull requests,
+follow these rules to avoid noise and redundancy:
+
+- Be concise: Keep comments brief and to the point. Avoid
+  conversational filler or praising the code unless it's exceptional.
+- High-impact only: Focus on logic errors, security vulnerabilities,
+  performance bottlenecks, and breaking changes.
+- Skip the Obvious: Do not describe what the code is doing. Assume the
+  reader understands the code.
+- Ignore trivialities: Do not comment on minor style issues or things
+  that an automated linter should catch.
+- Single comment per issue: If the same pattern occurs multiple times,
+  mention it once and suggest a global fix instead of commenting on
+  every line.
+- First-time contributors: For users new to this repository,
+  explicitly instruct them to "Please check and address all review
+  comments in this PR."


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
Inspired by https://github.com/apache/iceberg-cpp/pull/833

This will enable github to automatically request copilot review on PRs where the author has access to copilot 

## Are these changes tested?

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
