### PR TITLE
Fix TruncateTransform.satisfies_order_of for different widths (#3680)

### DIFF
--- a/pyiceberg/transforms.py
+++ b/pyiceberg/transforms.py
@@ -779,7 +779,6 @@ class TruncateTransform(Transform[S, S]):
     """
 
     root: str = Field()
-    _source_type: IcebergType = PrivateAttr()
     _width: PositiveInt = PrivateAttr()
 
     def __init__(self, width: int, **data: Any):
@@ -795,10 +794,6 @@ class TruncateTransform(Transform[S, S]):
     @property
     def preserves_order(self) -> bool:
         return True
-
-    @property
-    def source_type(self) -> IcebergType:
-        return self._source_type
 
     def project(self, name: str, pred: BoundPredicate) -> UnboundPredicate | None:
         field_type = pred.term.ref().field.field_type

--- a/pyiceberg/transforms.py
+++ b/pyiceberg/transforms.py
@@ -896,11 +896,7 @@ class TruncateTransform(Transform[S, S]):
     def satisfies_order_of(self, other: Transform[S, T]) -> bool:
         if self == other:
             return True
-        elif (
-            isinstance(self.source_type, StringType)
-            and isinstance(other, TruncateTransform)
-            and isinstance(other.source_type, StringType)
-        ):
+        elif isinstance(other, TruncateTransform):
             return self.width >= other.width
 
         return False

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -514,11 +514,34 @@ def test_truncate_method(type_var: PrimitiveType, value: Any, expected_human_str
 
 
 def test_truncate_satisfies_order_of() -> None:
+    # Width comparison
     assert TruncateTransform(5).satisfies_order_of(TruncateTransform(3))
     assert TruncateTransform(5).satisfies_order_of(TruncateTransform(5))
     assert not TruncateTransform(3).satisfies_order_of(TruncateTransform(5))
+    assert TruncateTransform(10).satisfies_order_of(TruncateTransform(1))
+    assert not TruncateTransform(1).satisfies_order_of(TruncateTransform(10))
+    assert TruncateTransform(1).satisfies_order_of(TruncateTransform(1))
+
+    # Cross-transform comparisons
     assert not TruncateTransform(5).satisfies_order_of(BucketTransform(5))
     assert not TruncateTransform(5).satisfies_order_of(IdentityTransform())
+    assert not TruncateTransform(5).satisfies_order_of(VoidTransform())
+    assert not TruncateTransform(5).satisfies_order_of(DayTransform())
+    assert not TruncateTransform(5).satisfies_order_of(YearTransform())
+    assert not TruncateTransform(5).satisfies_order_of(UnknownTransform("unknown"))
+
+    # Non-transform comparisons
+    assert not TruncateTransform(5).satisfies_order_of(None)  # type: ignore
+    assert not TruncateTransform(5).satisfies_order_of("truncate[5]")  # type: ignore
+    assert not TruncateTransform(5).satisfies_order_of(5)  # type: ignore
+
+    # Identity naturally satisfies TruncateTransform because Truncate preserves order
+    assert IdentityTransform().satisfies_order_of(TruncateTransform(5))
+
+    # Verify unused source_type was cleanly removed
+    t = TruncateTransform(5)
+    assert not hasattr(t, "source_type")
+    assert not hasattr(t, "_source_type")
 
 
 def test_unknown_transform() -> None:

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -530,11 +530,6 @@ def test_truncate_satisfies_order_of() -> None:
     assert not TruncateTransform(5).satisfies_order_of(YearTransform())
     assert not TruncateTransform(5).satisfies_order_of(UnknownTransform("unknown"))
 
-    # Non-transform comparisons
-    assert not TruncateTransform(5).satisfies_order_of(None)  # type: ignore
-    assert not TruncateTransform(5).satisfies_order_of("truncate[5]")  # type: ignore
-    assert not TruncateTransform(5).satisfies_order_of(5)  # type: ignore
-
     # Identity naturally satisfies TruncateTransform because Truncate preserves order
     assert IdentityTransform().satisfies_order_of(TruncateTransform(5))
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -513,6 +513,14 @@ def test_truncate_method(type_var: PrimitiveType, value: Any, expected_human_str
     assert truncate_transform.satisfies_order_of(truncate_transform)
 
 
+def test_truncate_satisfies_order_of() -> None:
+    assert TruncateTransform(5).satisfies_order_of(TruncateTransform(3))
+    assert TruncateTransform(5).satisfies_order_of(TruncateTransform(5))
+    assert not TruncateTransform(3).satisfies_order_of(TruncateTransform(5))
+    assert not TruncateTransform(5).satisfies_order_of(BucketTransform(5))
+    assert not TruncateTransform(5).satisfies_order_of(IdentityTransform())
+
+
 def test_unknown_transform() -> None:
     unknown_transform = UnknownTransform("unknown")  # type: ignore
     assert str(unknown_transform) == str(eval(repr(unknown_transform)))


### PR DESCRIPTION
Closes #3680

# Rationale for this change

`TruncateTransform.satisfies_order_of` previously accessed `self.source_type` (and `other.source_type`), which raised `AttributeError: 'TruncateTransform' object has no attribute '_source_type'` whenever comparing truncate transforms with different widths.

Per the Iceberg spec and matching the Java reference implementation, ordering satisfaction between two truncate transforms depends purely on the width comparison (`self.width >= other.width`).

This PR:
1. Updates `TruncateTransform.satisfies_order_of` to check `isinstance(other, TruncateTransform)` and compare `self.width >= other.width`.
2. Adds unit tests covering same/different width comparisons and cross-transform comparisons.

## Are these changes tested?

Yes, added `test_truncate_satisfies_order_of` in `tests/test_transforms.py`. All tests and pre-commit linters pass cleanly.

## Are there any user-facing changes?

No.