### PR TITLE
Build: Bump setuptools to 83.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ geoarrow = ["geoarrow-pyarrow>=0.2.0"]
 dev = [
     "pytest==9.1.1",
     "pytest-checkdocs==2.14.0",
+    "setuptools>=83.0.0",
     "prek>=0.2.1",
     "pytest-lazy-fixtures==1.4.0",
     "fastavro==1.12.2",
@@ -153,7 +154,7 @@ default-groups = [
 ]
 
 [build-system]
-requires = ["setuptools>=80", "wheel", "Cython>=3.0.0"]
+requires = ["setuptools>=83.0.0", "wheel", "Cython>=3.0.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]

--- a/uv.lock
+++ b/uv.lock
@@ -5003,6 +5003,7 @@ dev = [
     { name = "pytest-lazy-fixtures" },
     { name = "pytest-mock" },
     { name = "requests-mock" },
+    { name = "setuptools" },
     { name = "sqlalchemy" },
     { name = "typing-extensions" },
 ]
@@ -5095,6 +5096,7 @@ dev = [
     { name = "pytest-lazy-fixtures", specifier = "==1.4.0" },
     { name = "pytest-mock", specifier = "==3.15.1" },
     { name = "requests-mock", specifier = "==1.12.1" },
+    { name = "setuptools", specifier = ">=83.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.18,<3" },
     { name = "typing-extensions", specifier = "==4.16.0" },
 ]
@@ -6186,11 +6188,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.1"
+version = "83.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This is for to address security alert: https://github.com/apache/iceberg-python/security/dependabot/137

## Summary

- require setuptools 83.0.0 or newer in development and isolated build environments
- update the locked setuptools version from 82.0.1 to 83.0.0

## Why

Setuptools versions before 83.0.0 compare `MANIFEST.in` patterns and on-disk filenames without Unicode normalization. On normalization-preserving macOS filesystems, this can cause exclusion rules to miss non-ASCII filenames and unintentionally include excluded files in a published source distribution.

The build-system requirement previously allowed setuptools 80 through 82, and the development dependency graph resolved 82.0.1 through moto and pytest-checkdocs.

## Impact

This changes build and development tooling only. PyIceberg runtime dependencies and APIs are unchanged. Setuptools 83.0.0 requires Python 3.10 or newer, matching PyIceberg's supported Python range.

## Validation

- `uv lock --check --offline --default-index https://pypi.org/simple`
- `uv build --sdist`
- `git diff --check`
