### PR TITLE
INFRA: Use PR titles for squash commits

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -31,6 +31,7 @@ github:
   enabled_merge_buttons:
     merge: false
     squash: true
+    squash_commit_message: PR_TITLE_AND_COMMIT_DETAILS
     rebase: true
   protected_branches:
     main:


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
Context: https://github.com/apache/iceberg/issues/17467

Configure squash merges to always use the pull request title while preserving the existing commit-message details in the squash commit body.

## Are these changes tested?

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
