### PR TITLE
Avro: Cache Avro schema conversion in AvroFileHeader.get_schema (#3662)

### DIFF
--- a/pyiceberg/avro/file.py
+++ b/pyiceberg/avro/file.py
@@ -25,6 +25,7 @@ import os
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
+from functools import lru_cache
 from types import TracebackType
 from typing import (
     Generic,
@@ -68,6 +69,12 @@ META_SCHEMA = StructType(
 _SCHEMA_KEY = "avro.schema"
 
 
+@lru_cache(maxsize=128)
+def _parse_avro_schema(avro_schema_string: str) -> Schema:
+    avro_schema = json.loads(avro_schema_string)
+    return AvroSchemaConversion().avro_to_iceberg(avro_schema)
+
+
 class AvroFileHeader(Record):
     @property
     def magic(self) -> bytes:
@@ -97,9 +104,7 @@ class AvroFileHeader(Record):
 
     def get_schema(self) -> Schema:
         if _SCHEMA_KEY in self.meta:
-            avro_schema_string = self.meta[_SCHEMA_KEY]
-            avro_schema = json.loads(avro_schema_string)
-            return AvroSchemaConversion().avro_to_iceberg(avro_schema)
+            return _parse_avro_schema(self.meta[_SCHEMA_KEY])
         else:
             raise ValueError("No schema found in Avro file headers")
 

--- a/tests/avro/test_file.py
+++ b/tests/avro/test_file.py
@@ -87,6 +87,18 @@ def test_missing_schema() -> None:
     assert "No schema found in Avro file headers" in str(exc_info.value)
 
 
+def test_get_schema_is_cached() -> None:
+    schema_json = '{"type": "record", "name": "r", "fields": [{"name": "id", "type": "int", "field-id": 1}]}'
+    header1 = AvroFileHeader(bytes(0), {"avro.schema": schema_json}, bytes(16))
+    header2 = AvroFileHeader(bytes(0), {"avro.schema": schema_json}, bytes(16))
+
+    schema1 = header1.get_schema()
+    schema2 = header2.get_schema()
+
+    assert schema1 == schema2
+    assert schema1 is schema2
+
+
 # helper function to serialize our objects to dicts to enable
 # direct comparison with the dicts returned by fastavro
 def todict(obj: Any) -> Any:


### PR DESCRIPTION
### Description
Fixes #3662.

Every manifest file under a partition spec embeds an identical Avro schema string (`avro.schema`). Previously, `AvroFileHeader.get_schema()` in `pyiceberg/avro/file.py` performed a full `json.loads()` and recursive `AvroSchemaConversion().avro_to_iceberg()` conversion on every manifest read during scan planning.

This PR adds an LRU cache for Avro schema string parsing via `_parse_avro_schema`, avoiding redundant conversions across repeated manifest reads during scan planning (e.g. accelerating `scan().plan_files()` by ~1.8x on tables with many manifests).

### Testing
- Added unit test `test_get_schema_is_cached` in `tests/avro/test_file.py`.
- All 49 Avro and manifest tests pass locally.