### PR TITLE
fix(rest-catalog): serialize purgeRequested as lowercase boolean string

### DIFF
--- a/pyiceberg/catalog/rest/__init__.py
+++ b/pyiceberg/catalog/rest/__init__.py
@@ -1132,7 +1132,7 @@ class RestCatalog(Catalog):
         self._check_endpoint(Capability.V1_DELETE_TABLE)
         response = self._session.delete(
             self.url(Endpoints.drop_table, prefixed=True, **self._split_identifier_for_path(identifier)),
-            params={"purgeRequested": purge_requested},
+            params={"purgeRequested": "true" if purge_requested else "false"},
         )
         try:
             response.raise_for_status()


### PR DESCRIPTION
* Python's requests library serializes bool True as "True" (capitalized) in query parameters. Per OpenAPI 3.0 spec (JSON Schema Wright Draft 00, RFC 7159 Section 3), boolean query parameters must be serialized as lowercase "true"/"false". Servers that strictly validate boolean values (e.g., Aliyun OSS Tables) reject "True" with 400 Bad Request.

* Use explicit "true"/"false" string literals for spec-compliant wire format.

<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

## Are these changes tested?

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
