### PR TITLE
perf: cache Transaction.table_metadata between reads

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -241,6 +241,7 @@ class Transaction:
     _autocommit: bool
     _updates: tuple[TableUpdate, ...]
     _requirements: tuple[TableRequirement, ...]
+    _table_metadata_cache: tuple[TableMetadata, tuple[TableUpdate, ...], TableMetadata] | None
 
     def __init__(self, table: Table, autocommit: bool = False):
         """Open a transaction to stage and commit changes to a table.
@@ -255,10 +256,21 @@ class Transaction:
         self._requirements = ()
         self._snapshot_producers: list[_SnapshotProducer[Any]] = []
         self._failed = False
+        self._table_metadata_cache = None
 
     @property
     def table_metadata(self) -> TableMetadata:
-        return update_table_metadata(self._table.metadata, self._updates)
+        base, updates = self._table.metadata, self._updates
+        # update_table_metadata replays every staged update via model_copy(deep=True);
+        # the cache is keyed on the identity of its inputs so it self-invalidates
+        # whenever _updates is reassigned (tuple += creates a new object) or the
+        # underlying table metadata is refreshed.
+        cached = self._table_metadata_cache
+        if cached is not None and cached[0] is base and cached[1] is updates:
+            return cached[2]
+        result = update_table_metadata(base, updates)
+        self._table_metadata_cache = (base, updates, result)
+        return result
 
     def __enter__(self) -> Transaction:
         """Start a transaction to update the table."""

--- a/tests/table/test_init.py
+++ b/tests/table/test_init.py
@@ -2010,3 +2010,54 @@ def test_static_table_forwards_location_to_table_file_io(metadata_location: str,
 
     assert seen_locations, "expected at least one load_file_io call"
     assert all(loc is not None for loc in seen_locations), f"load_file_io called without a location: {seen_locations}"
+
+
+def test_transaction_table_metadata_cached(table_v2: Table) -> None:
+    """Repeated reads of an unchanged transaction state recompute at most once.
+
+    `Transaction.table_metadata` replays every staged update through
+    `model_copy(deep=True)`, so the cost of a read scales with the size of the
+    metadata (the snapshot list in particular), not with the work being done.
+    """
+    from unittest import mock
+
+    from pyiceberg.table.update import SetPropertiesUpdate, update_table_metadata
+
+    with mock.patch("pyiceberg.table.update_table_metadata", wraps=update_table_metadata) as spy:
+        txn = table_v2.transaction()
+
+        first = txn.table_metadata
+        for _ in range(10):
+            assert txn.table_metadata is first
+        assert spy.call_count == 1, f"expected 1 recompute for repeated reads, got {spy.call_count}"
+
+        txn._stage((SetPropertiesUpdate(updates={"k": "v"}),))
+        second = txn.table_metadata
+        assert second is not first
+        assert second.properties["k"] == "v"
+        for _ in range(10):
+            assert txn.table_metadata is second
+        assert spy.call_count == 2, f"expected 2 recomputes after one staged update, got {spy.call_count}"
+
+
+def test_transaction_table_metadata_cached_with_updates_already_staged(table_v2: Table) -> None:
+    """The cache must still hold once `_updates` is non-empty.
+
+    An empty-`_updates` short circuit (`return self._table.metadata` when nothing
+    is staged) would leave this case uncovered, and it is the expensive one:
+    `CreateTableTransaction` seeds `_updates` with ~10 entries before any write,
+    so a create-then-append transaction replays all of them on every read.
+    """
+    from unittest import mock
+
+    from pyiceberg.table.update import SetPropertiesUpdate, update_table_metadata
+
+    txn = table_v2.transaction()
+    txn._stage((SetPropertiesUpdate(updates={"staged": "before"}),))
+
+    with mock.patch("pyiceberg.table.update_table_metadata", wraps=update_table_metadata) as spy:
+        first = txn.table_metadata
+        for _ in range(10):
+            assert txn.table_metadata is first
+        assert first.properties["staged"] == "before"
+        assert spy.call_count == 1, f"expected 1 recompute with updates already staged, got {spy.call_count}"

--- a/tests/table/test_snapshots.py
+++ b/tests/table/test_snapshots.py
@@ -645,7 +645,13 @@ def test_snapshot_producer_bounded_metadata_access(table_v2: Table) -> None:
         spy.reset_mock()
         _MergeAppendFiles(operation=Operation.APPEND, transaction=txn, io=table_v2.io)
         merge_init = spy.call_count
-        assert merge_init - fast_init == 1, (
+        # Upper bound, not equality: `Transaction.table_metadata` caches on the identity of
+        # its inputs, so the second construction reads the same staged state and adds 0 calls.
+        # The trade-off is that this assertion no longer catches an un-hoisting of
+        # `_MergeAppendFiles.__init__` on its own — repeated reads of an unchanged state are
+        # free either way. What it still pins is that constructing the producer cannot start
+        # replaying updates per access again.
+        assert merge_init - fast_init <= 1, (
             f"_MergeAppendFiles.__init__ made {merge_init - fast_init} extra update_table_metadata "
-            "calls over its superclass; expected 1 (hoisted)"
+            "calls over its superclass; expected at most 1"
         )

--- a/tests/table/test_snapshots.py
+++ b/tests/table/test_snapshots.py
@@ -616,7 +616,8 @@ def test_snapshot_producer_bounded_metadata_access(table_v2: Table) -> None:
     """
     from unittest import mock
 
-    from pyiceberg.table.update import update_table_metadata
+    from pyiceberg.table import Transaction
+    from pyiceberg.table.metadata import TableMetadata
     from pyiceberg.table.update.snapshot import _FastAppendFiles, _MergeAppendFiles
 
     def make_file() -> DataFile:
@@ -624,29 +625,37 @@ def test_snapshot_producer_bounded_metadata_access(table_v2: Table) -> None:
 
     txn = table_v2.transaction()
 
-    with mock.patch("pyiceberg.table.update_table_metadata", wraps=update_table_metadata) as spy:
+    # Counts property reads rather than update_table_metadata calls: hoisting removes reads,
+    # and a read that the cache serves is still a read the hoisting was meant to remove.
+    reads = [0]
+    fget = Transaction.__dict__["table_metadata"].fget
+
+    def counting(self: Transaction) -> TableMetadata:
+        reads[0] += 1
+        return fget(self)
+
+    with mock.patch.object(Transaction, "table_metadata", property(counting)):
         # _summary() cost must not scale with the number of data files
-        def summary_calls(n_files: int) -> int:
+        def summary_reads(n_files: int) -> int:
             append = _FastAppendFiles(operation=Operation.APPEND, transaction=txn, io=table_v2.io)
             for _ in range(n_files):
                 append.append_data_file(make_file())
-            spy.reset_mock()
+            reads[0] = 0
             append._summary()
-            return spy.call_count
+            return reads[0]
 
-        few, many = summary_calls(10), summary_calls(100)
-        assert few == many, f"_summary() update_table_metadata calls scale with file count ({few} vs {many})"
-        assert many <= 2, f"_summary() triggered {many} update_table_metadata calls; expected O(1)"
+        few, many = summary_reads(10), summary_reads(100)
+        assert few == many, f"_summary() table_metadata reads scale with file count ({few} vs {many})"
+        assert many <= 2, f"_summary() made {many} table_metadata reads; expected O(1)"
 
-        # _MergeAppendFiles.__init__ should add exactly one call over _FastAppendFiles.__init__
-        spy.reset_mock()
+        # _MergeAppendFiles.__init__ should add exactly one read over _FastAppendFiles.__init__
+        reads[0] = 0
         _FastAppendFiles(operation=Operation.APPEND, transaction=txn, io=table_v2.io)
-        fast_init = spy.call_count
-        spy.reset_mock()
+        fast_init = reads[0]
+        reads[0] = 0
         _MergeAppendFiles(operation=Operation.APPEND, transaction=txn, io=table_v2.io)
-        merge_init = spy.call_count
-        # Upper bound, not equality: the cache absorbs this access when the staged state is unchanged.
-        assert merge_init - fast_init <= 1, (
-            f"_MergeAppendFiles.__init__ made {merge_init - fast_init} extra update_table_metadata "
-            "calls over its superclass; expected at most 1"
+        merge_init = reads[0]
+        assert merge_init - fast_init == 1, (
+            f"_MergeAppendFiles.__init__ made {merge_init - fast_init} extra table_metadata "
+            "reads over its superclass; expected 1 (hoisted)"
         )

--- a/tests/table/test_snapshots.py
+++ b/tests/table/test_snapshots.py
@@ -645,12 +645,7 @@ def test_snapshot_producer_bounded_metadata_access(table_v2: Table) -> None:
         spy.reset_mock()
         _MergeAppendFiles(operation=Operation.APPEND, transaction=txn, io=table_v2.io)
         merge_init = spy.call_count
-        # Upper bound, not equality: `Transaction.table_metadata` caches on the identity of
-        # its inputs, so the second construction reads the same staged state and adds 0 calls.
-        # The trade-off is that this assertion no longer catches an un-hoisting of
-        # `_MergeAppendFiles.__init__` on its own — repeated reads of an unchanged state are
-        # free either way. What it still pins is that constructing the producer cannot start
-        # replaying updates per access again.
+        # Upper bound, not equality: the cache absorbs this access when the staged state is unchanged.
         assert merge_init - fast_init <= 1, (
             f"_MergeAppendFiles.__init__ made {merge_init - fast_init} extra update_table_metadata "
             "calls over its superclass; expected at most 1"


### PR DESCRIPTION
# Rationale for this change

`Transaction.table_metadata` replays every staged update through `update_table_metadata`, which ends in `model_copy(deep=True)`. So a single read deep-copies the whole metadata object, snapshot list included, and its cost tracks table history rather than the work being done. Callers read the property many times per operation.

#2674 and #3301 hoisted repeated reads out of loops in `snapshot.py`. This goes after the same cost at the source: repeated reads of an unchanged transaction state now recompute once.

This carries forward #3302 by @rynewang, which @Fokko approved back in April and which the stale bot then closed for inactivity. Its branch is on a fork with `maintainerCanModify` off so it can't be reopened from outside, hence a new PR; authorship is kept via `Co-authored-by`.

## Numbers

We hit this in production. A writer that appends 1–6 rows at a time went from a mean of 2495 ms to 10302 ms when we upgraded 0.9.1 → 0.11.1 — same payloads, but the tables it writes to have long snapshot histories. With this cache it came back to 2856 ms. (10-minute bucket means over matched windows, n = 41–75 per bucket.)

Isolated against a local `SqlCatalog`, 20 timed appends per depth, 3 runs with the arms alternated, median:

| snapshots | without | with | |
|---|---|---|---|
| 0 | 7.7 ms | 4.3 ms | 1.8× |
| 100 | 42.4 ms | 13.2 ms | 3.2× |
| 300 | 104.4 ms | 24.3 ms | 4.3× |
| 500 | 173.4 ms | 36.2 ms | 4.8× |

`update_table_metadata` calls per append drop from 22 to 2 at every depth, and the resulting table is identical (rows, snapshots, schema). The multiplier grows with depth because each remaining recompute still copies a longer snapshot list — not because the cache does more work on deep histories. For the same reason the curve doesn't flatten: 4.3 ms at depth 0 against 36.2 ms at depth 500.

## On the simpler alternative from #3302

@geruh suggested `if not self._updates: return self._table.metadata` rather than a cache. That covers a bare append but misses the expensive case — `CreateTableTransaction._initial_changes()` seeds `_updates` with ~10 entries before any write, so it's never empty for the snapshot producer's lifetime. There's a test for that case now (`test_transaction_table_metadata_cached_with_updates_already_staged`) so it doesn't have to rest on an argument.

## Concurrency

The property does get read from worker threads — `_SnapshotProducer._manifests()` submits `_write_added_manifest` and `_write_delete_manifest` to the shared executor, and both reach it. A race there is harmless: two threads can both miss and both compute, the loser's result is dropped, and the entry is an immutable tuple assigned in a single store, so there's no half-built state to observe. If anything this narrows an existing gap, since without the cache each thread re-stamps `last_updated_ms` on its own and concurrent readers can already see metadata that differs.

# Are these changes tested?

Two new tests in `tests/table/test_init.py`, covering repeated reads and the already-staged case above. Both fail with the property reverted — I checked, rather than assuming they discriminate.

One existing test needed rework. `test_snapshot_producer_bounded_metadata_access` from #3301 asserts that `_MergeAppendFiles.__init__` makes exactly one more `update_table_metadata` call than its superclass. That count is a proxy for how many times the property is read, and the cache breaks the proxy — repeated reads collapse into one recompute, so an un-hoisting would slip through unnoticed.

Rather than loosen the assertion I switched the oracle to count property reads directly, which is what hoisting actually removes and which the cache doesn't affect. The original `== 1` stands. It passes with the cache and against `main` without it, and putting `__init__` back to three separate reads fails it.

Locally: `make test` passes (3931 passed, 3 skipped), `ruff check` is clean, and mypy reports nothing on `pyiceberg/table/__init__.py` that it doesn't already report on `main`.

# Are there any user-facing changes?

One: `last_updated_ms` on the returned metadata is now stable across repeated reads of the same logical state instead of being re-stamped with `now()` on every access. The timestamp written at commit time is unchanged. Nothing reads it expecting a fresh value per access — outside `table/metadata.py` and the commit path, the only consumer is `cli/output.py`, which prints it.
