### PR TITLE
bug: fix delete_data_file on partitioned tables

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -390,19 +390,16 @@ class Transaction:
 
         return updates, requirements
 
-    def _build_partition_predicate(
-        self, partition_records: set[Record], spec: PartitionSpec, schema: Schema
-    ) -> BooleanExpression:
+    def _build_partition_predicate(self, partition_records: set[Record], partition_fields: list[str]) -> BooleanExpression:
         """Build a filter predicate matching any of the input partition records.
 
         Args:
             partition_records: A set of partition records to match
-            spec: An optional partition spec, if none then defaults to current
-            schema: An optional schema, if none then defaults to current
+            partition_fields: The field names to reference for each position in a partition record
+
         Returns:
             A predicate matching any of the input partition records.
         """
-        partition_fields = [schema.find_field(field.source_id).name for field in spec.fields]
         if not partition_records or not partition_fields:
             return AlwaysFalse()
 
@@ -622,8 +619,11 @@ class Transaction:
         )
 
         partitions_to_overwrite = {data_file.partition for data_file in data_files}
+        partitions_fields = [
+            self.table_metadata.schema().find_field(field.source_id).name for field in self.table_metadata.spec().fields
+        ]
         delete_filter = self._build_partition_predicate(
-            partition_records=partitions_to_overwrite, spec=self.table_metadata.spec(), schema=self.table_metadata.schema()
+            partition_records=partitions_to_overwrite, partition_fields=partitions_fields
         )
         self.delete(
             delete_filter=delete_filter,

--- a/pyiceberg/table/update/snapshot.py
+++ b/pyiceberg/table/update/snapshot.py
@@ -528,11 +528,12 @@ class _SnapshotProducer(UpdateTableMetadata[U], Generic[U]):
             group.add(data_file.partition)
 
         for spec_id, partition_records in partition_to_overwrite.items():
-            self.delete_by_predicate(
+            self.partition_filters[spec_id] = Or(
+                self.partition_filters[spec_id],
                 self._transaction._build_partition_predicate(
-                    partition_records=partition_records, schema=self.schema(), spec=self.spec(spec_id)
-                ),
-                self._case_sensitive,
+                    partition_records=partition_records,
+                    partition_fields=[field.name for field in self.spec(spec_id).fields],
+                )
             )
 
 

--- a/pyiceberg/table/update/snapshot.py
+++ b/pyiceberg/table/update/snapshot.py
@@ -533,7 +533,7 @@ class _SnapshotProducer(UpdateTableMetadata[U], Generic[U]):
                 self._transaction._build_partition_predicate(
                     partition_records=partition_records,
                     partition_fields=[field.name for field in self.spec(spec_id).fields],
-                )
+                ),
             )
 
 

--- a/tests/table/test_init.py
+++ b/tests/table/test_init.py
@@ -24,6 +24,7 @@ import pytest
 from pydantic import BaseModel, ValidationError
 from pytest_lazy_fixtures import lf
 
+from pyiceberg.catalog import Catalog
 from pyiceberg.catalog.noop import NoopCatalog
 from pyiceberg.exceptions import CommitFailedException
 from pyiceberg.expressions import (
@@ -1990,6 +1991,30 @@ def test_build_large_partition_predicate(table_v2: Table) -> None:
         )
 
     bind(table_v2.metadata.schema(), expr, case_sensitive=True)
+
+
+def test_overwrite_delete_data_file_on_bucket_partition(catalog: Catalog) -> None:
+    """Delete a data file without projecting its already-transformed partition value again."""
+    import pyarrow as pa
+
+    from pyiceberg.io.pyarrow import schema_to_pyarrow
+
+    catalog.create_namespace("default")
+    schema = Schema(
+        NestedField(1, "tenant_id", StringType(), required=False),
+        NestedField(2, "value", IntegerType(), required=False),
+    )
+    spec = PartitionSpec(PartitionField(source_id=1, field_id=1000, transform=BucketTransform(8), name="tenant_id_bucket"))
+    table = catalog.create_table("default.bucket_file_delete", schema=schema, partition_spec=spec)
+
+    table.append(pa.Table.from_pylist([{"tenant_id": "tenant-a", "value": 1}], schema=schema_to_pyarrow(schema)))
+    data_file = next(iter(table.scan().plan_files())).file
+
+    with table.transaction() as transaction:
+        with transaction.update_snapshot().overwrite() as overwrite:
+            overwrite.delete_data_file(data_file)
+
+    assert table.scan().to_arrow().num_rows == 0
 
 
 def test_static_table_forwards_location_to_table_file_io(metadata_location: str, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/table/test_init.py
+++ b/tests/table/test_init.py
@@ -1982,10 +1982,11 @@ def test_check_uuid_passes_when_match(table_v2: Table, example_table_metadata_v2
 
 def test_build_large_partition_predicate(table_v2: Table) -> None:
     with table_v2.transaction() as tx:
+        schema = table_v2.schema()
+        spec = table_v2.spec()
         expr = tx._build_partition_predicate(
             partition_records={Record(i) for i in range(5000)},
-            spec=table_v2.metadata.spec(),
-            schema=table_v2.metadata.schema(),
+            partition_fields=[(schema.find_field(field.source_id).name) for field in spec.fields],
         )
 
     bind(table_v2.metadata.schema(), expr, case_sensitive=True)

--- a/tests/table/test_upsert.py
+++ b/tests/table/test_upsert.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from datetime import datetime
 from pathlib import PosixPath
 
 import pyarrow as pa
@@ -26,11 +27,13 @@ from pyiceberg.exceptions import NoSuchTableError
 from pyiceberg.expressions import AlwaysTrue, And, EqualTo, Reference
 from pyiceberg.expressions.literals import LongLiteral
 from pyiceberg.io.pyarrow import schema_to_pyarrow
+from pyiceberg.partitioning import PartitionField, PartitionSpec
 from pyiceberg.schema import Schema
 from pyiceberg.table import Table, UpsertResult
 from pyiceberg.table.snapshots import Operation
 from pyiceberg.table.upsert_util import create_match_filter
-from pyiceberg.types import IntegerType, NestedField, StringType, StructType
+from pyiceberg.transforms import DayTransform
+from pyiceberg.types import IntegerType, NestedField, StringType, StructType, TimestampType
 from tests.catalog.test_base import InMemoryCatalog
 
 
@@ -712,6 +715,42 @@ def test_upsert_with_nulls(catalog: Catalog) -> None:
         ],
         schema=schema,
     )
+
+
+def test_upsert_on_table_partitioned_by_transform(catalog: Catalog) -> None:
+    """Upsert has to rewrite the matched file on a table partitioned by a non-identity transform.
+
+    The manifest pruning in the overwrite builds its predicate from the partition records of
+    the deleted files. Those records hold already-transformed values, so referencing the source
+    column would send them through the transform twice, prune away the only relevant manifest
+    and leave the replaced row behind as a duplicate.
+    """
+    identifier = "default.test_upsert_on_table_partitioned_by_transform"
+    _drop_table(catalog, identifier)
+
+    schema = Schema(
+        NestedField(1, "k", StringType(), required=False),
+        NestedField(2, "v", IntegerType(), required=False),
+        NestedField(3, "ts", TimestampType(), required=False),
+    )
+    spec = PartitionSpec(PartitionField(source_id=3, field_id=1000, transform=DayTransform(), name="ts_day"))
+    table = catalog.create_table(identifier, schema, partition_spec=spec)
+
+    arrow_schema = schema_to_pyarrow(schema)
+    # A timestamp whose day ordinal is far from the value it would be read as if the
+    # DayTransform were applied a second time.
+    ts = datetime(2026, 1, 6, 12)
+
+    def rows(pairs: list[tuple[str, int]]) -> pa_table:
+        return pa.Table.from_pylist([{"k": k, "v": v, "ts": ts} for k, v in pairs], schema=arrow_schema)
+
+    table.append(rows([("a", 1), ("b", 1)]))
+
+    res = table.upsert(rows([("a", 2)]), join_cols=["k"])
+    assert_upsert_result(res, expected_updated=1, expected_inserted=0)
+
+    arrow = table.scan().to_arrow()
+    assert sorted(zip(arrow["k"].to_pylist(), arrow["v"].to_pylist(), strict=True)) == [("a", 2), ("b", 1)]
 
 
 def test_transaction(catalog: Catalog) -> None:


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
Closes #3779  
Related to #3758

# Rationale for this change

`_build_delete_files_partition_predicate` collects `data_file.partition` records from deleted files. These records contain already-transformed values, but they were passed to `Transaction._build_partition_predicate` using source column names. This caused the partition transform to be applied a second time.

## Are these changes tested?

Yes, added a regression test for upsert on a table with a non-identity partition transform.

## Are there any user-facing changes?

Yes, this fixes file deletion on tables with non-identity partition transforms.

<!-- In the case of user-facing changes, please add the changelog label. -->
