### PR TITLE
Enforce max-ref-age-ms when expiring snapshots

### DIFF
--- a/mkdocs/docs/api.md
+++ b/mkdocs/docs/api.md
@@ -1527,6 +1527,35 @@ def cleanup_old_snapshots(table_name: str, snapshot_ids: list[int]):
 cleanup_old_snapshots("analytics.user_events", [12345, 67890, 11111])
 ```
 
+### Expiring Branches and Tags
+
+A branch or tag protects the snapshot it points at from expiration, along with that snapshot's
+ancestors. A ref left behind by a failed job therefore pins storage indefinitely unless it is
+removed.
+
+`remove_expired_refs()` drops refs whose retention period has elapsed, using the ref's own
+`max-ref-age-ms` when set and the `history.expire.max-ref-age-ms` table property otherwise.
+The `main` branch never expires.
+
+```python
+from datetime import datetime, timedelta, timezone
+
+# Give an audit branch a one-day lifetime
+table.manage_snapshots().create_branch(
+    snapshot_id=table.metadata.current_snapshot_id,
+    branch_name="audit-2024-01-15",
+    max_ref_age_ms=24 * 60 * 60 * 1000,
+).commit()
+
+# Later: drop expired refs, then reclaim the snapshots they were pinning
+table.maintenance.expire_snapshots().remove_expired_refs().older_than(
+    datetime.now(timezone.utc) - timedelta(days=3)
+).commit()
+```
+
+Call `remove_expired_refs()` and `older_than()` in either order. Snapshots released by the
+removed refs are eligible for expiration in the same commit.
+
 ## Views
 
 If PyIceberg is unable to automatically determine view support on your REST Catalog, you can manually specify, `"view-endpoints-supported": "true"`:

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -219,6 +219,10 @@ class TableProperties:
     MIN_SNAPSHOTS_TO_KEEP = "history.expire.min-snapshots-to-keep"
     MIN_SNAPSHOTS_TO_KEEP_DEFAULT = 1
 
+    MAX_REF_AGE_MS = "history.expire.max-ref-age-ms"
+    # sys.maxsize would be 2**31-1 on a 32-bit build, silently expiring refs after ~25 days.
+    MAX_REF_AGE_MS_DEFAULT = 2**63 - 1
+
     COMMIT_NUM_RETRIES = "commit.retry.num-retries"
     COMMIT_NUM_RETRIES_DEFAULT = 4
 

--- a/pyiceberg/table/update/snapshot.py
+++ b/pyiceberg/table/update/snapshot.py
@@ -23,7 +23,7 @@ from abc import abstractmethod
 from collections import defaultdict
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import cached_property
 from typing import TYPE_CHECKING, Generic
 
@@ -1244,12 +1244,16 @@ class ExpireSnapshots(UpdateTableMetadata["ExpireSnapshots"]):
     _updates: tuple[TableUpdate, ...]
     _requirements: tuple[TableRequirement, ...]
     _snapshot_ids_to_expire: set[int]
+    _ref_names_to_remove: set[str]
+    _expire_older_than_ms: int | None
 
     def __init__(self, transaction: Transaction) -> None:
         super().__init__(transaction)
         self._updates = ()
         self._requirements = ()
         self._snapshot_ids_to_expire = set()
+        self._ref_names_to_remove = set()
+        self._expire_older_than_ms = None
 
     def _commit(self) -> UpdatesAndRequirements:
         """
@@ -1261,9 +1265,18 @@ class ExpireSnapshots(UpdateTableMetadata["ExpireSnapshots"]):
             Tuple of updates and requirements to be committed,
             as required by the calling parent apply functions.
         """
-        # Remove any protected snapshot IDs from the set to expire, just in case
+        # Resolved here rather than in older_than() so that snapshots released by
+        # remove_expired_refs() are expirable no matter which order the two were called in.
         protected_ids = self._get_protected_snapshot_ids()
+        if self._expire_older_than_ms is not None:
+            for snapshot in self._transaction.table_metadata.snapshots:
+                if snapshot.timestamp_ms < self._expire_older_than_ms and snapshot.snapshot_id not in protected_ids:
+                    self._snapshot_ids_to_expire.add(snapshot.snapshot_id)
+
+        # Remove any protected snapshot IDs from the set to expire, just in case
         self._snapshot_ids_to_expire -= protected_ids
+        for ref_name in self._ref_names_to_remove:
+            self._updates += (RemoveSnapshotRefUpdate(ref_name=ref_name),)
         update = RemoveSnapshotsUpdate(snapshot_ids=self._snapshot_ids_to_expire)
         self._updates += (update,)
         return self._updates, self._requirements
@@ -1273,15 +1286,57 @@ class ExpireSnapshots(UpdateTableMetadata["ExpireSnapshots"]):
         Get the IDs of protected snapshots.
 
         These are the HEAD snapshots of all branches and all tagged snapshots.  These ids are to be excluded from expiration.
+        Refs staged for removal by :meth:`remove_expired_refs` do not protect anything.
 
         Returns:
             Set of protected snapshot IDs to exclude from expiration.
         """
         return {
             ref.snapshot_id
-            for ref in self._transaction.table_metadata.refs.values()
+            for ref_name, ref in self._transaction.table_metadata.refs.items()
             if ref.snapshot_ref_type in [SnapshotRefType.TAG, SnapshotRefType.BRANCH]
+            and ref_name not in self._ref_names_to_remove
         }
+
+    def remove_expired_refs(self) -> ExpireSnapshots:
+        """
+        Remove branches and tags whose retention period has elapsed.
+
+        A ref's age is measured from the timestamp of the snapshot it points at, against its own
+        ``max-ref-age-ms`` when set, otherwise the ``history.expire.max-ref-age-ms`` table property.
+        The ``main`` branch never expires. A ref pointing at a snapshot that no longer exists is also
+        removed, since it can no longer be resolved.
+
+        This is step 2 of the snapshot retention policy in the Iceberg spec:
+        https://iceberg.apache.org/spec/#snapshot-retention-policy
+
+        Returns:
+            This for method chaining.
+        """
+        from pyiceberg.table import TableProperties
+
+        metadata = self._transaction.table_metadata
+        default_max_ref_age_ms = property_as_int(
+            metadata.properties,
+            TableProperties.MAX_REF_AGE_MS,
+            TableProperties.MAX_REF_AGE_MS_DEFAULT,
+        )
+        now_ms = datetime_to_millis(datetime.now(timezone.utc))
+
+        for ref_name, ref in metadata.refs.items():
+            if ref_name == MAIN_BRANCH:
+                continue
+
+            snapshot = metadata.snapshot_by_id(ref.snapshot_id)
+            if snapshot is None:
+                self._ref_names_to_remove.add(ref_name)
+                continue
+
+            max_ref_age_ms = ref.max_ref_age_ms if ref.max_ref_age_ms is not None else default_max_ref_age_ms
+            if max_ref_age_ms is not None and now_ms - snapshot.timestamp_ms > max_ref_age_ms:
+                self._ref_names_to_remove.add(ref_name)
+
+        return self
 
     def by_id(self, snapshot_id: int) -> ExpireSnapshots:
         """
@@ -1329,9 +1384,7 @@ class ExpireSnapshots(UpdateTableMetadata["ExpireSnapshots"]):
         Returns:
             This for method chaining.
         """
-        protected_ids = self._get_protected_snapshot_ids()
         expire_from = datetime_to_millis(dt)
-        for snapshot in self._transaction.table_metadata.snapshots:
-            if snapshot.timestamp_ms < expire_from and snapshot.snapshot_id not in protected_ids:
-                self._snapshot_ids_to_expire.add(snapshot.snapshot_id)
+        if self._expire_older_than_ms is None or expire_from > self._expire_older_than_ms:
+            self._expire_older_than_ms = expire_from
         return self

--- a/tests/integration/test_snapshot_operations.py
+++ b/tests/integration/test_snapshot_operations.py
@@ -14,8 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import time
 import uuid
 from collections.abc import Generator
+from datetime import datetime, timedelta, timezone
 
 import pyarrow as pa
 import pytest
@@ -332,3 +334,66 @@ def test_rollback_to_timestamp_chained_with_tag(table_with_snapshots: Table) -> 
     assert table_with_snapshots.metadata.refs[tag_name] == SnapshotRef(
         snapshot_id=current_snapshot.snapshot_id, snapshot_ref_type="tag"
     )
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("catalog", [lf("session_catalog_hive"), lf("session_catalog")])
+def test_remove_expired_refs(catalog: Catalog) -> None:
+    """An expired branch is removed, and the snapshot it pinned becomes expirable."""
+    catalog.create_namespace_if_not_exists("default")
+    identifier = f"default.test_expire_refs_{uuid.uuid4().hex[:8]}"
+    arrow_schema = pa.schema([pa.field("id", pa.int64(), nullable=False)])
+    tbl = catalog.create_table(identifier=identifier, schema=arrow_schema)
+
+    for i in range(3):
+        tbl.append(pa.Table.from_pylist([{"id": i}], schema=arrow_schema))
+    tbl = catalog.load_table(identifier)
+
+    pinned_snapshot_id = tbl.metadata.snapshots[0].snapshot_id
+    tbl.manage_snapshots().create_branch(
+        snapshot_id=pinned_snapshot_id,
+        branch_name="audit",
+        max_ref_age_ms=1,
+    ).commit()
+
+    tbl = catalog.load_table(identifier)
+    assert "audit" in tbl.metadata.refs
+    time.sleep(0.05)
+
+    tbl.maintenance.expire_snapshots().remove_expired_refs().older_than(datetime.now(timezone.utc) + timedelta(days=1)).commit()
+
+    tbl = catalog.load_table(identifier)
+    assert "audit" not in tbl.metadata.refs
+    assert tbl.snapshot_by_id(pinned_snapshot_id) is None
+
+    catalog.drop_table(identifier)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("catalog", [lf("session_catalog_hive"), lf("session_catalog")])
+def test_remove_expired_refs_keeps_unexpired_branch(catalog: Catalog) -> None:
+    """A branch inside its retention window survives and keeps protecting its snapshot."""
+    catalog.create_namespace_if_not_exists("default")
+    identifier = f"default.test_expire_refs_keep_{uuid.uuid4().hex[:8]}"
+    arrow_schema = pa.schema([pa.field("id", pa.int64(), nullable=False)])
+    tbl = catalog.create_table(identifier=identifier, schema=arrow_schema)
+
+    for i in range(3):
+        tbl.append(pa.Table.from_pylist([{"id": i}], schema=arrow_schema))
+    tbl = catalog.load_table(identifier)
+
+    pinned_snapshot_id = tbl.metadata.snapshots[0].snapshot_id
+    tbl.manage_snapshots().create_branch(
+        snapshot_id=pinned_snapshot_id,
+        branch_name="audit",
+        max_ref_age_ms=7 * 24 * 60 * 60 * 1000,
+    ).commit()
+
+    tbl = catalog.load_table(identifier)
+    tbl.maintenance.expire_snapshots().remove_expired_refs().older_than(datetime.now(timezone.utc) + timedelta(days=1)).commit()
+
+    tbl = catalog.load_table(identifier)
+    assert "audit" in tbl.metadata.refs
+    assert tbl.snapshot_by_id(pinned_snapshot_id) is not None
+
+    catalog.drop_table(identifier)

--- a/tests/table/test_expire_snapshots.py
+++ b/tests/table/test_expire_snapshots.py
@@ -15,15 +15,21 @@
 # specific language governing permissions and limitations
 # under the License.
 import threading
-from datetime import datetime, timedelta
+import time
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, Mock
 from uuid import uuid4
 
+import pyarrow as pa
 import pytest
 
-from pyiceberg.table import CommitTableResponse, Table
+from pyiceberg.catalog import Catalog
+from pyiceberg.io.pyarrow import schema_to_pyarrow
+from pyiceberg.schema import Schema
+from pyiceberg.table import CommitTableResponse, Table, TableProperties
 from pyiceberg.table.update import RemoveSnapshotsUpdate, update_table_metadata
 from pyiceberg.table.update.snapshot import ExpireSnapshots
+from pyiceberg.types import LongType, NestedField
 
 
 def test_cannot_expire_protected_head_snapshot(table_v2: Table) -> None:
@@ -316,3 +322,124 @@ def test_update_remove_snapshots_with_statistics(table_v2_with_statistics: Table
     assert not any(stat.snapshot_id == REMOVE_SNAPSHOT for stat in new_metadata.statistics), (
         "Statistics for removed snapshot should be gone"
     )
+
+
+def _table_with_expired_branch(
+    catalog_with_warehouse: Catalog,
+    max_ref_age_ms: int,
+    namespace: str,
+) -> tuple[Table, int]:
+    """Create a table with three snapshots and a branch on the oldest, then wait out its TTL.
+
+    Returns the reloaded table and the snapshot id the branch pins.
+    """
+    catalog_with_warehouse.create_namespace(namespace)
+    schema = Schema(NestedField(field_id=1, name="id", field_type=LongType(), required=False))
+    table = catalog_with_warehouse.create_table(f"{namespace}.tbl", schema=schema)
+
+    arrow_schema = schema_to_pyarrow(schema, include_field_ids=False)
+    for i in range(3):
+        table.append(pa.table({"id": pa.array([i], type=pa.int64())}, schema=arrow_schema))
+    table = catalog_with_warehouse.load_table(f"{namespace}.tbl")
+
+    pinned_snapshot_id = table.metadata.snapshots[0].snapshot_id
+    table.manage_snapshots().create_branch(
+        snapshot_id=pinned_snapshot_id,
+        branch_name="audit",
+        max_ref_age_ms=max_ref_age_ms,
+    ).commit()
+
+    time.sleep(0.05)
+    return catalog_with_warehouse.load_table(f"{namespace}.tbl"), pinned_snapshot_id
+
+
+def test_remove_expired_refs_removes_expired_branch(catalog_with_warehouse: Catalog) -> None:
+    """An expired branch is dropped, and the snapshot it pinned becomes expirable."""
+    table, pinned_snapshot_id = _table_with_expired_branch(catalog_with_warehouse, namespace="ns_removes", max_ref_age_ms=1)
+    assert "audit" in table.metadata.refs
+
+    table.maintenance.expire_snapshots().remove_expired_refs().older_than(datetime.now(timezone.utc) + timedelta(days=1)).commit()
+
+    table = catalog_with_warehouse.load_table("ns_removes.tbl")
+    assert "audit" not in table.metadata.refs
+    assert table.snapshot_by_id(pinned_snapshot_id) is None
+
+
+@pytest.mark.parametrize("refs_first", [True, False])
+def test_remove_expired_refs_is_order_independent(catalog_with_warehouse: Catalog, refs_first: bool) -> None:
+    """Snapshots released by an expired ref are reclaimed whichever order the builder is chained in."""
+    table, pinned_snapshot_id = _table_with_expired_branch(catalog_with_warehouse, namespace="ns_order", max_ref_age_ms=1)
+    cutoff = datetime.now(timezone.utc) + timedelta(days=1)
+
+    expire = table.maintenance.expire_snapshots()
+    if refs_first:
+        expire.remove_expired_refs().older_than(cutoff).commit()
+    else:
+        expire.older_than(cutoff).remove_expired_refs().commit()
+
+    table = catalog_with_warehouse.load_table("ns_order.tbl")
+    assert "audit" not in table.metadata.refs
+    assert table.snapshot_by_id(pinned_snapshot_id) is None
+
+
+def test_remove_expired_refs_is_opt_in(catalog_with_warehouse: Catalog) -> None:
+    """Without remove_expired_refs(), an expired branch survives and keeps pinning its snapshot."""
+    table, pinned_snapshot_id = _table_with_expired_branch(catalog_with_warehouse, namespace="ns_optin", max_ref_age_ms=1)
+
+    table.maintenance.expire_snapshots().older_than(datetime.now(timezone.utc) + timedelta(days=1)).commit()
+
+    table = catalog_with_warehouse.load_table("ns_optin.tbl")
+    assert "audit" in table.metadata.refs
+    assert table.snapshot_by_id(pinned_snapshot_id) is not None
+
+
+def test_remove_expired_refs_keeps_unexpired_branch(catalog_with_warehouse: Catalog) -> None:
+    """A branch still inside its retention window is kept, and keeps protecting its snapshot."""
+    table, pinned_snapshot_id = _table_with_expired_branch(
+        catalog_with_warehouse, namespace="ns_keeps", max_ref_age_ms=7 * 24 * 60 * 60 * 1000
+    )
+
+    table.maintenance.expire_snapshots().remove_expired_refs().older_than(datetime.now(timezone.utc) + timedelta(days=1)).commit()
+
+    table = catalog_with_warehouse.load_table("ns_keeps.tbl")
+    assert "audit" in table.metadata.refs
+    assert table.snapshot_by_id(pinned_snapshot_id) is not None
+
+
+def test_remove_expired_refs_falls_back_to_table_property(catalog_with_warehouse: Catalog) -> None:
+    """A ref without its own TTL uses history.expire.max-ref-age-ms."""
+    catalog_with_warehouse.create_namespace("ns_prop")
+    schema = Schema(NestedField(field_id=1, name="id", field_type=LongType(), required=False))
+    table = catalog_with_warehouse.create_table("ns_prop.tbl", schema=schema, properties={TableProperties.MAX_REF_AGE_MS: "1"})
+    arrow_schema = schema_to_pyarrow(schema, include_field_ids=False)
+    table.append(pa.table({"id": pa.array([1], type=pa.int64())}, schema=arrow_schema))
+    table = catalog_with_warehouse.load_table("ns_prop.tbl")
+
+    snapshot_id = table.metadata.current_snapshot_id
+    assert snapshot_id is not None
+    table.manage_snapshots().create_tag(snapshot_id=snapshot_id, tag_name="release").commit()
+    table = catalog_with_warehouse.load_table("ns_prop.tbl")
+    assert table.metadata.refs["release"].max_ref_age_ms is None
+
+    time.sleep(0.05)
+    table.maintenance.expire_snapshots().remove_expired_refs().commit()
+
+    table = catalog_with_warehouse.load_table("ns_prop.tbl")
+    assert "release" not in table.metadata.refs
+
+
+def test_remove_expired_refs_never_removes_main(catalog_with_warehouse: Catalog) -> None:
+    """main is exempt from ref expiry even when the table-level TTL has elapsed."""
+    catalog_with_warehouse.create_namespace("ns_main")
+    schema = Schema(NestedField(field_id=1, name="id", field_type=LongType(), required=False))
+    table = catalog_with_warehouse.create_table("ns_main.tbl", schema=schema, properties={TableProperties.MAX_REF_AGE_MS: "1"})
+    arrow_schema = schema_to_pyarrow(schema, include_field_ids=False)
+    table.append(pa.table({"id": pa.array([1], type=pa.int64())}, schema=arrow_schema))
+    table = catalog_with_warehouse.load_table("ns_main.tbl")
+
+    time.sleep(0.05)
+    table.maintenance.expire_snapshots().remove_expired_refs().commit()
+
+    table = catalog_with_warehouse.load_table("ns_main.tbl")
+    assert "main" in table.metadata.refs
+    assert table.metadata.current_snapshot_id is not None


### PR DESCRIPTION
<!-- Relates to #737 -->

# Rationale for this change

Give a branch a retention window, let it go stale, and the snapshots it pins are never reclaimed:

```
start             snapshots=3 refs=['main', 'stale']
after older_than  snapshots=2 refs=['main', 'stale']
```

Branch and tag creation accept a max ref age and write it to table metadata, but nothing in pyiceberg reads it back, and there is no API to drop an expired ref. The branch keeps its snapshot and every ancestor alive indefinitely.

This is step 2 of the spec's [snapshot retention policy](https://iceberg.apache.org/spec/#snapshot-retention-policy), which Java implements in its remove-snapshots action.

# What this does

`remove_expired_refs()` ages each ref by the timestamp of the snapshot it points at, against that ref's own max ref age or the new `history.expire.max-ref-age-ms` table property. The main branch is exempt, and a ref whose snapshot is already gone is dropped. It is opt-in, so nothing changes unless you call it.

`older_than()` now resolves its snapshot set at commit time, so the two calls are order-independent.

[#3246](https://github.com/apache/iceberg-python/pull/3246) proposed this in April and was closed by the stale bot without review. This PR keeps that design.

# Are these changes tested?

The same script against a local SQLite catalog, on both branches:

```bash
git checkout upstream/main && python repro.py
git checkout fix-expire-refs-max-ref-age && python repro.py
```

| | snapshots left | refs left |
|---|---|---|
| upstream, after expiring by age | 2 | main, stale |
| upstream, calling the new step | n/a | raises an attribute error |
| this PR, after the new step | 1 | main |

<details><summary>Raw output and the script</summary>

```console
$ git checkout upstream/main   # 68898e5a
$ python repro.py
start                    snapshots=3 refs=['main', 'stale']
after older_than         snapshots=2 refs=['main', 'stale']
after remove_expired_refs AttributeError: 'ExpireSnapshots' object has no attribute 'remove_expired_refs'

$ git checkout fix-expire-refs-max-ref-age
$ python repro.py
start                    snapshots=3 refs=['main', 'stale']
after older_than         snapshots=2 refs=['main', 'stale']
after remove_expired_refs snapshots=1 refs=['main']

$ python -m pytest tests/table/test_expire_snapshots.py -q
30 passed in 6.62s
```

```python
# repro.py
import os, shutil, time
from datetime import datetime, timezone
import pyarrow as pa
from pyiceberg.catalog.sql import SqlCatalog

root = "/tmp/ice-repro"
shutil.rmtree(root, ignore_errors=True)
os.makedirs(root)

cat = SqlCatalog("r", uri=f"sqlite:///{root}/cat.db", warehouse=f"file://{root}")
cat.create_namespace("db")
schema = pa.schema([("x", pa.int64())])
tbl = cat.create_table("db.t", schema=schema)

tbl.append(pa.table({"x": [1]}, schema=schema))
first = tbl.metadata.current_snapshot_id
tbl.append(pa.table({"x": [2]}, schema=schema))
tbl.append(pa.table({"x": [3]}, schema=schema))

tbl.manage_snapshots().create_branch(first, "stale", max_ref_age_ms=1).commit()
time.sleep(0.5)
show = lambda lbl: print("%-24s snapshots=%d refs=%s" % (lbl, len(tbl.metadata.snapshots), sorted(tbl.metadata.refs)))
show("start")

tbl.maintenance.expire_snapshots().older_than(datetime.now(timezone.utc)).commit()
tbl = cat.load_table("db.t")
show("after older_than")

tbl.maintenance.expire_snapshots().remove_expired_refs().older_than(datetime.now(timezone.utc)).commit()
tbl = cat.load_table("db.t")
show("after remove_expired_refs")
```

</details>

Integration tests run the same scenario against the REST catalog and Hive metastore from the repo's integration compose file. Unit tests cover the in-memory and SQL catalogs: expired ref removed, unexpired ref kept, table-property fallback, main exempt, and order independence.

# Are there any user-facing changes?

The change is additive: a new opt-in builder step for removing expired refs, and the `history.expire.max-ref-age-ms` property, which defaults to no expiry to match Java. The API docs gain a section on expiring branches and tags.
