### PR TITLE
Infra: Enable Merge Queue with required CI gates

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -36,8 +36,6 @@ github:
   protected_branches:
     main:
       required_status_checks:
-        # strict means "Require branches to be up to date before merging".
-        strict: true
         contexts:
           # Repository policy and security checks.
           - Analyze Actions
@@ -58,6 +56,25 @@ github:
         required_approving_review_count: 1
 
       required_linear_history: true
+  rulesets:
+    - name: Merge Queue
+      target: branch
+      enforcement: active
+      conditions:
+        ref_name:
+          include:
+            - "~DEFAULT_BRANCH"
+          exclude: []
+      rules:
+        - type: merge_queue
+          parameters:
+            check_response_timeout_minutes: 90
+            grouping_strategy: ALLGREEN
+            max_entries_to_build: 1
+            max_entries_to_merge: 1
+            merge_method: SQUASH
+            min_entries_to_merge: 1
+            min_entries_to_merge_wait_minutes: 0
   pull_requests:
     # allow pull requests to merge automatically once all requirements are met
     allow_auto_merge: true

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -38,6 +38,26 @@ github:
       required_status_checks:
         # strict means "Require branches to be up to date before merging".
         strict: true
+        contexts:
+          - Analyze Actions
+          - CodeQL
+          - Run zizmor 🌈
+          - asf-allowlist-check
+          - cibw-dev-env-smoke-test
+          - docs
+          - integration-coverage-report
+          - integration-test
+          - integration-test-adls
+          - integration-test-gcs
+          - integration-test-s3
+          - lint-and-unit-test (3.10)
+          - lint-and-unit-test (3.11)
+          - lint-and-unit-test (3.12)
+          - lint-and-unit-test (3.13)
+          - lint-and-unit-test (3.14)
+          - markdown-link-check
+          - rat
+          - windows-unit-test (3.12)
 
       required_pull_request_reviews:
         required_approving_review_count: 1

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -39,7 +39,6 @@ github:
         contexts:
           # Repository policy and security checks.
           - Analyze Actions
-          - CodeQL
           - Run zizmor 🌈
           - asf-allowlist-check
           - rat

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -39,25 +39,32 @@ github:
         # strict means "Require branches to be up to date before merging".
         strict: true
         contexts:
+          # Repository policy and security checks.
           - Analyze Actions
           - CodeQL
           - Run zizmor 🌈
           - asf-allowlist-check
-          - cibw-dev-env-smoke-test
+          - rat
+
+          # Documentation checks.
           - docs
-          - integration-coverage-report
-          - integration-test
-          - integration-test-adls
-          - integration-test-gcs
-          - integration-test-s3
+          - markdown-link-check
+
+          # Python CI checks.
+          - cibw-dev-env-smoke-test
           - lint-and-unit-test (3.10)
           - lint-and-unit-test (3.11)
           - lint-and-unit-test (3.12)
           - lint-and-unit-test (3.13)
           - lint-and-unit-test (3.14)
-          - markdown-link-check
-          - rat
           - windows-unit-test (3.12)
+
+          # Python integration checks.
+          - integration-coverage-report
+          - integration-test
+          - integration-test-adls
+          - integration-test-gcs
+          - integration-test-s3
 
       required_pull_request_reviews:
         required_approving_review_count: 1

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -50,21 +50,9 @@ github:
           - docs
           - markdown-link-check
 
-          # Python CI checks.
-          - cibw-dev-env-smoke-test
-          - lint-and-unit-test (3.10)
-          - lint-and-unit-test (3.11)
-          - lint-and-unit-test (3.12)
-          - lint-and-unit-test (3.13)
-          - lint-and-unit-test (3.14)
-          - windows-unit-test (3.12)
-
-          # Python integration checks.
-          - integration-coverage-report
-          - integration-test
-          - integration-test-adls
-          - integration-test-gcs
-          - integration-test-s3
+          # Python workflow gates.
+          - python-ci-required
+          - python-integration-required
 
       required_pull_request_reviews:
         required_approving_review_count: 1

--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -25,6 +25,7 @@ name: "ASF Allowlist Check"
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - main

--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -24,6 +24,7 @@
 name: "ASF Allowlist Check"
 
 on:
+  # Do not add pull_request path filters: skipped workflows do not report required checks, which blocks auto-merge indefinitely.
   pull_request:
   push:
     branches:

--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -24,7 +24,6 @@
 name: "ASF Allowlist Check"
 
 on:
-  # Do not add pull_request path filters: skipped workflows do not report required checks, which blocks auto-merge indefinitely.
   pull_request:
   push:
     branches:

--- a/.github/workflows/check-md-link.yml
+++ b/.github/workflows/check-md-link.yml
@@ -27,6 +27,7 @@ on:
     branches:
     - 'main'
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/check-md-link.yml
+++ b/.github/workflows/check-md-link.yml
@@ -26,6 +26,7 @@ on:
       - 'mkdocs/**'
     branches:
     - 'main'
+  # Do not add pull_request path filters: skipped workflows do not report required checks, which blocks auto-merge indefinitely.
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/check-md-link.yml
+++ b/.github/workflows/check-md-link.yml
@@ -26,7 +26,6 @@ on:
       - 'mkdocs/**'
     branches:
     - 'main'
-  # Do not add pull_request path filters: skipped workflows do not report required checks, which blocks auto-merge indefinitely.
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/check-md-link.yml
+++ b/.github/workflows/check-md-link.yml
@@ -27,9 +27,6 @@ on:
     branches:
     - 'main'
   pull_request:
-    paths:
-      - '.github/workflows/check-md-link.yml'
-      - 'mkdocs/**'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,6 +24,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  merge_group:
   schedule:
     - cron: '16 4 * * 1'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,6 @@ name: "CodeQL"
 on:
   push:
     branches: [ "main" ]
-  # Do not add pull_request path filters: skipped workflows do not report required checks, which blocks auto-merge indefinitely.
   pull_request:
     branches: [ "main" ]
   schedule:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,6 +22,7 @@ name: "CodeQL"
 on:
   push:
     branches: [ "main" ]
+  # Do not add pull_request path filters: skipped workflows do not report required checks, which blocks auto-merge indefinitely.
   pull_request:
     branches: [ "main" ]
   schedule:

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -18,7 +18,9 @@
 #
 
 name: "Run License Check"
-on: pull_request
+on:
+  pull_request:
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -18,6 +18,7 @@
 #
 
 name: "Run License Check"
+# Do not add pull_request path filters: skipped workflows do not report required checks, which blocks auto-merge indefinitely.
 on: pull_request
 
 permissions:

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -18,7 +18,6 @@
 #
 
 name: "Run License Check"
-# Do not add pull_request path filters: skipped workflows do not report required checks, which blocks auto-merge indefinitely.
 on: pull_request
 
 permissions:

--- a/.github/workflows/python-ci-docs.yml
+++ b/.github/workflows/python-ci-docs.yml
@@ -24,6 +24,7 @@ on:
     branches:
       - 'main'
   pull_request:
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/python-ci-docs.yml
+++ b/.github/workflows/python-ci-docs.yml
@@ -23,7 +23,6 @@ on:
   push:
     branches:
       - 'main'
-  # Do not add pull_request path filters: skipped workflows do not report required checks, which blocks auto-merge indefinitely.
   pull_request:
 
 permissions:

--- a/.github/workflows/python-ci-docs.yml
+++ b/.github/workflows/python-ci-docs.yml
@@ -23,6 +23,7 @@ on:
   push:
     branches:
       - 'main'
+  # Do not add pull_request path filters: skipped workflows do not report required checks, which blocks auto-merge indefinitely.
   pull_request:
 
 permissions:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -24,6 +24,7 @@ on:
     branches:
     - 'main'
   pull_request:
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -24,19 +24,6 @@ on:
     branches:
     - 'main'
   pull_request:
-    paths:
-    - '**'                              # Include all files and directories in the repository by default.
-    - '!.github/workflows/**'           # Exclude all workflow files
-    - '.github/workflows/python-ci.yml' # except the current file.
-    - '!.github/ISSUE_TEMPLATE/**'      # Exclude files and directories that don't impact tests or code like templates, metadata, and documentation.
-    - '!.gitignore'
-    - '!.asf.yml'
-    - '!mkdocs/**'
-    - '!.gitattributes'
-    - '!README.md'
-    - '!CONTRIBUTING.md'
-    - '!LICENSE'
-    - '!NOTICE'
 
 permissions:
   contents: read

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -23,6 +23,7 @@ on:
   push:
     branches:
     - 'main'
+  # Do not add pull_request path filters: skipped workflows do not report required checks, which blocks auto-merge indefinitely.
   pull_request:
 
 permissions:
@@ -114,3 +115,17 @@ jobs:
       run: uv sync --directory . --only-group dev --no-install-project
     - name: Mirror wheel CIBW_TEST_COMMAND
       run: uv run --directory . pytest tests/avro/test_decoder.py
+
+  python-ci-required:
+    if: ${{ always() }}
+    needs: [lint-and-unit-test, windows-unit-test, cibw-dev-env-smoke-test]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Verify Python CI jobs succeeded
+      env:
+        RESULTS: ${{ join(needs.*.result, ' ') }}
+      run: |
+        read -ra results <<< "$RESULTS"
+        for result in "${results[@]}"; do
+          test "$result" = "success"
+        done

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -23,7 +23,6 @@ on:
   push:
     branches:
     - 'main'
-  # Do not add pull_request path filters: skipped workflows do not report required checks, which blocks auto-merge indefinitely.
   pull_request:
 
 permissions:

--- a/.github/workflows/python-integration.yml
+++ b/.github/workflows/python-integration.yml
@@ -24,6 +24,7 @@ on:
     branches:
     - 'main'
   pull_request:
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/python-integration.yml
+++ b/.github/workflows/python-integration.yml
@@ -23,6 +23,7 @@ on:
   push:
     branches:
     - 'main'
+  # Do not add pull_request path filters: skipped workflows do not report required checks, which blocks auto-merge indefinitely.
   pull_request:
 
 permissions:
@@ -176,3 +177,17 @@ jobs:
         merge-multiple: true
     - name: Generate coverage report (75%) # Coverage threshold should only increase over time — never decrease it!
       run: COVERAGE_FAIL_UNDER=75 make coverage-report
+
+  python-integration-required:
+    if: ${{ always() }}
+    needs: [integration-test, integration-test-s3, integration-test-adls, integration-test-gcs, integration-coverage-report]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Verify Python integration jobs succeeded
+      env:
+        RESULTS: ${{ join(needs.*.result, ' ') }}
+      run: |
+        read -ra results <<< "$RESULTS"
+        for result in "${results[@]}"; do
+          test "$result" = "success"
+        done

--- a/.github/workflows/python-integration.yml
+++ b/.github/workflows/python-integration.yml
@@ -24,13 +24,6 @@ on:
     branches:
     - 'main'
   pull_request:
-    paths:                                       # Only run integration tests when Python (or the code they exercise) changes.
-    - '**/*.py'
-    - 'pyproject.toml'
-    - 'uv.lock'
-    - 'Makefile'
-    - 'dev/**'                                   # docker-compose files and fixtures used by the integration suites.
-    - '.github/workflows/python-integration.yml' # this file itself.
 
 permissions:
   contents: read

--- a/.github/workflows/python-integration.yml
+++ b/.github/workflows/python-integration.yml
@@ -23,7 +23,6 @@ on:
   push:
     branches:
     - 'main'
-  # Do not add pull_request path filters: skipped workflows do not report required checks, which blocks auto-merge indefinitely.
   pull_request:
 
 permissions:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -24,6 +24,7 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["**"]
+  merge_group:
 
 permissions: {}
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -22,7 +22,6 @@ name: GitHub Actions Security Analysis with zizmor 🌈
 on:
   push:
     branches: ["main"]
-  # Do not add pull_request path filters: skipped workflows do not report required checks, which blocks auto-merge indefinitely.
   pull_request:
     branches: ["**"]
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -22,6 +22,7 @@ name: GitHub Actions Security Analysis with zizmor 🌈
 on:
   push:
     branches: ["main"]
+  # Do not add pull_request path filters: skipped workflows do not report required checks, which blocks auto-merge indefinitely.
   pull_request:
     branches: ["**"]
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,13 @@ lives under `pyiceberg/`, organized by concern rather than by engine:
 - Use existing test fixtures when possible.
 - We have a strong bias towards integration testing over mocks. Mocks should be avoided whenever possible and should only be used if similar, existing tests are using mocks.
 
+### Required CI and Merge Queue
+
+- Keep the `required_status_checks.contexts` list in `.asf.yaml` synchronized whenever a required job/check is added, renamed, or removed. Each entry is a job/check context name, not a workflow filename.
+- Verify that every required context reports for both `pull_request` and `merge_group`. Its producer workflow must run on both events.
+- When a workflow uses an aggregate required job, such as `python-ci-required`, keep `if: always()` and its `needs` list in sync with every job whose result should block merging.
+- Do not use `pull_request` path filters in workflows that produce required contexts. A skipped workflow does not report its required context, which blocks pull requests and causes Merge Queue entries to time out.
+
 ## Commands
 
 - **Install / set up dev env:** `make install` (installs `uv`, syncs all extras, builds Cython, installs pre-commit hooks)


### PR DESCRIPTION
# Rationale

[PR #3815](https://github.com/apache/iceberg-python/pull/3815) enabled auto-merge. This PR completes that work by adding the required checks and configuration needed for GitHub Merge Queue.

## Changes

- **Required checks:** `.asf.yaml` defines the checks Merge Queue must wait for. Stable aggregate Python gates cover all jobs and always report a final result, following DataFusion's pattern ([workflow](https://github.com/apache/datafusion/blob/3c021aceb50546ed1a1235afd207df7cc70e6d00/.github/workflows/rust.yml#L836-L862), [required context](https://github.com/apache/datafusion/blob/3c021aceb50546ed1a1235afd207df7cc70e6d00/.asf.yaml#L53-L59)). `Analyze Actions` gates the CodeQL workflow; the separate `CodeQL` status is omitted because it is not reported for merge groups ([GitHub CodeQL issue](https://github.com/github/codeql-action/issues/1537)).
- **Always-reported checks:** Workflow-level path filters are removed because a skipped required workflow leaves PRs and queue entries blocked. DataFusion performs path-based skipping inside an always-triggered workflow instead ([lines 24-50](https://github.com/apache/datafusion/blob/3c021aceb50546ed1a1235afd207df7cc70e6d00/.github/workflows/rust.yml#L24-L50)).
- **Merge Queue policy:** An ASF-managed raw ruleset requires one-at-a-time squash merges on the default branch ([ASF rulesets](https://github.com/apache/infrastructure-asfyaml/blob/main/README.md#rulesets)). `strict` is omitted because Merge Queue provides up-to-date validation and ASF defaults it to `false` ([ASF branch protection](https://github.com/apache/infrastructure-asfyaml/blob/main/README.md#branch-protection)).
- **Queue CI:** Required workflows handle `merge_group`; GitHub requires this event for queue checks to report ([GitHub documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions)). This matches DataFusion's configuration ([lines 24-39](https://github.com/apache/datafusion/blob/351675ddc27c42684a079b3a89fe2dee581d89a2/.github/workflows/rust.yml#L24-L39)).

## Testing

Repository lint hooks, YAML validation, and workflow coverage assertions pass. No user-facing changes.
