### PR TITLE
Honor identity sort orders for Arrow table writes

### DIFF
--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -50,6 +50,9 @@ from typing import (
     TypeVar,
     cast,
 )
+from typing import (
+    Literal as LiteralType,
+)
 from urllib.parse import urlparse
 
 import pyarrow as pa
@@ -3059,11 +3062,13 @@ def _dataframe_to_data_files(
 
 def _sort_table_for_write(table_metadata: TableMetadata, table: pa.Table) -> tuple[pa.Table, int | None]:
     """Apply a supported Iceberg sort order and return its file sort-order id."""
+    from packaging import version
+
     sort_order = table_metadata.sort_order()
     if sort_order.is_unsorted:
         return table, None
 
-    sort_keys: list[tuple[str, str]] = []
+    sort_keys: list[tuple[str, LiteralType["ascending", "descending"]]] = []
     null_orders = set()
     for field in sort_order.fields:
         if not isinstance(field.transform, IdentityTransform):
@@ -3079,15 +3084,22 @@ def _sort_table_for_write(table_metadata: TableMetadata, table: pa.Table) -> tup
                 stacklevel=2,
             )
             return table, None
-        direction = "descending" if field.direction == SortDirection.DESC else "ascending"
+        direction: LiteralType["ascending", "descending"] = "descending" if field.direction == SortDirection.DESC else "ascending"
         sort_keys.append((name, direction))
         null_orders.add(field.null_order)
 
     if len(null_orders) != 1:
         warnings.warn("Mixed null ordering is not supported; data files are marked unsorted", stacklevel=2)
         return table, None
-    null_placement = "at_start" if null_orders == {NullOrder.NULLS_FIRST} else "at_end"
-    indices = pc.sort_indices(table, sort_keys=sort_keys, null_placement=null_placement)
+    null_placement: LiteralType["at_start", "at_end"] = "at_start" if null_orders == {NullOrder.NULLS_FIRST} else "at_end"
+    if version.parse(pyarrow.__version__) < version.parse("25.0.0"):
+        indices = pc.sort_indices(table, sort_keys=sort_keys, null_placement=null_placement)
+    else:
+        # Per-key null placement replaced the SortOptions-level argument in Arrow 25
+        indices = pc.sort_indices(
+            table,
+            sort_keys=cast(Any, [(name, order, null_placement) for name, order in sort_keys]),
+        )
     return table.take(indices), sort_order.order_id
 
 

--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -152,6 +152,7 @@ from pyiceberg.table.locations import load_location_provider
 from pyiceberg.table.metadata import TableMetadata
 from pyiceberg.table.name_mapping import NameMapping, apply_name_mapping
 from pyiceberg.table.puffin import PuffinFile
+from pyiceberg.table.sorting import NullOrder, SortDirection
 from pyiceberg.transforms import IdentityTransform, TruncateTransform
 from pyiceberg.typedef import EMPTY_DICT, Properties, Record, TableVersion
 from pyiceberg.types import (
@@ -2763,10 +2764,7 @@ def write_file(io: FileIO, table_metadata: TableMetadata, tasks: Iterator[WriteT
             file_format=file_format,
             partition=task.partition_key.partition if task.partition_key else Record(),
             file_size_in_bytes=len(fo),
-            # After this has been fixed:
-            # https://github.com/apache/iceberg-python/issues/271
-            # sort_order_id=task.sort_order_id,
-            sort_order_id=None,
+            sort_order_id=task.sort_order_id,
             # Just copy these from the table for now
             spec_id=table_metadata.default_spec_id,
             equality_ids=None,
@@ -2998,6 +2996,7 @@ def _dataframe_to_data_files(
         downcast_ns_timestamp_to_us=downcast_ns_timestamp_to_us,
         format_version=table_metadata.format_version,
     )
+    sort_order = table_metadata.sort_order()
 
     if isinstance(df, pa.RecordBatchReader):
         if not table_metadata.spec().is_unpartitioned():
@@ -3005,6 +3004,11 @@ def _dataframe_to_data_files(
                 "Writing a pa.RecordBatchReader to a partitioned table is not yet supported. "
                 "Materialise the reader as a pa.Table first, or follow "
                 "https://github.com/apache/iceberg-python/issues/2152 for partitioned streaming support."
+            )
+        if not sort_order.is_unsorted:
+            warnings.warn(
+                "Sort order is not applied to streaming RecordBatchReader writes; data files are marked unsorted",
+                stacklevel=2,
             )
         yield from write_file(
             io=io,
@@ -3017,11 +3021,18 @@ def _dataframe_to_data_files(
         return
 
     if table_metadata.spec().is_unpartitioned():
+        df, sort_order_id = _sort_table_for_write(table_metadata, df)
         yield from write_file(
             io=io,
             table_metadata=table_metadata,
             tasks=(
-                WriteTask(write_uuid=write_uuid, task_id=next(counter), record_batches=batches, schema=task_schema)
+                WriteTask(
+                    write_uuid=write_uuid,
+                    task_id=next(counter),
+                    record_batches=batches,
+                    schema=task_schema,
+                    sort_order_id=sort_order_id,
+                )
                 for batches in bin_pack_arrow_table(df, target_file_size)
             ),
         )
@@ -3037,11 +3048,47 @@ def _dataframe_to_data_files(
                     record_batches=batches,
                     partition_key=partition.partition_key,
                     schema=task_schema,
+                    sort_order_id=sort_order_id,
                 )
                 for partition in partitions
-                for batches in bin_pack_arrow_table(partition.arrow_table_partition, target_file_size)
+                for sorted_partition, sort_order_id in [_sort_table_for_write(table_metadata, partition.arrow_table_partition)]
+                for batches in bin_pack_arrow_table(sorted_partition, target_file_size)
             ),
         )
+
+
+def _sort_table_for_write(table_metadata: TableMetadata, table: pa.Table) -> tuple[pa.Table, int | None]:
+    """Apply a supported Iceberg sort order and return its file sort-order id."""
+    sort_order = table_metadata.sort_order()
+    if sort_order.is_unsorted:
+        return table, None
+
+    sort_keys: list[tuple[str, str]] = []
+    null_orders = set()
+    for field in sort_order.fields:
+        if not isinstance(field.transform, IdentityTransform):
+            warnings.warn(
+                f"Unsupported sort transform {field.transform}; data files are marked unsorted",
+                stacklevel=2,
+            )
+            return table, None
+        name = table_metadata.schema().find_column_name(field.source_id)
+        if name is None or name not in table.column_names:
+            warnings.warn(
+                f"Unsupported nested or missing sort field id {field.source_id}; data files are marked unsorted",
+                stacklevel=2,
+            )
+            return table, None
+        direction = "descending" if field.direction == SortDirection.DESC else "ascending"
+        sort_keys.append((name, direction))
+        null_orders.add(field.null_order)
+
+    if len(null_orders) != 1:
+        warnings.warn("Mixed null ordering is not supported; data files are marked unsorted", stacklevel=2)
+        return table, None
+    null_placement = "at_start" if null_orders == {NullOrder.NULLS_FIRST} else "at_end"
+    indices = pc.sort_indices(table, sort_keys=sort_keys, null_placement=null_placement)
+    return table.take(indices), sort_order.order_id
 
 
 @dataclass(frozen=True)

--- a/tests/integration/test_writes/test_writes.py
+++ b/tests/integration/test_writes/test_writes.py
@@ -52,7 +52,7 @@ from pyiceberg.partitioning import PartitionField, PartitionSpec
 from pyiceberg.schema import Schema
 from pyiceberg.table import TableProperties
 from pyiceberg.table.refs import MAIN_BRANCH
-from pyiceberg.table.sorting import SortDirection, SortField, SortOrder
+from pyiceberg.table.sorting import NullOrder, SortDirection, SortField, SortOrder
 from pyiceberg.transforms import DayTransform, HourTransform, IdentityTransform, Transform
 from pyiceberg.types import (
     DateType,
@@ -1067,6 +1067,27 @@ def test_create_table_with_non_default_values(catalog: Catalog, table_schema_wit
     assert tbl.specs() == tbl_ref.specs()
     assert tbl.sort_order() == tbl_ref.sort_order()
     assert tbl.sort_orders() == tbl_ref.sort_orders()
+
+
+@pytest.mark.integration
+def test_write_identity_sort_order(session_catalog: Catalog) -> None:
+    identifier = "default.write_identity_sort_order"
+    schema = Schema(
+        NestedField(1, "id", LongType(), required=False),
+        NestedField(2, "value", StringType(), required=False),
+    )
+    table = session_catalog.create_table(
+        identifier,
+        schema,
+        sort_order=SortOrder(
+            SortField(1, IdentityTransform(), SortDirection.ASC, NullOrder.NULLS_LAST),
+        ),
+    )
+
+    table.append(pa.table({"id": [2, None, 1], "value": ["b", "null", "a"]}))
+
+    assert table.scan().to_arrow()["id"].to_pylist() == [1, 2, None]
+    assert table.inspect.data_files()["sort_order_id"].to_pylist() == [table.sort_order().order_id]
 
 
 @pytest.mark.integration

--- a/tests/io/test_pyarrow.py
+++ b/tests/io/test_pyarrow.py
@@ -76,6 +76,7 @@ from pyiceberg.io.pyarrow import (
     _determine_partitions,
     _primitive_to_physical,
     _read_deletes,
+    _sort_table_for_write,
     _task_to_record_batches,
     _to_requested_schema,
     bin_pack_arrow_table,
@@ -91,8 +92,9 @@ from pyiceberg.manifest import DataFile, DataFileContent, FileFormat
 from pyiceberg.partitioning import PartitionField, PartitionSpec
 from pyiceberg.schema import Schema, make_compatible_name, visit
 from pyiceberg.table import FileScanTask, TableProperties, WriteTask
-from pyiceberg.table.metadata import TableMetadataV2
+from pyiceberg.table.metadata import TableMetadataV2, new_table_metadata
 from pyiceberg.table.name_mapping import create_mapping_from_schema
+from pyiceberg.table.sorting import NullOrder, SortDirection, SortField, SortOrder
 from pyiceberg.transforms import HourTransform, IdentityTransform
 from pyiceberg.typedef import UTF8, Properties, Record, TableVersion
 from pyiceberg.types import (
@@ -125,6 +127,28 @@ skip_if_pyarrow_too_old = pytest.mark.skipif(
     version.parse(pyarrow.__version__) < version.parse("20.0.0"),
     reason="Requires pyarrow version >= 20.0.0",
 )
+
+
+def test_sort_table_for_identity_sort_order() -> None:
+    schema = Schema(
+        NestedField(1, "id", LongType(), required=False),
+        NestedField(2, "value", StringType(), required=False),
+    )
+    metadata = new_table_metadata(
+        schema=schema,
+        partition_spec=PartitionSpec(),
+        sort_order=SortOrder(
+            SortField(1, IdentityTransform(), SortDirection.ASC, NullOrder.NULLS_LAST),
+        ),
+        location="file:///tmp/sorted",
+        properties={},
+    )
+    table = pa.table({"id": [2, None, 1], "value": ["b", "null", "a"]})
+
+    sorted_table, sort_order_id = _sort_table_for_write(metadata, table)
+
+    assert sorted_table["id"].to_pylist() == [1, 2, None]
+    assert sort_order_id == metadata.default_sort_order_id
 
 
 def test_pyarrow_infer_local_fs_from_path() -> None:

--- a/tests/io/test_pyarrow.py
+++ b/tests/io/test_pyarrow.py
@@ -73,6 +73,7 @@ from pyiceberg.io.pyarrow import (
     StatsAggregator,
     _check_pyarrow_schema_compatible,
     _ConvertToArrowSchema,
+    _dataframe_to_data_files,
     _determine_partitions,
     _primitive_to_physical,
     _read_deletes,
@@ -129,7 +130,16 @@ skip_if_pyarrow_too_old = pytest.mark.skipif(
 )
 
 
-def test_sort_table_for_identity_sort_order() -> None:
+@pytest.mark.parametrize(
+    "direction, null_order, expected",
+    [
+        (SortDirection.ASC, NullOrder.NULLS_LAST, [1, 2, None]),
+        (SortDirection.ASC, NullOrder.NULLS_FIRST, [None, 1, 2]),
+        (SortDirection.DESC, NullOrder.NULLS_LAST, [2, 1, None]),
+        (SortDirection.DESC, NullOrder.NULLS_FIRST, [None, 2, 1]),
+    ],
+)
+def test_sort_table_for_identity_sort_order(direction: SortDirection, null_order: NullOrder, expected: list[int | None]) -> None:
     schema = Schema(
         NestedField(1, "id", LongType(), required=False),
         NestedField(2, "value", StringType(), required=False),
@@ -138,7 +148,7 @@ def test_sort_table_for_identity_sort_order() -> None:
         schema=schema,
         partition_spec=PartitionSpec(),
         sort_order=SortOrder(
-            SortField(1, IdentityTransform(), SortDirection.ASC, NullOrder.NULLS_LAST),
+            SortField(1, IdentityTransform(), direction, null_order),
         ),
         location="file:///tmp/sorted",
         properties={},
@@ -147,8 +157,42 @@ def test_sort_table_for_identity_sort_order() -> None:
 
     sorted_table, sort_order_id = _sort_table_for_write(metadata, table)
 
-    assert sorted_table["id"].to_pylist() == [1, 2, None]
+    assert sorted_table["id"].to_pylist() == expected
     assert sort_order_id == metadata.default_sort_order_id
+
+
+def test_write_sorted_data_files_per_partition(tmp_path: str) -> None:
+    schema = Schema(
+        NestedField(1, "id", LongType(), required=False),
+        NestedField(2, "category", StringType(), required=False),
+    )
+    metadata = new_table_metadata(
+        schema=schema,
+        partition_spec=PartitionSpec(PartitionField(source_id=2, field_id=1000, transform=IdentityTransform(), name="category")),
+        sort_order=SortOrder(
+            SortField(1, IdentityTransform(), SortDirection.ASC, NullOrder.NULLS_LAST),
+        ),
+        location=f"file://{tmp_path}/sorted-partitioned",
+        properties={},
+    )
+    table = pa.table(
+        {
+            "id": [3, None, 1, 2, None, 4],
+            "category": ["a", "b", "b", "a", "a", "b"],
+        }
+    )
+
+    data_files = list(_dataframe_to_data_files(table_metadata=metadata, df=table, io=PyArrowFileIO()))
+
+    assert len(data_files) == 2  # one data file per partition
+    for data_file in data_files:
+        assert data_file.sort_order_id == metadata.default_sort_order_id
+        input_file = PyArrowFileIO().new_input(data_file.file_path)
+        with input_file.open() as f:
+            read_table = pq.read_table(f)
+        assert len(read_table["category"].unique()) == 1  # rows belong to a single partition
+        ids = read_table["id"].to_pylist()
+        assert ids == sorted(ids, key=lambda v: (v is None, v))  # ascending, nulls last
 
 
 def test_pyarrow_infer_local_fs_from_path() -> None:


### PR DESCRIPTION
Related: https://github.com/apache/iceberg-python/issues/271 and #3848

# Rationale for this change

PyIceberg accepts table sort metadata but currently writes unsorted files and hard-codes `sort_order_id=None`. This prevents readers from safely using sort-order-aware pruning and leaves manifest metadata inconsistent with users' write intent.

## What changes?

Honors table sort orders for materialized `pyarrow.Table` writes when every sort field uses an identity transform and one consistent null placement:

- sorts unpartitioned tables before bin packing
- sorts each final Iceberg partition independently before bin packing
- carries the table sort-order ID through `WriteTask`
- writes the truthful `DataFile.sort_order_id`

Unsupported transforms, nested/missing fields, mixed null placement, and streaming `RecordBatchReader` writes preserve current behavior: data is not claimed as sorted and the file sort-order ID remains null. A warning explains why.

## Are these changes tested?

- Unit tests cover ascending/descending ordering, nulls-first/nulls-last placement, the returned sort-order ID, and the partitioned write path
- Integration test verifies scan order and manifest `sort_order_id` against a REST catalog
- `PYTHONPATH=. uv run pytest tests/io/test_pyarrow.py -k "sort_table_for_identity_sort_order or write_sorted_data_files_per_partition" -q` — passed
- `ruff check` on changed files — passed
- `git diff --check` — passed

## Are there any user-facing changes?

Yes. Tables with an identity-transform sort order now write physically sorted data files carrying the truthful `sort_order_id`; previously all files were written unsorted with a null sort-order ID. Unsupported sort orders keep the previous behavior. Changelog label requested.

Tooling note: developed with assistance from DS v4 Pro. I reviewed and verified the changes.
