### PR TITLE
SQL Catalog: Filter on iceberg_type in commit_table (#3337)

### DIFF
--- a/pyiceberg/catalog/sql.py
+++ b/pyiceberg/catalog/sql.py
@@ -517,6 +517,7 @@ class SqlCatalog(MetastoreCatalog):
         with Session(self.engine) as session:
             if current_table:
                 # table exists, update it
+                type_filter = self._iceberg_type_filter()
                 if self.engine.dialect.supports_sane_rowcount:
                     stmt = (
                         update(IcebergTables)
@@ -531,12 +532,14 @@ class SqlCatalog(MetastoreCatalog):
                             previous_metadata_location=current_table.metadata_location,
                         )
                     )
+                    if type_filter is not None:
+                        stmt = stmt.where(type_filter)
                     result = session.execute(stmt)
                     if result.rowcount < 1:
                         raise CommitFailedException(f"Table has been updated by another process: {namespace}.{table_name}")
                 else:
                     try:
-                        tbl = (
+                        query = (
                             session.query(IcebergTables)
                             .with_for_update(of=IcebergTables)
                             .filter(
@@ -545,8 +548,10 @@ class SqlCatalog(MetastoreCatalog):
                                 IcebergTables.table_name == table_name,
                                 IcebergTables.metadata_location == current_table.metadata_location,
                             )
-                            .one()
                         )
+                        if type_filter is not None:
+                            query = query.filter(type_filter)
+                        tbl = query.one()
                         tbl.metadata_location = updated_staged_table.metadata_location
                         tbl.previous_metadata_location = current_table.metadata_location
                     except NoResultFound as e:

--- a/tests/catalog/test_sql.py
+++ b/tests/catalog/test_sql.py
@@ -32,6 +32,7 @@ from pyiceberg.catalog.sql import (
     SqlCatalogBaseTable,
 )
 from pyiceberg.exceptions import (
+    CommitFailedException,
     NoSuchPropertyException,
     NoSuchTableError,
     TableAlreadyExistsError,
@@ -382,6 +383,31 @@ def test_rename_table_ignores_view_rows(warehouse: Path) -> None:
         catalog.rename_table(("ns", "a_view"), ("ns", "renamed_view"))
 
     # The view row must not have been renamed.
+    with catalog.engine.connect() as conn:
+        row = conn.execute(text("SELECT iceberg_type FROM iceberg_tables WHERE table_name = 'a_view'")).fetchone()
+    assert row is not None
+    assert row[0] == "VIEW"
+
+
+def test_commit_table_ignores_view_rows(warehouse: Path) -> None:
+    catalog = SqlCatalog(
+        name="test", uri=f"sqlite:///{warehouse.as_posix()}/test_commit_view.db", warehouse=f"file://{warehouse}"
+    )
+    catalog.create_namespace("ns")
+    schema = Schema(NestedField(1, "id", StringType(), required=True))
+    tbl = catalog.create_table(("ns", "a_view"), schema=schema)
+
+    # Tamper the table row into a VIEW (simulating external writer)
+    with catalog.engine.connect() as conn:
+        conn.execute(text("UPDATE iceberg_tables SET iceberg_type = 'VIEW' WHERE table_name = 'a_view'"))
+        conn.commit()
+
+    # Attempting to commit table updates must fail and not modify the VIEW row
+    with pytest.raises(CommitFailedException):
+        with tbl.update_schema() as update:
+            update.add_column("new_col", StringType())
+
+    # The view row must remain untouched with iceberg_type == 'VIEW'
     with catalog.engine.connect() as conn:
         row = conn.execute(text("SELECT iceberg_type FROM iceberg_tables WHERE table_name = 'a_view'")).fetchone()
     assert row is not None

--- a/tests/catalog/test_sql.py
+++ b/tests/catalog/test_sql.py
@@ -18,6 +18,7 @@
 from collections.abc import Generator
 from pathlib import Path
 from typing import cast
+from unittest.mock import patch
 
 import pytest
 from sqlalchemy import Engine, create_engine, inspect, text
@@ -395,21 +396,27 @@ def test_commit_table_ignores_view_rows(warehouse: Path) -> None:
     )
     catalog.create_namespace("ns")
     schema = Schema(NestedField(1, "id", StringType(), required=True))
-    tbl = catalog.create_table(("ns", "a_view"), schema=schema)
+    tbl = catalog.create_table(("ns", "a_table"), schema=schema)
 
-    # Tamper the table row into a VIEW (simulating external writer)
+    tx = tbl.transaction()
+    tx.set_properties({"key": "val"})
+    updates = tuple(tx._updates)
+    requirements = tuple(tx._requirements)
+
+    # Tamper the table row into a VIEW (simulating concurrent change to VIEW after load_table)
     with catalog.engine.connect() as conn:
-        conn.execute(text("UPDATE iceberg_tables SET iceberg_type = 'VIEW' WHERE table_name = 'a_view'"))
+        conn.execute(text("UPDATE iceberg_tables SET iceberg_type = 'VIEW' WHERE table_name = 'a_table'"))
         conn.commit()
 
-    # Attempting to commit table updates must fail and not modify the VIEW row
-    with pytest.raises(CommitFailedException):
-        with tbl.update_schema() as update:
-            update.add_column("new_col", StringType())
+    # When load_table returns the pre-loaded table, commit_table must fail in the SQL UPDATE
+    # due to type_filter and not overwrite the VIEW row.
+    with patch.object(catalog, "load_table", return_value=tbl):
+        with pytest.raises(CommitFailedException, match="Table has been updated by another process: ns.a_table"):
+            catalog.commit_table(tbl, requirements=requirements, updates=updates)
 
     # The view row must remain untouched with iceberg_type == 'VIEW'
     with catalog.engine.connect() as conn:
-        row = conn.execute(text("SELECT iceberg_type FROM iceberg_tables WHERE table_name = 'a_view'")).fetchone()
+        row = conn.execute(text("SELECT iceberg_type FROM iceberg_tables WHERE table_name = 'a_table'")).fetchone()
     assert row is not None
     assert row[0] == "VIEW"
 


### PR DESCRIPTION
### Description
Fixes #3337.

In `SqlCatalog`, `_iceberg_type_filter()` was added in #3263 to filter on `iceberg_type` (matching `TABLE` or `NULL`) and avoid operating on `VIEW` rows written by other Iceberg implementations (e.g., Java or Rust). While `load_table`, `drop_table`, `rename_table`, and `list_tables` incorporate this filter, `commit_table` omitted `type_filter` in its SQL update statement.

This PR applies `type_filter = self._iceberg_type_filter()` to the `commit_table` update query in `pyiceberg/catalog/sql.py`.

### Testing
- Added unit test `test_commit_table_ignores_view_rows` in `tests/catalog/test_sql.py`.
- All 31 catalog unit tests pass locally.