### PR TITLE
Add Windows ARM64 support to CI

### DIFF
--- a/.github/workflows/pypi-build-artifacts.yml
+++ b/.github/workflows/pypi-build-artifacts.yml
@@ -36,7 +36,11 @@ jobs:
     strategy:
       max-parallel: 15
       matrix:
-        os: [ ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-15-intel, macos-latest ]
+        os: [ ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm, macos-15-intel, macos-latest ]
+        include:
+          - os: windows-11-arm
+            before_test: "uv pip install pytest==9.1.1"
+            test_command: "python -m pytest --confcutdir={project}/tests/avro {project}/tests/avro/test_decoder.py"
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -79,8 +83,10 @@ jobs:
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.10,<3.15"
           # Keep these in sync with Python CI job `cibw-dev-env-smoke-test`
           # in .github/workflows/python-ci.yml to catch import-time regressions early.
-          CIBW_BEFORE_TEST: "uv sync --directory {project} --only-group dev --no-install-project"
-          CIBW_TEST_COMMAND: "uv run --directory {project} pytest tests/avro/test_decoder.py"
+          # PyArrow does not publish Windows ARM64 wheels, so that runner uses
+          # the minimal test environment configured in the matrix.
+          CIBW_BEFORE_TEST: ${{ matrix.before_test || 'uv sync --directory {project} --only-group dev --no-install-project' }}
+          CIBW_TEST_COMMAND: ${{ matrix.test_command || 'uv run --directory {project} pytest tests/avro/test_decoder.py' }}
           # Skip free-threaded (PEP 703) builds until we evaluate decoder_fast support
           CIBW_SKIP: "cp3*t-*"
 

--- a/.github/workflows/pypi-build-artifacts.yml
+++ b/.github/workflows/pypi-build-artifacts.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       max-parallel: 15
       matrix:
-        os: [ ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm, macos-15-intel, macos-latest ]
+        os: [ ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-15-intel, macos-latest ]
         include:
           - os: windows-11-arm
             before_test: "uv pip install pytest==9.1.1"

--- a/.github/workflows/pypi-build-artifacts.yml
+++ b/.github/workflows/pypi-build-artifacts.yml
@@ -39,6 +39,7 @@ jobs:
         os: [ ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-15-intel, macos-latest ]
         include:
           - os: windows-11-arm
+            windows_archs: "ARM64"
             before_test: "uv pip install pytest==9.1.1"
             test_command: "python -m pytest --confcutdir={project}/tests/avro {project}/tests/avro/test_decoder.py"
 
@@ -80,11 +81,13 @@ jobs:
         env:
           # Ignore 32 bit architectures
           CIBW_ARCHS: "auto64"
+          CIBW_ARCHS_WINDOWS: ${{ matrix.windows_archs || 'auto64' }}
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.10,<3.15"
           # Keep these in sync with Python CI job `cibw-dev-env-smoke-test`
           # in .github/workflows/python-ci.yml to catch import-time regressions early.
-          # PyArrow does not publish Windows ARM64 wheels, so that runner uses
-          # the minimal test environment configured in the matrix.
+          # Every platform runs the decoder wheel smoke test. PyArrow does not
+          # publish Windows ARM64 wheels, so that runner uses a minimal test
+          # environment and avoids loading the repository-wide conftest.
           CIBW_BEFORE_TEST: ${{ matrix.before_test || 'uv sync --directory {project} --only-group dev --no-install-project' }}
           CIBW_TEST_COMMAND: ${{ matrix.test_command || 'uv run --directory {project} pytest tests/avro/test_decoder.py' }}
           # Skip free-threaded (PEP 703) builds until we evaluate decoder_fast support

--- a/.github/workflows/svn-build-artifacts.yml
+++ b/.github/workflows/svn-build-artifacts.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       max-parallel: 15
       matrix:
-        os: [ ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm, macos-15-intel, macos-latest ]
+        os: [ ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-15-intel, macos-latest ]
         include:
           - os: windows-11-arm
             before_test: "uv pip install pytest==9.1.1"

--- a/.github/workflows/svn-build-artifacts.yml
+++ b/.github/workflows/svn-build-artifacts.yml
@@ -36,7 +36,11 @@ jobs:
     strategy:
       max-parallel: 15
       matrix:
-        os: [ ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-15-intel, macos-latest ]
+        os: [ ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm, macos-15-intel, macos-latest ]
+        include:
+          - os: windows-11-arm
+            before_test: "uv pip install pytest==9.1.1"
+            test_command: "python -m pytest --confcutdir={project}/tests/avro {project}/tests/avro/test_decoder.py"
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -71,8 +75,10 @@ jobs:
           # Ignore 32 bit architectures
           CIBW_ARCHS: "auto64"
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.10,<3.15"
-          CIBW_BEFORE_TEST: "uv sync --directory {project} --only-group dev --no-install-project"
-          CIBW_TEST_COMMAND: "uv run --directory {project} pytest tests/avro/test_decoder.py"
+          # PyArrow does not publish Windows ARM64 wheels, so that runner uses
+          # the minimal test environment configured in the matrix.
+          CIBW_BEFORE_TEST: ${{ matrix.before_test || 'uv sync --directory {project} --only-group dev --no-install-project' }}
+          CIBW_TEST_COMMAND: ${{ matrix.test_command || 'uv run --directory {project} pytest tests/avro/test_decoder.py' }}
           # Skip free-threaded (PEP 703) builds until we evaluate decoder_fast support
           CIBW_SKIP: "cp3*t-*"
 

--- a/.github/workflows/svn-build-artifacts.yml
+++ b/.github/workflows/svn-build-artifacts.yml
@@ -39,6 +39,7 @@ jobs:
         os: [ ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-15-intel, macos-latest ]
         include:
           - os: windows-11-arm
+            windows_archs: "ARM64"
             before_test: "uv pip install pytest==9.1.1"
             test_command: "python -m pytest --confcutdir={project}/tests/avro {project}/tests/avro/test_decoder.py"
 
@@ -74,9 +75,11 @@ jobs:
         env:
           # Ignore 32 bit architectures
           CIBW_ARCHS: "auto64"
+          CIBW_ARCHS_WINDOWS: ${{ matrix.windows_archs || 'auto64' }}
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.10,<3.15"
-          # PyArrow does not publish Windows ARM64 wheels, so that runner uses
-          # the minimal test environment configured in the matrix.
+          # Every platform runs the decoder wheel smoke test. PyArrow does not
+          # publish Windows ARM64 wheels, so that runner uses a minimal test
+          # environment and avoids loading the repository-wide conftest.
           CIBW_BEFORE_TEST: ${{ matrix.before_test || 'uv sync --directory {project} --only-group dev --no-install-project' }}
           CIBW_TEST_COMMAND: ${{ matrix.test_command || 'uv run --directory {project} pytest tests/avro/test_decoder.py' }}
           # Skip free-threaded (PEP 703) builds until we evaluate decoder_fast support


### PR DESCRIPTION
Hi @kevinjqliu , I'm from Microsoft and recently I'm working on improving Python ecosystem support for Windows on Arm.
So I updates the CI workflows to add support for Windows ARM64 builds and tests. Could you please help to review? Thanks.

# Rationale for this change

Add Windows ARM64 to the PyPI and source distribution artifact build workflows.

Because PyArrow does not currently publish Windows ARM64 wheels, the Windows ARM64 runner uses a minimal test environment with `pytest==9.1.1` and runs the Avro decoder test directly. Other platforms continue to use the existing development-environment setup and test command.

## Are these changes tested?

The Windows ARM64 configuration runs:

```text
python -m pytest --confcutdir={project}/tests/avro {project}/tests/avro/test_decoder.py