### PR TITLE
Spark: Fix deprecated PuffinFile.to_vector call in test_read_spark_written_puffin_dv

### DIFF
--- a/tests/integration/test_deletes.py
+++ b/tests/integration/test_deletes.py
@@ -29,6 +29,7 @@ from pyiceberg.manifest import ManifestContent, ManifestEntryStatus
 from pyiceberg.partitioning import PartitionField, PartitionSpec
 from pyiceberg.schema import Schema
 from pyiceberg.table import Table
+from pyiceberg.table.deletion_vector import deletion_vectors_from_puffin_file
 from pyiceberg.table.puffin import PuffinFile
 from pyiceberg.table.snapshots import Operation, Summary
 from pyiceberg.transforms import IdentityTransform
@@ -1081,10 +1082,11 @@ def test_read_spark_written_puffin_dv(spark: SparkSession, session_catalog: Rest
     assert "referenced-data-file" in blob.properties
     assert blob.properties["cardinality"] == "4"
 
-    dv_dict = puffin.to_vector()
-    assert len(dv_dict) == 1, "Expected one data file's deletions"
+    dvs = deletion_vectors_from_puffin_file(puffin)
+    assert len(dvs) == 1, "Expected one data file's deletions"
 
-    for _data_file_path, chunked_array in dv_dict.items():
+    for dv in dvs:
+        chunked_array = dv.to_vector()
         positions = chunked_array.to_pylist()
         assert len(positions) == 4, f"Expected 4 deleted positions, got {len(positions)}"
         assert sorted(positions) == [9, 19, 29, 39], f"Unexpected positions: {positions}"


### PR DESCRIPTION
### Description

Fixes #3803.

`test_read_spark_written_puffin_dv` was invoking deprecated `PuffinFile.to_vector()`, which raised a `DeprecationWarning` and caused CI integration test failures under `filterwarnings = ["error"]`.

This PR replaces the deprecated call with `deletion_vectors_from_puffin_file(puffin)` and calls `dv.to_vector()` directly on each `DeletionVector` instance.