### PR TITLE
fix(decimal): use minimal byte length for negative powers of two

### DIFF
--- a/pyiceberg/utils/decimal.py
+++ b/pyiceberg/utils/decimal.py
@@ -58,11 +58,16 @@ def bytes_required(value: int | Decimal) -> int:
         int: the minimum number of bytes needed to serialize the value.
     """
     if isinstance(value, int):
-        return (value.bit_length() + 8) // 8
+        unscaled = value
     elif isinstance(value, Decimal):
-        return (decimal_to_unscaled(value).bit_length() + 8) // 8
+        unscaled = decimal_to_unscaled(value)
+    else:
+        raise ValueError(f"Unsupported value: {value}")
 
-    raise ValueError(f"Unsupported value: {value}")
+    # bit_length() overcounts negatives equal to -2**(8k-1) (e.g. -128, -32768) by one byte;
+    # using (unscaled + 1) for negatives yields the true minimum, matching the Iceberg spec.
+    n_bits = unscaled.bit_length() if unscaled >= 0 else (unscaled + 1).bit_length()
+    return (n_bits + 8) // 8
 
 
 def decimal_to_bytes(value: Decimal, byte_length: int | None = None) -> bytes:

--- a/pyiceberg/utils/decimal.py
+++ b/pyiceberg/utils/decimal.py
@@ -64,10 +64,10 @@ def bytes_required(value: int | Decimal) -> int:
     else:
         raise ValueError(f"Unsupported value: {value}")
 
-    # bit_length() overcounts negatives equal to -2**(8k-1) (e.g. -128, -32768) by one byte;
-    # using (unscaled + 1) for negatives yields the true minimum, matching the Iceberg spec.
-    n_bits = unscaled.bit_length() if unscaled >= 0 else (unscaled + 1).bit_length()
-    return (n_bits + 8) // 8
+    # bit_length() ignores the sign, so -128 appears to need 9 signed bits instead of 8.
+    # Adding 1 before counting avoids the extra byte at negative boundaries.
+    num_bits = unscaled.bit_length() if unscaled >= 0 else (unscaled + 1).bit_length()
+    return (num_bits + 8) // 8
 
 
 def decimal_to_bytes(value: Decimal, byte_length: int | None = None) -> bytes:

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -187,6 +187,7 @@ def test_bucket_hash_values(test_input: Any, test_type: PrimitiveType, expected:
         (BucketTransform(100).transform(TimeType()), 81068000000, 59),
         (BucketTransform(100).transform(TimestampType()), 1510871468000000, 7),
         (BucketTransform(100).transform(DecimalType(9, 2)), Decimal("14.20"), 59),
+        (BucketTransform(16).transform(DecimalType(5, 2)), Decimal("-1.28"), 13),
         (BucketTransform(100).transform(StringType()), "iceberg", 89),
         (
             BucketTransform(100).transform(UUIDType()),

--- a/tests/utils/test_decimal.py
+++ b/tests/utils/test_decimal.py
@@ -55,6 +55,7 @@ def test_bytes_required() -> None:
     assert bytes_required(-32768) == 2
     assert bytes_required(-8388608) == 3
     # The same applies when the unscaled value comes from a Decimal.
+    assert bytes_required(Decimal("1.27")) == 1
     assert bytes_required(Decimal("-1.28")) == 1
     assert bytes_required(Decimal("-327.68")) == 2
 

--- a/tests/utils/test_decimal.py
+++ b/tests/utils/test_decimal.py
@@ -18,7 +18,7 @@ from decimal import Decimal
 
 import pytest
 
-from pyiceberg.utils.decimal import decimal_required_bytes, decimal_to_bytes
+from pyiceberg.utils.decimal import bytes_required, decimal_required_bytes, decimal_to_bytes
 
 
 def test_decimal_required_bytes() -> None:
@@ -42,8 +42,29 @@ def test_decimal_required_bytes() -> None:
     assert "(0, 40]" in str(exc_info.value)
 
 
+def test_bytes_required() -> None:
+    # Positive values and the negative values just past a byte boundary are unaffected.
+    assert bytes_required(0) == 1
+    assert bytes_required(127) == 1
+    assert bytes_required(128) == 2
+    assert bytes_required(-127) == 1
+    assert bytes_required(-129) == 2
+    # The most-negative value that fits in N bytes (-2**(8N-1)) must require exactly N bytes,
+    # not N + 1. These are the cases the previous (value.bit_length() + 8) // 8 formula overcounted.
+    assert bytes_required(-128) == 1
+    assert bytes_required(-32768) == 2
+    assert bytes_required(-8388608) == 3
+    # The same applies when the unscaled value comes from a Decimal.
+    assert bytes_required(Decimal("-1.28")) == 1
+    assert bytes_required(Decimal("-327.68")) == 2
+
+
 def test_decimal_to_bytes() -> None:
     # Check the boundary between 2 and 3 bytes.
     # 2 bytes has a minimum of -32,768 and a maximum value of 32,767 (inclusive).
     assert decimal_to_bytes(Decimal("32767.")) == b"\x7f\xff"
     assert decimal_to_bytes(Decimal("32768.")) == b"\x00\x80\x00"
+    # The most-negative value for a given width must serialize to the minimum number of bytes
+    # (matching the Iceberg spec / Java BigInteger.toByteArray), not one byte longer.
+    assert decimal_to_bytes(Decimal("-1.28")) == b"\x80"
+    assert decimal_to_bytes(Decimal("-327.68")) == b"\x80\x00"

--- a/tests/utils/test_decimal.py
+++ b/tests/utils/test_decimal.py
@@ -43,18 +43,15 @@ def test_decimal_required_bytes() -> None:
 
 
 def test_bytes_required() -> None:
-    # Positive values and the negative values just past a byte boundary are unaffected.
     assert bytes_required(0) == 1
     assert bytes_required(127) == 1
     assert bytes_required(128) == 2
+    # Check negative signed-byte boundaries and their neighbors.
     assert bytes_required(-127) == 1
-    assert bytes_required(-129) == 2
-    # The most-negative value that fits in N bytes (-2**(8N-1)) must require exactly N bytes,
-    # not N + 1. These are the cases the previous (value.bit_length() + 8) // 8 formula overcounted.
     assert bytes_required(-128) == 1
+    assert bytes_required(-129) == 2
     assert bytes_required(-32768) == 2
     assert bytes_required(-8388608) == 3
-    # The same applies when the unscaled value comes from a Decimal.
     assert bytes_required(Decimal("1.27")) == 1
     assert bytes_required(Decimal("-1.28")) == 1
     assert bytes_required(Decimal("-327.68")) == 2
@@ -65,7 +62,6 @@ def test_decimal_to_bytes() -> None:
     # 2 bytes has a minimum of -32,768 and a maximum value of 32,767 (inclusive).
     assert decimal_to_bytes(Decimal("32767.")) == b"\x7f\xff"
     assert decimal_to_bytes(Decimal("32768.")) == b"\x00\x80\x00"
-    # The most-negative value for a given width must serialize to the minimum number of bytes
-    # (matching the Iceberg spec / Java BigInteger.toByteArray), not one byte longer.
+    # Unscaled values -128 and -32768 require no sign padding.
     assert decimal_to_bytes(Decimal("-1.28")) == b"\x80"
     assert decimal_to_bytes(Decimal("-327.68")) == b"\x80\x00"


### PR DESCRIPTION
Reopening #3523, which was auto-closed for inactivity. Rebased on latest `main`; the bug is still present.

Closes #3522

# Rationale for this change

`bytes_required` should return the *minimum* number of bytes for a value, but it returns one byte too many for negatives like -128 and -32768.

This matters because the decimal bucket transform hashes those bytes. The extra byte changes the hash, so PyIceberg can put a value in a different bucket than Spark/Java. For example, `Decimal("-1.28")` goes to bucket 12 in PyIceberg but bucket 13 everywhere else.

The fix computes the length from `(value + 1)` for negative values, which gives the true minimum and matches the Iceberg spec.

## Are these changes tested?

Yes. Added tests for the -128 / -32768 / -8388608 boundary cases (where the old code was wrong) plus positive/negative controls. Lint and the decimal/conversion/transform tests pass.

## Are there any user-facing changes?

Yes. For decimal values like -1.28, the computed bucket changes (e.g. 12 → 13) so it now matches other Iceberg engines.
