### PR TITLE
refactor: simplify CLI property lookup

### DIFF
--- a/pyiceberg/cli/console.py
+++ b/pyiceberg/cli/console.py
@@ -326,14 +326,15 @@ def get_namespace(ctx: Context, identifier: str, property_name: str) -> None:
 
     namespace_properties = catalog.load_namespace_properties(identifier_tuple)
 
-    if property_name:
-        property_value = namespace_properties.get(property_name)
-        if property_value is not None:
-            output.text(property_value)
-        else:
-            raise NoSuchPropertyException(f"Could not find property {property_name} on namespace {identifier}")
-    else:
+    if not property_name:
         output.describe_properties(namespace_properties)
+        return
+
+    property_value = namespace_properties.get(property_name)
+    if property_value is None:
+        raise NoSuchPropertyException(f"Could not find property {property_name} on namespace {identifier}")
+
+    output.text(property_value)
 
 
 @get.command("table")
@@ -348,14 +349,15 @@ def get_table(ctx: Context, identifier: str, property_name: str) -> None:
 
     metadata = catalog.load_table(identifier_tuple).metadata
 
-    if property_name:
-        property_value = metadata.properties.get(property_name)
-        if property_value is not None:
-            output.text(property_value)
-        else:
-            raise NoSuchPropertyException(f"Could not find property {property_name} on table {identifier}")
-    else:
+    if not property_name:
         output.describe_properties(metadata.properties)
+        return
+
+    property_value = metadata.properties.get(property_name)
+    if property_value is None:
+        raise NoSuchPropertyException(f"Could not find property {property_name} on table {identifier}")
+
+    output.text(property_value)
 
 
 @properties.group()

--- a/tests/cli/test_console.py
+++ b/tests/cli/test_console.py
@@ -506,6 +506,17 @@ def test_properties_get_namespace_specific_empty_property(catalog: InMemoryCatal
     assert result.output == "\n"
 
 
+def test_properties_get_namespace_specific_property_that_doesnt_exist(
+    catalog: InMemoryCatalog, namespace_properties: Properties
+) -> None:
+    catalog.create_namespace(TEST_TABLE_NAMESPACE, namespace_properties)
+
+    runner = CliRunner()
+    result = runner.invoke(run, ["properties", "get", "namespace", "default", "doesnotexist"])
+    assert result.exit_code == 1
+    assert result.output == "Could not find property doesnotexist on namespace default\n"
+
+
 def test_properties_get_namespace_does_not_exist(catalog: InMemoryCatalog, namespace_properties: Properties) -> None:
     catalog.create_namespace(TEST_TABLE_NAMESPACE, namespace_properties)
 


### PR DESCRIPTION
# Rationale for this change

This is a follow-up to the review suggestion in #3745. The table and namespace property lookup paths can be flattened with early returns, making the success path easier to read without changing behavior.

This applies the same structure to both commands:

- return after describing all properties when no property name is provided
- raise immediately when a requested property is missing
- write the property value at the end

## Are these changes tested?

Yes. Added regression coverage for a missing namespace property and ran:

- `make lint`
- `uv run python -m pytest tests/cli/test_console.py`

## Are there any user-facing changes?

No.
