### PR TITLE
Fix upsert after schema evolution

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -898,7 +898,7 @@ class Transaction:
         except ModuleNotFoundError as e:
             raise ModuleNotFoundError("For writes PyArrow needs to be installed") from e
 
-        from pyiceberg.io.pyarrow import ArrowScan, expression_to_pyarrow
+        from pyiceberg.io.pyarrow import expression_to_pyarrow
         from pyiceberg.table import upsert_util
 
         if join_cols is None:
@@ -934,15 +934,13 @@ class Transaction:
 
         matched_iceberg_file_scan = self._scan(row_filter=matched_predicate, case_sensitive=case_sensitive, branch=branch)
 
-        # The target branch determines which files to read; the transaction schema determines how to project their rows.
-        # These can differ because schema updates do not create snapshots.
-        matched_iceberg_record_batches = ArrowScan(
-            table_metadata=self.table_metadata,
-            io=self._table.io,
-            projected_schema=self.table_metadata.schema(),
-            row_filter=matched_predicate,
-            case_sensitive=case_sensitive,
-        ).to_record_batches(matched_iceberg_file_scan.plan_files())
+        # Plan files from the target branch, but read them using the transaction's current schema.
+        # A schema update does not create a snapshot, so the branch snapshot may use an older schema.
+        matched_iceberg_record_batches = _to_arrow_batch_reader_via_file_scan_tasks(
+            matched_iceberg_file_scan,
+            self.table_metadata.schema(),
+            matched_iceberg_file_scan.plan_files(),
+        )
 
         batches_to_overwrite = []
         overwrite_predicates = []

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -314,11 +314,19 @@ class Transaction:
 
         return self
 
-    def _scan(self, row_filter: str | BooleanExpression = ALWAYS_TRUE, case_sensitive: bool = True) -> DataScan:
-        """Minimal data scan of the table with the current state of the transaction."""
-        return DataScan(
+    def _scan(
+        self,
+        row_filter: str | BooleanExpression = ALWAYS_TRUE,
+        case_sensitive: bool = True,
+        branch: str | None = None,
+    ) -> DataScan:
+        """Minimal data scan of the current transaction state, optionally scoped to a branch."""
+        scan = DataScan(
             table_metadata=self.table_metadata, io=self._table.io, row_filter=row_filter, case_sensitive=case_sensitive
         )
+        if branch in self.table_metadata.refs:
+            return scan.use_ref(branch)
+        return scan
 
     def upgrade_table_version(self, format_version: TableVersion) -> Transaction:
         """Set the table to a certain version.
@@ -778,9 +786,7 @@ class Transaction:
             bound_delete_filter = bind(self.table_metadata.schema(), delete_filter, case_sensitive)
             preserve_row_filter = _expression_to_complementary_pyarrow(bound_delete_filter, self.table_metadata.schema())
 
-            file_scan = self._scan(row_filter=delete_filter, case_sensitive=case_sensitive)
-            if branch is not None:
-                file_scan = file_scan.use_ref(branch)
+            file_scan = self._scan(row_filter=delete_filter, case_sensitive=case_sensitive, branch=branch)
             files = file_scan.plan_files()
 
             commit_uuid = uuid.uuid4()
@@ -926,10 +932,7 @@ class Transaction:
         # get list of rows that exist so we don't have to load the entire target table
         matched_predicate = upsert_util.create_match_filter(df, join_cols)
 
-        matched_iceberg_file_scan = self._scan(row_filter=matched_predicate, case_sensitive=case_sensitive)
-
-        if branch in self.table_metadata.refs:
-            matched_iceberg_file_scan = matched_iceberg_file_scan.use_ref(branch)
+        matched_iceberg_file_scan = self._scan(row_filter=matched_predicate, case_sensitive=case_sensitive, branch=branch)
 
         # The target branch determines which files to read; the transaction schema determines how to project their rows.
         # These can differ because schema updates do not create snapshots.

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -892,7 +892,7 @@ class Transaction:
         except ModuleNotFoundError as e:
             raise ModuleNotFoundError("For writes PyArrow needs to be installed") from e
 
-        from pyiceberg.io.pyarrow import expression_to_pyarrow
+        from pyiceberg.io.pyarrow import ArrowScan, expression_to_pyarrow
         from pyiceberg.table import upsert_util
 
         if join_cols is None:
@@ -926,19 +926,20 @@ class Transaction:
         # get list of rows that exist so we don't have to load the entire target table
         matched_predicate = upsert_util.create_match_filter(df, join_cols)
 
-        # We must use Transaction.table_metadata for the scan. This includes all uncommitted - but relevant - changes.
-
-        matched_iceberg_record_batches_scan = DataScan(
-            table_metadata=self.table_metadata,
-            io=self._table.io,
-            row_filter=matched_predicate,
-            case_sensitive=case_sensitive,
-        )
+        matched_iceberg_file_scan = self._scan(row_filter=matched_predicate, case_sensitive=case_sensitive)
 
         if branch in self.table_metadata.refs:
-            matched_iceberg_record_batches_scan = matched_iceberg_record_batches_scan.use_ref(branch)
+            matched_iceberg_file_scan = matched_iceberg_file_scan.use_ref(branch)
 
-        matched_iceberg_record_batches = matched_iceberg_record_batches_scan.to_arrow_batch_reader()
+        # The target branch determines which files to read; the transaction schema determines how to project their rows.
+        # These can differ because schema updates do not create snapshots.
+        matched_iceberg_record_batches = ArrowScan(
+            table_metadata=self.table_metadata,
+            io=self._table.io,
+            projected_schema=self.table_metadata.schema(),
+            row_filter=matched_predicate,
+            case_sensitive=case_sensitive,
+        ).to_record_batches(matched_iceberg_file_scan.plan_files())
 
         batches_to_overwrite = []
         overwrite_predicates = []

--- a/tests/table/test_upsert.py
+++ b/tests/table/test_upsert.py
@@ -30,7 +30,6 @@ from pyiceberg.io.pyarrow import schema_to_pyarrow
 from pyiceberg.partitioning import PartitionField, PartitionSpec
 from pyiceberg.schema import Schema
 from pyiceberg.table import Table, UpsertResult
-from pyiceberg.table.refs import MAIN_BRANCH
 from pyiceberg.table.snapshots import Operation
 from pyiceberg.table.upsert_util import create_match_filter
 from pyiceberg.transforms import DayTransform
@@ -392,9 +391,50 @@ def test_upsert_with_identifier_fields(catalog: Catalog) -> None:
     assert [snap.summary.operation for snap in tbl.snapshots() if snap.summary is not None] == expected_operations
 
 
-@pytest.mark.parametrize("branch", [MAIN_BRANCH, "test_branch"])
-def test_upsert_after_schema_evolution(catalog: Catalog, branch: str) -> None:
+def test_upsert_after_schema_evolution(catalog: Catalog) -> None:
     identifier = "default.test_upsert_after_schema_evolution"
+    schema = Schema(
+        NestedField(1, "city", StringType(), required=True),
+        NestedField(2, "population", IntegerType(), required=True),
+        identifier_field_ids=[1],
+    )
+    tbl = catalog.create_table(identifier, schema=schema)
+    initial_arrow_schema = pa.schema(
+        [
+            pa.field("city", pa.string(), nullable=False),
+            pa.field("population", pa.int32(), nullable=False),
+        ]
+    )
+    tbl.append(pa.Table.from_pylist([{"city": "Amsterdam", "population": 921402}], schema=initial_arrow_schema))
+
+    snapshot_before_schema_update = tbl.current_snapshot()
+    assert snapshot_before_schema_update is not None
+
+    with tbl.update_schema() as update:
+        update.add_column("country", StringType())
+
+    assert tbl.schema().schema_id != snapshot_before_schema_update.schema_id
+    assert tbl.metadata.current_snapshot_id == snapshot_before_schema_update.snapshot_id
+
+    evolved_arrow_schema = pa.schema(
+        [
+            pa.field("city", pa.string(), nullable=False),
+            pa.field("population", pa.int32(), nullable=False),
+            pa.field("country", pa.string()),
+        ]
+    )
+    source = pa.Table.from_pylist(
+        [{"city": "Amsterdam", "population": 934927, "country": "Netherlands"}], schema=evolved_arrow_schema
+    )
+
+    result = tbl.upsert(source)
+
+    assert_upsert_result(result, expected_updated=1, expected_inserted=0)
+    assert tbl.scan().to_arrow().to_pylist() == [{"city": "Amsterdam", "population": 934927, "country": "Netherlands"}]
+
+
+def test_upsert_to_branch_after_schema_evolution(catalog: Catalog) -> None:
+    identifier = "default.test_upsert_to_branch_after_schema_evolution"
     schema = Schema(
         NestedField(1, "city", StringType(), required=True),
         NestedField(2, "population", IntegerType(), required=True),
@@ -412,9 +452,9 @@ def test_upsert_after_schema_evolution(catalog: Catalog, branch: str) -> None:
     initial_snapshot = tbl.current_snapshot()
     assert initial_snapshot is not None
 
-    if branch != MAIN_BRANCH:
-        tbl.manage_snapshots().create_branch(snapshot_id=initial_snapshot.snapshot_id, branch_name=branch).commit()
-        tbl.delete("city == 'Amsterdam'")
+    branch = "test_branch"
+    tbl.manage_snapshots().create_branch(snapshot_id=initial_snapshot.snapshot_id, branch_name=branch).commit()
+    tbl.delete("city == 'Amsterdam'")
 
     snapshot_before_schema_update = tbl.current_snapshot()
     assert snapshot_before_schema_update is not None
@@ -439,10 +479,10 @@ def test_upsert_after_schema_evolution(catalog: Catalog, branch: str) -> None:
     result = tbl.upsert(source, branch=branch)
 
     assert_upsert_result(result, expected_updated=1, expected_inserted=0)
-    result_scan = tbl.scan() if branch == MAIN_BRANCH else tbl.scan().use_ref(branch)
-    assert result_scan.to_arrow().to_pylist() == [{"city": "Amsterdam", "population": 934927, "country": "Netherlands"}]
-    if branch != MAIN_BRANCH:
-        assert tbl.scan().to_arrow().to_pylist() == []
+    assert tbl.scan().use_ref(branch).to_arrow().to_pylist() == [
+        {"city": "Amsterdam", "population": 934927, "country": "Netherlands"}
+    ]
+    assert tbl.scan().to_arrow().to_pylist() == []
 
 
 def test_upsert_into_empty_table(catalog: Catalog) -> None:

--- a/tests/table/test_upsert.py
+++ b/tests/table/test_upsert.py
@@ -30,6 +30,7 @@ from pyiceberg.io.pyarrow import schema_to_pyarrow
 from pyiceberg.partitioning import PartitionField, PartitionSpec
 from pyiceberg.schema import Schema
 from pyiceberg.table import Table, UpsertResult
+from pyiceberg.table.refs import MAIN_BRANCH
 from pyiceberg.table.snapshots import Operation
 from pyiceberg.table.upsert_util import create_match_filter
 from pyiceberg.transforms import DayTransform
@@ -389,6 +390,59 @@ def test_upsert_with_identifier_fields(catalog: Catalog) -> None:
     assert upd.rows_inserted == 0
 
     assert [snap.summary.operation for snap in tbl.snapshots() if snap.summary is not None] == expected_operations
+
+
+@pytest.mark.parametrize("branch", [MAIN_BRANCH, "test_branch"])
+def test_upsert_after_schema_evolution(catalog: Catalog, branch: str) -> None:
+    identifier = "default.test_upsert_after_schema_evolution"
+    schema = Schema(
+        NestedField(1, "city", StringType(), required=True),
+        NestedField(2, "population", IntegerType(), required=True),
+        identifier_field_ids=[1],
+    )
+    tbl = catalog.create_table(identifier, schema=schema)
+    initial_arrow_schema = pa.schema(
+        [
+            pa.field("city", pa.string(), nullable=False),
+            pa.field("population", pa.int32(), nullable=False),
+        ]
+    )
+    tbl.append(pa.Table.from_pylist([{"city": "Amsterdam", "population": 921402}], schema=initial_arrow_schema))
+
+    initial_snapshot = tbl.current_snapshot()
+    assert initial_snapshot is not None
+
+    if branch != MAIN_BRANCH:
+        tbl.manage_snapshots().create_branch(snapshot_id=initial_snapshot.snapshot_id, branch_name=branch).commit()
+        tbl.delete("city == 'Amsterdam'")
+
+    snapshot_before_schema_update = tbl.current_snapshot()
+    assert snapshot_before_schema_update is not None
+
+    with tbl.update_schema() as update:
+        update.add_column("country", StringType())
+
+    assert tbl.schema().schema_id != snapshot_before_schema_update.schema_id
+    assert tbl.metadata.current_snapshot_id == snapshot_before_schema_update.snapshot_id
+
+    evolved_arrow_schema = pa.schema(
+        [
+            pa.field("city", pa.string(), nullable=False),
+            pa.field("population", pa.int32(), nullable=False),
+            pa.field("country", pa.string()),
+        ]
+    )
+    source = pa.Table.from_pylist(
+        [{"city": "Amsterdam", "population": 934927, "country": "Netherlands"}], schema=evolved_arrow_schema
+    )
+
+    result = tbl.upsert(source, branch=branch)
+
+    assert_upsert_result(result, expected_updated=1, expected_inserted=0)
+    result_scan = tbl.scan() if branch == MAIN_BRANCH else tbl.scan().use_ref(branch)
+    assert result_scan.to_arrow().to_pylist() == [{"city": "Amsterdam", "population": 934927, "country": "Netherlands"}]
+    if branch != MAIN_BRANCH:
+        assert tbl.scan().to_arrow().to_pylist() == []
 
 
 def test_upsert_into_empty_table(catalog: Catalog) -> None:


### PR DESCRIPTION
Closes #2467

# Rationale for this change

Schema updates change the current table schema but do not create snapshots. The target branch can therefore still point to a snapshot with an older `schema_id`.

Before this change, upsert built its source and target rows with different schemas:

- The source is [validated against `self.table_metadata.schema()`](https://github.com/apache/iceberg-python/blob/8544bb40964cc9f6ae8f9ef92b605abf910ff0fe/pyiceberg/table/__init__.py#L916-L924), the current transaction schema and the schema [recorded on the new snapshot](https://github.com/apache/iceberg-python/blob/8544bb40964cc9f6ae8f9ef92b605abf910ff0fe/pyiceberg/table/update/snapshot.py#L346-L353).
- The matched target rows came from a branch scan. `use_ref()` [sets `snapshot_id`](https://github.com/apache/iceberg-python/blob/8544bb40964cc9f6ae8f9ef92b605abf910ff0fe/pyiceberg/table/__init__.py#L2210-L2214), which makes `DataScan.projection()` [use the snapshot schema](https://github.com/apache/iceberg-python/blob/8544bb40964cc9f6ae8f9ef92b605abf910ff0fe/pyiceberg/table/__init__.py#L2190-L2208).

After adding `created_at`, this produced:

```text
Source/current schema: cik_str, ticker, title, created_at
Target snapshot schema: cik_str, ticker, title
```

When `get_rows_to_update` [casts the source to the target Arrow schema](https://github.com/apache/iceberg-python/blob/8544bb40964cc9f6ae8f9ef92b605abf910ff0fe/pyiceberg/table/upsert_util.py#L88-L101), PyArrow reports:

```text
An error occurred during upsert: Target schema's field names are not matching the table's field names: ['cik_str', 'ticker', 'title', 'created_at'], ['cik_str', 'ticker', 'title']
```

The branch snapshot should determine which files to read, while the current transaction schema should define the rows being compared and written. This change [plans files from the target branch and materializes them with the current transaction schema](https://github.com/kevinjqliu/iceberg-python/blob/6e5522b5d7b878c0634e21a214960f7d49b9495e/pyiceberg/table/__init__.py#L932-L943). Older files are projected into the current schema, so the source and matched target rows have the same columns. Snapshot-based projection remains unchanged for normal and time-travel scans.

## Are these changes tested?

Yes. Added [regression tests for main and a diverged branch](https://github.com/kevinjqliu/iceberg-python/blob/6e5522b5d7b878c0634e21a214960f7d49b9495e/tests/table/test_upsert.py#L394-L485).

## Are there any user-facing changes?

Yes. Upsert works after schema evolution.