### PR TITLE
fix(inspect): handle 4-byte bounds in _readable_bound after int/float type promotion (#3744)

### DIFF
--- a/pyiceberg/table/inspect.py
+++ b/pyiceberg/table/inspect.py
@@ -26,7 +26,7 @@ from pyiceberg.expressions import AlwaysTrue, BooleanExpression
 from pyiceberg.manifest import DataFile, DataFileContent, ManifestContent, ManifestFile, PartitionFieldSummary
 from pyiceberg.partitioning import PartitionSpec
 from pyiceberg.table.snapshots import Snapshot, ancestors_of
-from pyiceberg.types import PrimitiveType
+from pyiceberg.types import DoubleType, FloatType, IntegerType, LongType, PrimitiveType
 from pyiceberg.utils.concurrent import ExecutorFactory
 from pyiceberg.utils.singleton import _convert_to_hashable_type
 
@@ -39,7 +39,13 @@ ALWAYS_TRUE = AlwaysTrue()
 
 
 def _readable_bound(field_type: PrimitiveType, bound: bytes | None) -> Any | None:
-    return from_bytes(field_type, bound) if bound is not None else None
+    if bound is None:
+        return None
+    if isinstance(field_type, LongType) and len(bound) == 4:
+        return from_bytes(IntegerType(), bound)
+    if isinstance(field_type, DoubleType) and len(bound) == 4:
+        return from_bytes(FloatType(), bound)
+    return from_bytes(field_type, bound)
 
 
 class InspectTable:
@@ -246,7 +252,6 @@ class InspectTable:
                         "value_count": value_counts.get(field.field_id),
                         "null_value_count": null_value_counts.get(field.field_id),
                         "nan_value_count": nan_value_counts.get(field.field_id),
-                        # Makes them readable
                         "lower_bound": _readable_bound(field.field_type, lower_bounds.get(field.field_id)),
                         "upper_bound": _readable_bound(field.field_type, upper_bounds.get(field.field_id)),
                     }
@@ -562,7 +567,7 @@ class InspectTable:
                 lower_bound = (
                     (
                         field.transform.to_human_string(
-                            partition_field_type, from_bytes(partition_field_type, field_summary.lower_bound)
+                            partition_field_type, _readable_bound(partition_field_type, field_summary.lower_bound)
                         )
                     )
                     if field_summary.lower_bound is not None
@@ -571,7 +576,7 @@ class InspectTable:
                 upper_bound = (
                     (
                         field.transform.to_human_string(
-                            partition_field_type, from_bytes(partition_field_type, field_summary.upper_bound)
+                            partition_field_type, _readable_bound(partition_field_type, field_summary.upper_bound)
                         )
                     )
                     if field_summary.upper_bound is not None

--- a/tests/table/test_inspect.py
+++ b/tests/table/test_inspect.py
@@ -118,3 +118,52 @@ def test_readable_bound_type_promotions() -> None:
 
     # Test float -> double promotion decoding
     assert _readable_bound(DoubleType(), four_byte_float_bound) == 10.0
+
+
+def test_inspect_files_type_promoted_bounds_e2e() -> None:
+    import shutil
+    import tempfile
+
+    import pyarrow as pa
+
+    from pyiceberg.catalog.sql import SqlCatalog
+    from pyiceberg.schema import Schema
+    from pyiceberg.types import IntegerType, LongType, NestedField, StringType
+
+    warehouse = tempfile.mkdtemp(prefix="iceberg_test_e2e_")
+    try:
+        catalog = SqlCatalog("test_e2e", uri=f"sqlite:///{warehouse}/catalog.db", warehouse=f"file://{warehouse}")
+        catalog.create_namespace("ns")
+
+        tbl = catalog.create_table(
+            "ns.t",
+            schema=Schema(
+                NestedField(1, "name", StringType(), required=False),
+                NestedField(2, "qty", IntegerType(), required=False),
+            ),
+        )
+
+        tbl.append(
+            pa.Table.from_pylist(
+                [{"name": "a", "qty": 10}],
+                schema=pa.schema([pa.field("name", pa.string()), pa.field("qty", pa.int32())]),
+            )
+        )
+
+        # Promote int -> long
+        with tbl.update_schema() as update:
+            update.update_column("qty", field_type=LongType())
+
+        tbl = catalog.load_table("ns.t")
+
+        # Test metadata inspection tables
+        files_df = tbl.inspect.files()
+        assert files_df.num_rows == 1
+
+        entries_df = tbl.inspect.entries()
+        assert entries_df.num_rows == 1
+
+        manifests_df = tbl.inspect.manifests()
+        assert manifests_df.num_rows >= 1
+    finally:
+        shutil.rmtree(warehouse, ignore_errors=True)

--- a/tests/table/test_inspect.py
+++ b/tests/table/test_inspect.py
@@ -106,6 +106,7 @@ def test_inspect_manifests_preserves_empty_string_bounds(catalog: InMemoryCatalo
     assert partition_summary["lower_bound"] == ""
     assert partition_summary["upper_bound"] == ""
 
+
 def test_readable_bound_type_promotions() -> None:
     # 4-byte LE representation of integer 10 -> b'\x0a\x00\x00\x00'
     four_byte_int_bound = b"\x0a\x00\x00\x00"

--- a/tests/table/test_inspect.py
+++ b/tests/table/test_inspect.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
 from pathlib import PosixPath
 from typing import Any
 
@@ -29,7 +28,7 @@ from pyiceberg.table.inspect import InspectTable, _readable_bound
 from pyiceberg.table.snapshots import Snapshot
 from pyiceberg.transforms import IdentityTransform
 from pyiceberg.typedef import Record
-from pyiceberg.types import NestedField, StringType
+from pyiceberg.types import DoubleType, LongType, NestedField, StringType
 from tests.catalog.test_base import InMemoryCatalog
 
 
@@ -106,3 +105,16 @@ def test_inspect_manifests_preserves_empty_string_bounds(catalog: InMemoryCatalo
     partition_summary = tbl.inspect.manifests().to_pydict()["partition_summaries"][0][0]
     assert partition_summary["lower_bound"] == ""
     assert partition_summary["upper_bound"] == ""
+
+def test_readable_bound_type_promotions() -> None:
+    # 4-byte LE representation of integer 10 -> b'\x0a\x00\x00\x00'
+    four_byte_int_bound = b"\x0a\x00\x00\x00"
+
+    # 4-byte LE representation of float 10.0 -> b'\x00\x00\x20\x41'
+    four_byte_float_bound = b"\x00\x00\x20\x41"
+
+    # Test int -> long promotion decoding
+    assert _readable_bound(LongType(), four_byte_int_bound) == 10
+
+    # Test float -> double promotion decoding
+    assert _readable_bound(DoubleType(), four_byte_float_bound) == 10.0


### PR DESCRIPTION
Fixes #3744

### Summary
When a table undergoes spec-allowed type promotion (`int` → `long` or `float` → `double`), pre-existing manifest files retain their 4-byte bounds (`IntegerType` / `FloatType`). Currently, `_readable_bound` passes these bytes directly to `from_bytes(field.field_type, bound)`. Because `field.field_type` is updated to `LongType()` / `DoubleType()`, `from_bytes` attempts an 8-byte unpack (`_LONG_STRUCT.unpack(b)`), raising `struct.error: unpack requires a buffer of 8 bytes`.

### Changes Made
- Updated `_readable_bound` in `pyiceberg/table/inspect.py` to inspect byte lengths before decoding.
- If `field_type` is `LongType` / `DoubleType` and `len(bound) == 4`, decode using `IntegerType()` / `FloatType()`.
- Added unit tests in `tests/table/test_inspect.py` covering promoted bound deserialization for `LongType` and `DoubleType`.

### Testing
- `python -m pytest tests/table/test_inspect.py` (5/5 tests passed).