### PR TITLE
Fix misleading error messages in conversions dispatch fallbacks

### DIFF
--- a/pyiceberg/conversions.py
+++ b/pyiceberg/conversions.py
@@ -198,7 +198,7 @@ def _(_: PrimitiveType, value_str: str) -> bytes:
 
 @singledispatch
 def to_bytes(
-    primitive_type: PrimitiveType, _: bool | bytes | Decimal | date | datetime | float | int | str | time | uuid.UUID
+    primitive_type: PrimitiveType, value: bool | bytes | Decimal | date | datetime | float | int | str | time | uuid.UUID
 ) -> bytes:
     """Convert a built-in python value to bytes.
 
@@ -208,10 +208,10 @@ def to_bytes(
 
     Args:
         primitive_type (PrimitiveType): An implementation of the PrimitiveType base class.
-        _: The value to convert to bytes (The type of this value depends on which dispatched function is
+        value: The value to convert to bytes (The type of this value depends on which dispatched function is
             used--check dispatchable functions for type hints).
     """
-    raise TypeError(f"scale does not match {primitive_type}")
+    raise TypeError(f"Cannot serialize to bytes, type {primitive_type} not supported: {value!r}")
 
 
 @to_bytes.register(BooleanType)
@@ -408,7 +408,7 @@ def to_json(primitive_type: PrimitiveType, val: Any) -> L:  # type: ignore
         primitive_type (PrimitiveType): An implementation of the PrimitiveType base class.
         val (Any): The arbitrary built-in value to convert into the right form
     """
-    raise TypeError(f"Cannot deserialize bytes, type {primitive_type} not supported: {val}")
+    raise TypeError(f"Cannot serialize to JSON, type {primitive_type} not supported: {val}")
 
 
 @to_json.register(BooleanType)
@@ -547,7 +547,7 @@ def from_json(primitive_type: PrimitiveType, val: Any) -> L:  # type: ignore
         primitive_type (PrimitiveType): An implementation of the PrimitiveType base class.
         val (Any): The arbitrary JSON value to convert into the right form
     """
-    raise TypeError(f"Cannot deserialize bytes, type {primitive_type} not supported: {str(val)}")
+    raise TypeError(f"Cannot deserialize JSON, type {primitive_type} not supported: {val}")
 
 
 @from_json.register(BooleanType)

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -499,11 +499,19 @@ def test_raise_on_unregistered_type() -> None:
 
     with pytest.raises(TypeError) as exc_info:
         conversions.to_bytes(FooUnknownType(), "foo")  # type: ignore
-    assert "scale does not match FooUnknownType()" in str(exc_info.value)
+    assert "Cannot serialize to bytes, type FooUnknownType() not supported: 'foo'" in str(exc_info.value)
 
     with pytest.raises(TypeError) as exc_info:
         conversions.from_bytes(FooUnknownType(), b"foo")  # type: ignore
     assert "Cannot deserialize bytes, type FooUnknownType() not supported: b'foo'" in str(exc_info.value)
+
+    with pytest.raises(TypeError) as exc_info:
+        conversions.to_json(FooUnknownType(), "foo")  # type: ignore
+    assert "Cannot serialize to JSON, type FooUnknownType() not supported: foo" in str(exc_info.value)
+
+    with pytest.raises(TypeError) as exc_info:
+        conversions.from_json(FooUnknownType(), "foo")  # type: ignore
+    assert "Cannot deserialize JSON, type FooUnknownType() not supported: foo" in str(exc_info.value)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

The `singledispatch` fallbacks in `conversions.py` describe the wrong operation, so an unregistered type produces a message that sends you looking in the wrong place. Passing a type with no registered implementation to each of the five entry points today:

```
partition_to_py  Cannot convert 'foo' to unsupported type: FooUnknownType()
to_bytes         scale does not match FooUnknownType()
from_bytes       Cannot deserialize bytes, type FooUnknownType() not supported: b'foo'
to_json          Cannot deserialize bytes, type FooUnknownType() not supported: foo
from_json        Cannot deserialize bytes, type FooUnknownType() not supported: foo
```

This reworks the three to follow the shape `from_bytes` already uses, so each names the operation it performs and the value it rejected:

```
to_bytes         Cannot serialize to bytes, type FooUnknownType() not supported: b'foo'
to_json          Cannot serialize to JSON, type FooUnknownType() not supported: foo
from_json        Cannot deserialize JSON, type FooUnknownType() not supported: foo
```

`partition_to_py` and `from_bytes` are already accurate and are left alone.

One small change beyond the strings: `to_bytes` takes its value parameter as `value` instead of `_` so the message can include it, matching the other four. It is rendered with `!r`, like `from_bytes`, because the parameter also accepts `bytes`.

## Are these changes tested?

Yes. `test_raise_on_unregistered_type` asserted the old `to_bytes` wording, so it is updated. `to_json` and `from_json` had no fallback coverage at all — which is how the copied text survived — so cases for both are added and all five entry points are now covered.

## Are there any user-facing changes?

Only the text of these `TypeError` messages. No behaviour changes: the same inputs raise the same exception type in the same places.

<!-- In the case of user-facing changes, please add the changelog label. -->
