### PR TITLE
Fix deprecation warning text and location

### DIFF
--- a/pyiceberg/utils/deprecated.py
+++ b/pyiceberg/utils/deprecated.py
@@ -60,5 +60,5 @@ def _deprecation_warning(message: str) -> None:
         warnings.warn(
             message,
             category=DeprecationWarning,
-            stacklevel=2,
+            stacklevel=3,
         )

--- a/pyiceberg/utils/deprecated.py
+++ b/pyiceberg/utils/deprecated.py
@@ -25,13 +25,12 @@ def deprecated(deprecated_in: str, removed_in: str, help_message: str | None = N
 
     Adding this will result in a warning being emitted when the function is used.
     """
-    if help_message is not None:
-        help_message = f" {help_message}."
+    help_suffix = f" {help_message}." if help_message else ""
 
     def decorator(func: Callable):  # type: ignore
         @functools.wraps(func)
         def new_func(*args: Any, **kwargs: Any) -> Any:
-            message = f"Call to {func.__name__}, deprecated in {deprecated_in}, will be removed in {removed_in}.{help_message}"
+            message = f"Call to {func.__name__}, deprecated in {deprecated_in}, will be removed in {removed_in}.{help_suffix}"
 
             _deprecation_warning(message)
 
@@ -44,7 +43,8 @@ def deprecated(deprecated_in: str, removed_in: str, help_message: str | None = N
 
 def deprecation_notice(deprecated_in: str, removed_in: str, help_message: str | None) -> str:
     """Return a deprecation notice."""
-    return f"Deprecated in {deprecated_in}, will be removed in {removed_in}. {help_message}"
+    help_suffix = f" {help_message}" if help_message else ""
+    return f"Deprecated in {deprecated_in}, will be removed in {removed_in}.{help_suffix}"
 
 
 def deprecation_message(deprecated_in: str, removed_in: str, help_message: str | None) -> None:

--- a/tests/utils/test_deprecated.py
+++ b/tests/utils/test_deprecated.py
@@ -16,7 +16,9 @@
 # under the License.
 from unittest.mock import Mock, patch
 
-from pyiceberg.utils.deprecated import deprecated
+import pytest
+
+from pyiceberg.utils.deprecated import deprecated, deprecation_message, deprecation_notice
 
 
 @patch("warnings.warn")
@@ -39,8 +41,6 @@ def test_deprecated(warn: Mock) -> None:
 
 @patch("warnings.warn")
 def test_deprecation_message(warn: Mock) -> None:
-    from pyiceberg.utils.deprecated import deprecation_message
-
     deprecation_message(
         deprecated_in="0.1.0",
         removed_in="0.2.0",
@@ -49,3 +49,42 @@ def test_deprecation_message(warn: Mock) -> None:
 
     assert warn.called
     assert warn.call_args[0] == ("Deprecated in 0.1.0, will be removed in 0.2.0. Please use something_else instead",)
+
+
+@patch("warnings.warn")
+def test_deprecated_without_help_message(warn: Mock) -> None:
+    @deprecated(
+        deprecated_in="0.1.0",
+        removed_in="0.2.0",
+    )
+    def deprecated_method() -> None:
+        pass
+
+    deprecated_method()
+
+    assert warn.called
+    assert warn.call_args[0] == ("Call to deprecated_method, deprecated in 0.1.0, will be removed in 0.2.0.",)
+
+
+@patch("warnings.warn")
+def test_deprecation_message_without_help_message(warn: Mock) -> None:
+    deprecation_message(
+        deprecated_in="0.1.0",
+        removed_in="0.2.0",
+        help_message=None,
+    )
+
+    assert warn.called
+    assert warn.call_args[0] == ("Deprecated in 0.1.0, will be removed in 0.2.0.",)
+
+
+@pytest.mark.parametrize("help_message", [None, ""])
+def test_deprecation_notice_without_help_message(help_message: str | None) -> None:
+    assert deprecation_notice("0.1.0", "0.2.0", help_message) == "Deprecated in 0.1.0, will be removed in 0.2.0."
+
+
+def test_deprecation_notice_with_help_message() -> None:
+    assert (
+        deprecation_notice("0.1.0", "0.2.0", "Please use something_else instead")
+        == "Deprecated in 0.1.0, will be removed in 0.2.0. Please use something_else instead"
+    )

--- a/tests/utils/test_deprecated.py
+++ b/tests/utils/test_deprecated.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import warnings
 from unittest.mock import Mock, patch
 
 import pytest
@@ -88,3 +89,28 @@ def test_deprecation_notice_with_help_message() -> None:
         deprecation_notice("0.1.0", "0.2.0", "Please use something_else instead")
         == "Deprecated in 0.1.0, will be removed in 0.2.0. Please use something_else instead"
     )
+
+
+def test_deprecated_warning_points_at_the_caller() -> None:
+    """The warning is attributed to the code using the deprecated API, not to the helper."""
+
+    @deprecated(deprecated_in="0.1.0", removed_in="0.2.0")
+    def deprecated_method() -> None:
+        pass
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        deprecated_method()
+
+    assert len(caught) == 1
+    assert caught[0].filename == __file__
+
+
+def test_deprecation_message_points_at_the_caller() -> None:
+    """The warning is attributed to the code using the deprecated behavior, not to the helper."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        deprecation_message(deprecated_in="0.1.0", removed_in="0.2.0", help_message="Use something_else instead")
+
+    assert len(caught) == 1
+    assert caught[0].filename == __file__

--- a/tests/utils/test_deprecated.py
+++ b/tests/utils/test_deprecated.py
@@ -41,18 +41,6 @@ def test_deprecated(warn: Mock) -> None:
 
 
 @patch("warnings.warn")
-def test_deprecation_message(warn: Mock) -> None:
-    deprecation_message(
-        deprecated_in="0.1.0",
-        removed_in="0.2.0",
-        help_message="Please use something_else instead",
-    )
-
-    assert warn.called
-    assert warn.call_args[0] == ("Deprecated in 0.1.0, will be removed in 0.2.0. Please use something_else instead",)
-
-
-@patch("warnings.warn")
 def test_deprecated_without_help_message(warn: Mock) -> None:
     @deprecated(
         deprecated_in="0.1.0",
@@ -65,30 +53,6 @@ def test_deprecated_without_help_message(warn: Mock) -> None:
 
     assert warn.called
     assert warn.call_args[0] == ("Call to deprecated_method, deprecated in 0.1.0, will be removed in 0.2.0.",)
-
-
-@patch("warnings.warn")
-def test_deprecation_message_without_help_message(warn: Mock) -> None:
-    deprecation_message(
-        deprecated_in="0.1.0",
-        removed_in="0.2.0",
-        help_message=None,
-    )
-
-    assert warn.called
-    assert warn.call_args[0] == ("Deprecated in 0.1.0, will be removed in 0.2.0.",)
-
-
-@pytest.mark.parametrize("help_message", [None, ""])
-def test_deprecation_notice_without_help_message(help_message: str | None) -> None:
-    assert deprecation_notice("0.1.0", "0.2.0", help_message) == "Deprecated in 0.1.0, will be removed in 0.2.0."
-
-
-def test_deprecation_notice_with_help_message() -> None:
-    assert (
-        deprecation_notice("0.1.0", "0.2.0", "Please use something_else instead")
-        == "Deprecated in 0.1.0, will be removed in 0.2.0. Please use something_else instead"
-    )
 
 
 def test_deprecated_warning_points_at_the_caller() -> None:
@@ -104,6 +68,42 @@ def test_deprecated_warning_points_at_the_caller() -> None:
 
     assert len(caught) == 1
     assert caught[0].filename == __file__
+
+
+def test_deprecation_notice_with_help_message() -> None:
+    assert (
+        deprecation_notice("0.1.0", "0.2.0", "Please use something_else instead")
+        == "Deprecated in 0.1.0, will be removed in 0.2.0. Please use something_else instead"
+    )
+
+
+@pytest.mark.parametrize("help_message", [None, ""])
+def test_deprecation_notice_without_help_message(help_message: str | None) -> None:
+    assert deprecation_notice("0.1.0", "0.2.0", help_message) == "Deprecated in 0.1.0, will be removed in 0.2.0."
+
+
+@patch("warnings.warn")
+def test_deprecation_message(warn: Mock) -> None:
+    deprecation_message(
+        deprecated_in="0.1.0",
+        removed_in="0.2.0",
+        help_message="Please use something_else instead",
+    )
+
+    assert warn.called
+    assert warn.call_args[0] == ("Deprecated in 0.1.0, will be removed in 0.2.0. Please use something_else instead",)
+
+
+@patch("warnings.warn")
+def test_deprecation_message_without_help_message(warn: Mock) -> None:
+    deprecation_message(
+        deprecated_in="0.1.0",
+        removed_in="0.2.0",
+        help_message=None,
+    )
+
+    assert warn.called
+    assert warn.call_args[0] == ("Deprecated in 0.1.0, will be removed in 0.2.0.",)
 
 
 def test_deprecation_message_points_at_the_caller() -> None:


### PR DESCRIPTION
# Rationale for this change

Deprecation warnings are wrong in two ways: what they say, and where they point.

**The text leaks a literal `None`.** `help_message` is optional in all three public helpers, but it is interpolated straight into the message, so omitting it renders `str(None)`:

```python
@deprecated(deprecated_in="0.12.0", removed_in="0.13.0")
def foo() -> None: ...
```

```shell
DeprecationWarning: Call to foo, deprecated in 0.12.0, will be removed in 0.13.0.None
```

`deprecation_notice(..., help_message=None)` has the same problem.

**The warning is attributed to PyIceberg, not to the caller.** `warnings.warn` used to be called inline from the decorator's wrapper, where `stacklevel=2` pointed at the caller. #962 extracted it into the shared `_deprecation_warning` helper and kept `stacklevel=2`, which added a frame:

```shell
pyiceberg/utils/deprecated.py:35: DeprecationWarning: Call to foo, ...
```

That hides the one thing a reader needs — which of their own calls to change. Both callers, the decorator's wrapper and `deprecation_message`, sit exactly one frame above the helper, so `stacklevel=3` fixes both.

An empty `help_message` is treated the same as no message. It is not a meaningful help string, and `is not None` would render a dangling `" ."`.

# Are these changes tested?

Yes. `tests/utils/test_deprecated.py` gains cases for all three helpers without a help message, with `deprecation_notice` parametrized over `None` and `""`. The existing tests assert the same strings as before.

The attribution is covered separately: the existing tests patch `warnings.warn`, so they can only see the arguments, not where the warning lands. Two new tests record real warnings and assert the reported filename is the caller's — they fail on `stacklevel=2`.

# Are there any user-facing changes?

The warning text no longer ends in `None` when a call site omits the help message, and warnings now report the caller's file and line. Both in-repo call sites pass a help message, so no emitted text changes today; the attribution fix applies to every warning.

<!-- In the case of user-facing changes, please add the changelog label. -->
