### PR TITLE
Infra: Enable pull request auto-merge

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -44,6 +44,8 @@ github:
 
       required_linear_history: true
   pull_requests:
+    # allow pull requests to merge automatically once all requirements are met
+    allow_auto_merge: true
     # auto-delete head branches after being merged
     del_branch_on_merge: true
   features:


### PR DESCRIPTION
# Rationale for this change

Maintainers currently need to revisit an approved PR after CI completes and merge it manually. This enables GitHub auto-merge through ASF's documented `github.pull_requests.allow_auto_merge` setting, reducing CI polling and context switching.

Before: maintainers wait for CI, return to the PR, and merge manually.

After: a maintainer can enable auto-merge once; GitHub waits for the existing review, CI, and branch-protection requirements, then merges automatically. If CI fails, auto-merge will not go through and the PR remains open.

ASF documentation: https://github.com/apache/infrastructure-asfyaml#pull-request-settings

## Are these changes tested?

Yes. YAML validation and repository pre-commit checks pass.

## Are there any user-facing changes?

No.
