### PR TITLE
fix: stop calling deprecated PuffinFile.to_vector in Spark DV test

### DIFF
--- a/tests/integration/test_deletes.py
+++ b/tests/integration/test_deletes.py
@@ -29,6 +29,7 @@ from pyiceberg.manifest import ManifestContent, ManifestEntryStatus
 from pyiceberg.partitioning import PartitionField, PartitionSpec
 from pyiceberg.schema import Schema
 from pyiceberg.table import Table
+from pyiceberg.table.deletion_vector import deletion_vectors_from_puffin_file
 from pyiceberg.table.puffin import PuffinFile
 from pyiceberg.table.snapshots import Operation, Summary
 from pyiceberg.transforms import IdentityTransform
@@ -1081,10 +1082,10 @@ def test_read_spark_written_puffin_dv(spark: SparkSession, session_catalog: Rest
     assert "referenced-data-file" in blob.properties
     assert blob.properties["cardinality"] == "4"
 
-    dv_dict = puffin.to_vector()
-    assert len(dv_dict) == 1, "Expected one data file's deletions"
+    dvs = deletion_vectors_from_puffin_file(puffin)
+    assert len(dvs) == 1, "Expected one data file's deletions"
 
-    for _data_file_path, chunked_array in dv_dict.items():
-        positions = chunked_array.to_pylist()
+    for dv in dvs:
+        positions = dv.to_vector().to_pylist()
         assert len(positions) == 4, f"Expected 4 deleted positions, got {len(positions)}"
         assert sorted(positions) == [9, 19, 29, 39], f"Unexpected positions: {positions}"


### PR DESCRIPTION
Closes #3803

# Rationale for this change

Follow-up to #3476. `test_read_spark_written_puffin_dv` still calls `PuffinFile.to_vector()`, which #3491 deprecated in 0.12.0. `filterwarnings = ["error"]` turns that into a hard CI failure, so `integration-test` is red on `main` and on unrelated PRs including #3801.

This test now uses `deletion_vectors_from_puffin_file(...)`, matching `pyiceberg/io/pyarrow.py`. Spark interop assertions are unchanged. Not part of #3801.

## Are these changes tested?

Yes. `make test-integration PYTEST_ARGS="-v -k test_read_spark_written_puffin_dv"` → 1 passed, 5517 deselected.

## Are there any user-facing changes?

No.
