### PR TITLE
Update release docs for uv lock

### DIFF
--- a/mkdocs/docs/how-to-release.md
+++ b/mkdocs/docs/how-to-release.md
@@ -67,7 +67,7 @@ deprecation_message(
 
 ### Update Library Version
 
-Update the version in `pyproject.toml` and `pyiceberg/__init__.py` to match the release version. You will need to additionally run `uv lock`. See [#1276](https://github.com/apache/iceberg-python/pull/1276).
+Update the release version by running `uv version <release-version>`, which updates both `pyproject.toml` and `uv.lock`. Then update the version in `pyiceberg/__init__.py` to match.
 
 ## Publishing a Release Candidate (RC)
 

--- a/mkdocs/docs/how-to-release.md
+++ b/mkdocs/docs/how-to-release.md
@@ -67,7 +67,7 @@ deprecation_message(
 
 ### Update Library Version
 
-Update the version in `pyproject.toml` and `pyiceberg/__init__.py` to match the release version. See [#1276](https://github.com/apache/iceberg-python/pull/1276).
+Update the version in `pyproject.toml` and `pyiceberg/__init__.py` to match the release version. You will need to additionally run `uv lock`. See [#1276](https://github.com/apache/iceberg-python/pull/1276).
 
 ## Publishing a Release Candidate (RC)
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
When we bump the version for a release, we have to re-run uv lock. I'm adjusting our instructions for future release managers.

## Are these changes tested?
Docs only.

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
