### PR TITLE
Manifest: Use int for equality_ids in manifest schema per Iceberg spec (#3840)

### DIFF
--- a/pyiceberg/avro/resolver.py
+++ b/pyiceberg/avro/resolver.py
@@ -461,9 +461,24 @@ class ReadSchemaResolver(PrimitiveWithPartnerVisitor[IcebergType, Reader]):
 
             # ensure that the type can be projected to the expected
             if primitive != expected_primitive:
+                if self._is_legacy_long_equality_ids(primitive, expected_primitive):
+                    return IntegerReader()
                 promote(primitive, expected_primitive)
 
         return super().primitive(primitive, expected_primitive)
+
+    def _is_legacy_long_equality_ids(self, primitive: PrimitiveType, expected_primitive: PrimitiveType) -> bool:
+        # PyIceberg previously wrote the wrong schema, list<long>, for equality_ids; the Iceberg spec requires list<int>.
+        # The default schema now uses list<int>, but the schema promotion rules do not allow reading long as int.
+        # Ints and longs share the same Avro encoding, so allow this exact mismatch for the equality_ids element (136)
+        # when reading existing files.
+        # See: https://github.com/apache/iceberg-python/issues/3840
+        # See: https://iceberg.apache.org/spec/#manifests
+        return (
+            self.context == [2, 135, 136]  # field id path from manifest_entry: data_file (2), equality_ids (135), element (136)
+            and isinstance(primitive, LongType)
+            and isinstance(expected_primitive, IntegerType)
+        )
 
     def visit_boolean(self, boolean_type: BooleanType, partner: IcebergType | None) -> Reader:
         return BooleanReader()

--- a/pyiceberg/manifest.py
+++ b/pyiceberg/manifest.py
@@ -295,7 +295,7 @@ DATA_FILE_TYPE: dict[int, StructType] = {
         NestedField(
             field_id=135,
             name="equality_ids",
-            field_type=ListType(element_id=136, element_type=LongType(), element_required=True),
+            field_type=ListType(element_id=136, element_type=IntegerType(), element_required=True),
             required=False,
             doc="Field ids used to determine row equality in equality delete files.",
         ),
@@ -390,7 +390,7 @@ DATA_FILE_TYPE: dict[int, StructType] = {
         NestedField(
             field_id=135,
             name="equality_ids",
-            field_type=ListType(element_id=136, element_type=LongType(), element_required=True),
+            field_type=ListType(element_id=136, element_type=IntegerType(), element_required=True),
             required=False,
             doc="Field ids used to determine row equality in equality delete files.",
         ),

--- a/tests/utils/test_manifest.py
+++ b/tests/utils/test_manifest.py
@@ -25,10 +25,11 @@ import pytest
 
 import pyiceberg.manifest as manifest_module
 from pyiceberg.avro.codecs import AvroCompressionCodec
-from pyiceberg.avro.file import AvroOutputFile
+from pyiceberg.avro.file import AvroFile, AvroOutputFile
 from pyiceberg.io import load_file_io
 from pyiceberg.io.pyarrow import PyArrowFileIO
 from pyiceberg.manifest import (
+    DATA_FILE_TYPE,
     MANIFEST_ENTRY_SCHEMAS,
     MANIFEST_LIST_FILE_SCHEMAS,
     DataFile,
@@ -50,7 +51,7 @@ from pyiceberg.partitioning import UNPARTITIONED_PARTITION_SPEC, PartitionSpec
 from pyiceberg.schema import Schema
 from pyiceberg.table.snapshots import Operation, Snapshot, Summary
 from pyiceberg.typedef import Record, TableVersion
-from pyiceberg.types import IntegerType, NestedField
+from pyiceberg.types import IntegerType, ListType, LongType, NestedField, StructType
 
 
 @pytest.fixture(autouse=True)
@@ -292,6 +293,57 @@ def test_read_manifest_entry_v3_fields(tmp_path: Path) -> None:
     assert delete_file.referenced_data_file == "s3://bucket/data.parquet"
     assert delete_file.content_offset == 1
     assert delete_file.content_size_in_bytes == 46
+
+
+def test_read_legacy_long_equality_ids(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Manifests written by older PyIceberg versions with equality_ids as list<long> can still be read.
+
+    PyIceberg previously wrote the wrong schema, list<long>, for equality_ids; the Iceberg spec requires list<int>.
+    The default schema now uses list<int>, so reading existing manifests relies on the fallback in the Avro resolver.
+    See: https://github.com/apache/iceberg-python/issues/3840
+    See: https://iceberg.apache.org/spec/#manifests
+    """
+    io = PyArrowFileIO()
+    manifest_path = str(tmp_path / "manifest.avro")
+
+    entry = ManifestEntry.from_args(
+        status=ManifestEntryStatus.ADDED,
+        snapshot_id=1,
+        sequence_number=1,
+        file_sequence_number=1,
+        data_file=DataFile.from_args(
+            content=DataFileContent.EQUALITY_DELETES,
+            file_path="s3://bucket/deletes.parquet",
+            file_format=FileFormat.PARQUET,
+            partition=Record(),
+            record_count=10,
+            file_size_in_bytes=1024,
+            equality_ids=[1, 2],
+        ),
+    )
+
+    # Write the manifest as older PyIceberg versions did, with equality_ids as list<long>
+    legacy_data_file_type = StructType(
+        *[
+            NestedField(135, "equality_ids", ListType(136, LongType()), required=False) if field.field_id == 135 else field
+            for field in DATA_FILE_TYPE[2].fields
+        ]
+    )
+    with monkeypatch.context() as legacy:
+        legacy.setitem(DATA_FILE_TYPE, 2, legacy_data_file_type)
+        with write_manifest(
+            format_version=2,
+            spec=UNPARTITIONED_PARTITION_SPEC,
+            schema=Schema(NestedField(1, "foo", IntegerType(), False)),
+            output_file=io.new_output(manifest_path),
+            snapshot_id=1,
+            avro_compression="null",
+        ) as writer:
+            writer.add_entry(entry)
+    with AvroFile[ManifestEntry](io.new_input(manifest_path)) as avro_file:
+        assert avro_file.schema.find_field("data_file.equality_ids").field_type == ListType(136, LongType())
+
+    assert writer.to_manifest_file().fetch_manifest_entry(io)[0].data_file.equality_ids == [1, 2]
 
 
 def test_read_manifest_list(generated_manifest_file_file_v1: str) -> None:


### PR DESCRIPTION
### Description

Fixes #3840.

The Iceberg specification defines `data_file.equality_ids` (field 135, with element field 136) as `list<int>`. PyIceberg instead declared it as `list<long>` in its format-version 2 and 3 data-file schemas. Although PyIceberg does not currently produce equality-delete files through its table APIs, this field is present in every manifest schema, so strict readers such as `iceberg-cpp` can reject otherwise ordinary manifests written by PyIceberg.

This PR:

1. Changes `DATA_FILE_TYPE` for format versions 2 and 3 to declare `equality_ids` as `list<int>`, so newly written manifests use the spec-compliant schema.
2. Preserves PyIceberg's ability to read existing manifests by handling `long` → `int` only at the exact manifest field-ID path `[2, 135, 136]` (`data_file.equality_ids.element`). Avro `int` and `long` use the same zigzag-varint encoding, so the legacy value can be decoded with `IntegerReader` without enabling general narrowing promotion.
3. Adds an end-to-end regression test that writes a version 2 manifest using the legacy `list<long>` schema, verifies the schema stored in the Avro file, and reads the manifest through the normal `ManifestFile` path.

This change does not rewrite existing manifest files; it stops producing the incorrect schema while retaining read compatibility so those manifests can be migrated separately.

### Testing

- Added regression coverage for reading a legacy `list<long>` `equality_ids` manifest.
- Required Python CI and integration checks pass.