### PR TITLE
Fix strict evaluation for negative record counts

### DIFF
--- a/pyiceberg/expressions/visitors.py
+++ b/pyiceberg/expressions/visitors.py
@@ -1527,11 +1527,13 @@ class _StrictMetricsEvaluator:
         Returns: false if the file may contain any row that doesn't match
                     the expression, true otherwise.
         """
-        if file.record_count <= 0:
-            # Older version don't correctly implement record count from avro file and thus
-            # set record count -1 when importing avro tables to iceberg tables. This should
-            # be updated once we implemented and set correct record count.
+        if file.record_count == 0:
             return ROWS_MUST_MATCH
+
+        if file.record_count < 0:
+            # Older versions set the record count to -1 when importing Avro tables.
+            # Treat an unknown count conservatively rather than as an empty file.
+            return ROWS_MIGHT_NOT_MATCH
 
         return visit(self.expr, _StrictMetricsEvaluationVisitor(self.struct, file))
 

--- a/tests/expressions/test_evaluator.py
+++ b/tests/expressions/test_evaluator.py
@@ -1523,7 +1523,7 @@ def test_metrics_evaluator_record_count_short_circuits() -> None:
     )
     assert _InclusiveMetricsEvaluator(schema, EqualTo("x", 10)).eval(negative_record_file) is ROWS_MIGHT_MATCH
     assert _StrictMetricsEvaluator(schema, EqualTo("x", 10)).eval(zero_record_file) is ROWS_MUST_MATCH
-    assert _StrictMetricsEvaluator(schema, EqualTo("x", 10)).eval(negative_record_file) is ROWS_MUST_MATCH
+    assert _StrictMetricsEvaluator(schema, EqualTo("x", 10)).eval(negative_record_file) is ROWS_MIGHT_NOT_MATCH
 
 
 def test_strict_not(schema_data_file: Schema, strict_data_file_1: DataFile) -> None:


### PR DESCRIPTION
## Summary

- Treat `record_count == 0` as empty in strict metrics evaluation.
- Treat negative legacy/unknown counts conservatively as `ROWS_MIGHT_NOT_MATCH`.
- Update the record-count short-circuit regression test.

This prevents strict evaluation from classifying files with unknown counts as fully matching, which can incorrectly authorize whole-file deletion.

Java validates newly built files with `recordCount >= 0` ([DataFiles.java](https://github.com/apache/iceberg/blob/7f879b11366e17a676a03f15247a821751415529/core/src/main/java/org/apache/iceberg/DataFiles.java#L334-L341)), while manifest reads instantiate through Avro ([GenericDataFile.java](https://github.com/apache/iceberg/blob/7f879b11366e17a676a03f15247a821751415529/core/src/main/java/org/apache/iceberg/GenericDataFile.java#L29-L37)). Its inclusive evaluator handles negative counts as unknown ([InclusiveMetricsEvaluator.java](https://github.com/apache/iceberg/blob/7f879b11366e17a676a03f15247a821751415529/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java#L78-L87)); the strict evaluator still groups them with empty files ([StrictMetricsEvaluator.java](https://github.com/apache/iceberg/blob/7f879b11366e17a676a03f15247a821751415529/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java#L82-L85)).

Related to #3498.

## Tests

- `uv run pytest tests/expressions/test_evaluator.py -q`