### PR TITLE
Docs: Update Iceberg Slack link

### DIFF
--- a/mkdocs/docs/community.md
+++ b/mkdocs/docs/community.md
@@ -26,7 +26,7 @@ hide:
 
 Apache Iceberg tracks issues in GitHub and prefers to receive contributions as pull requests.
 
-Community discussions happen primarily on the [dev mailing list](https://lists.apache.org/list.html?dev@iceberg.apache.org), on [Apache Iceberg Slack workspace](https://join.slack.com/t/apache-iceberg/shared_invite/zt-287g3akar-K9Oe_En5j1UL7Y_Ikpai3A) in the #python channel, and on specific [GitHub issues](https://github.com/apache/iceberg-python/issues).
+Community discussions happen primarily on the [dev mailing list](https://lists.apache.org/list.html?dev@iceberg.apache.org), on [Apache Iceberg Slack workspace](https://iceberg.apache.org/community/#slack) in the #python channel, and on specific [GitHub issues](https://github.com/apache/iceberg-python/issues).
 
 ## Iceberg Community Events
 


### PR DESCRIPTION
# Rationale for this change

I suggest using https://iceberg.apache.org/community/#slack instead, as the invitation link might expire. 

- #3766

## Are these changes tested?

No

## Are there any user-facing changes?

No

<!-- In the case of user-facing changes, please add the changelog label. -->
