### PR TITLE
Fix flaky moto_server fixture by using an OS-assigned ephemeral port

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,6 @@ retrieved using `request.getfixturevalue(fixture_name)`.
 
 import os
 import re
-import socket
 import string
 import time
 import uuid
@@ -2341,14 +2340,14 @@ def fixture_aws_credentials() -> Generator[None, None, None]:
 
 
 @pytest.fixture(scope="session")
-def moto_server() -> "ThreadedMotoServer":
+def moto_server() -> Generator["ThreadedMotoServer", None, None]:
     from moto.server import ThreadedMotoServer
 
-    server = ThreadedMotoServer(ip_address="localhost", port=5001)
-
-    # this will throw an exception if the port is already in use
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind((server._ip_address, server._port))
+    # Bind to port 0 so the OS assigns a free ephemeral port. A hardcoded port
+    # collides when tests run in parallel (e.g. on shared CI agents) or when a
+    # previous run leaves the port in TIME_WAIT, raising
+    # "OSError: [Errno 98] Address already in use".
+    server = ThreadedMotoServer(ip_address="localhost", port=0)
 
     server.start()
     yield server
@@ -2357,7 +2356,8 @@ def moto_server() -> "ThreadedMotoServer":
 
 @pytest.fixture(scope="session")
 def moto_endpoint_url(moto_server: "ThreadedMotoServer") -> str:
-    _url = f"http://{moto_server._ip_address}:{moto_server._port}"
+    host, port = moto_server.get_host_and_port()
+    _url = f"http://{host}:{port}"
     return _url
 
 


### PR DESCRIPTION
# Rationale for this change

The `moto_server` session fixture in `tests/conftest.py` hardcodes port `5001` and pre-binds a socket to it purely to detect conflicts (added in #292). This is still flaky: when the test session runs on a shared/parallel CI runner, or when a previous run left the port in `TIME_WAIT`, the pre-bind raises and fails the entire test session at fixture setup:

```
ERROR at setup of test_...
OSError: [Errno 98] Address already in use
tests/conftest.py: OSError
```

Bumping the port (as #292 did, 5000 → 5001) and failing fast doesn't remove the collision — it only surfaces it sooner.

This change binds to port `0` so the OS assigns a free ephemeral port, then reads the actual bound port back via moto's `get_host_and_port()`. That eliminates the collision entirely and removes the now-unnecessary pre-bind check (and the `socket` import). The fixture's return annotation is also corrected to `Generator[...]` since it `yield`s.

## Are these changes tested?

Yes — existing moto-backed tests continue to pass against the new fixture (e.g. `tests/catalog/test_glue.py` S3 tests, which consume `moto_endpoint_url`). Verified locally that `ThreadedMotoServer(port=0)` starts, `get_host_and_port()` returns a real ephemeral port, serves requests, and stops cleanly. `ruff check tests/conftest.py` passes.

## Are there any user-facing changes?

No. Test-infrastructure only.