### PR TITLE
Remove stale VariantType transform TODO

### DIFF
--- a/pyiceberg/transforms.py
+++ b/pyiceberg/transforms.py
@@ -719,7 +719,6 @@ class IdentityTransform(Transform[S, S]):
         return lambda v: v
 
     def can_transform(self, source: IcebergType) -> bool:
-        # TODO: disallow VariantType when PyIceberg supports it.
         return source.is_primitive and not isinstance(source, (GeographyType, GeometryType))
 
     def result_type(self, source: IcebergType) -> IcebergType:


### PR DESCRIPTION


<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

VariantType is modeled separately from PrimitiveType and rejected by primitive-scoped transforms in apache/iceberg#11324.

## Are these changes tested?

Just removed a stale TODO comment, no tests required.

## Are there any user-facing changes?

Nope.

<!-- In the case of user-facing changes, please add the changelog label. -->
