### PR TITLE
Add `hive.kerberos-service-host` configuration option

### DIFF
--- a/mkdocs/docs/configuration.md
+++ b/mkdocs/docs/configuration.md
@@ -749,6 +749,7 @@ catalog:
 | hive.hive2-compatible        | true    | Using Hive 2.x compatibility mode    |
 | hive.kerberos-authentication | true    | Using authentication via Kerberos    |
 | hive.kerberos-service-name   | hive    | Kerberos service name (default hive) |
+| hive.kerberos-service-host   | hive-host | Kerberos service host (default URI host) |
 | ugi                 | t-1234:secret                    | Hadoop UGI for Hive client.                                                                        |
 
 When using Hive 2.x, make sure to set the compatibility flag:

--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -129,6 +129,7 @@ HIVE_KERBEROS_AUTH = "hive.kerberos-authentication"
 HIVE_KERBEROS_AUTH_DEFAULT = False
 HIVE_KERBEROS_SERVICE_NAME = "hive.kerberos-service-name"
 HIVE_KERBEROS_SERVICE_NAME_DEFAULT = "hive"
+HIVE_KERBEROS_SERVICE_HOST = "hive.kerberos-service-host"
 
 LOCK_CHECK_MIN_WAIT_TIME = "lock-check-min-wait-time"
 LOCK_CHECK_MAX_WAIT_TIME = "lock-check-max-wait-time"
@@ -155,10 +156,12 @@ class _HiveClient:
         ugi: str | None = None,
         kerberos_auth: bool | None = HIVE_KERBEROS_AUTH_DEFAULT,
         kerberos_service_name: str | None = HIVE_KERBEROS_SERVICE_NAME,
+        kerberos_service_host: str | None = None,
     ):
         self._uri = uri
         self._kerberos_auth = kerberos_auth
         self._kerberos_service_name = kerberos_service_name
+        self._kerberos_service_host = kerberos_service_host
         self._ugi = ugi.split(":") if ugi else None
         self._transport = self._init_thrift_transport()
         self._was_opened = False
@@ -169,7 +172,8 @@ class _HiveClient:
         if not self._kerberos_auth:
             return TTransport.TBufferedTransport(socket)
         else:
-            return TTransport.TSaslClientTransport(socket, host=url_parts.hostname, service=self._kerberos_service_name)
+            host = self._kerberos_service_host or url_parts.hostname
+            return TTransport.TSaslClientTransport(socket, host=host, service=self._kerberos_service_name)
 
     def _client(self) -> Client:
         protocol = TBinaryProtocol.TBinaryProtocol(self._transport)
@@ -316,6 +320,7 @@ class HiveCatalog(MetastoreCatalog):
                     properties.get("ugi"),
                     property_as_bool(properties, HIVE_KERBEROS_AUTH, HIVE_KERBEROS_AUTH_DEFAULT),
                     properties.get(HIVE_KERBEROS_SERVICE_NAME, HIVE_KERBEROS_SERVICE_NAME_DEFAULT),
+                    properties.get(HIVE_KERBEROS_SERVICE_HOST),
                 )
             except BaseException as e:
                 last_exception = e

--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -161,7 +161,7 @@ class _HiveClient:
         self._uri = uri
         self._kerberos_auth = kerberos_auth
         self._kerberos_service_name = kerberos_service_name
-        self._kerberos_service_host = kerberos_service_host
+        self._kerberos_service_host = kerberos_service_host or urlparse(uri).hostname
         self._ugi = ugi.split(":") if ugi else None
         self._transport = self._init_thrift_transport()
         self._was_opened = False
@@ -172,8 +172,7 @@ class _HiveClient:
         if not self._kerberos_auth:
             return TTransport.TBufferedTransport(socket)
         else:
-            host = self._kerberos_service_host or url_parts.hostname
-            return TTransport.TSaslClientTransport(socket, host=host, service=self._kerberos_service_name)
+            return TTransport.TSaslClientTransport(socket, host=self._kerberos_service_host, service=self._kerberos_service_name)
 
     def _client(self) -> Client:
         protocol = TBinaryProtocol.TBinaryProtocol(self._transport)

--- a/tests/catalog/test_hive.py
+++ b/tests/catalog/test_hive.py
@@ -48,6 +48,7 @@ from pyiceberg.catalog.hive import (
     DO_NOT_UPDATE_STATS,
     DO_NOT_UPDATE_STATS_DEFAULT,
     HIVE_KERBEROS_AUTH,
+    HIVE_KERBEROS_SERVICE_HOST,
     HIVE_KERBEROS_SERVICE_NAME,
     LOCK_CHECK_MAX_WAIT_TIME,
     LOCK_CHECK_MIN_WAIT_TIME,
@@ -1330,7 +1331,7 @@ def test_create_hive_client_success() -> None:
 
     with patch("pyiceberg.catalog.hive._HiveClient", return_value=MagicMock()) as mock_hive_client:
         client = HiveCatalog._create_hive_client(properties)
-        mock_hive_client.assert_called_once_with("thrift://localhost:10000", "user", False, "hive")
+        mock_hive_client.assert_called_once_with("thrift://localhost:10000", "user", False, "hive", None)
         assert client is not None
 
 
@@ -1343,7 +1344,21 @@ def test_create_hive_client_with_kerberos_success() -> None:
     }
     with patch("pyiceberg.catalog.hive._HiveClient", return_value=MagicMock()) as mock_hive_client:
         client = HiveCatalog._create_hive_client(properties)
-        mock_hive_client.assert_called_once_with("thrift://localhost:10000", "user", True, "hiveuser")
+        mock_hive_client.assert_called_once_with("thrift://localhost:10000", "user", True, "hiveuser", None)
+        assert client is not None
+
+
+def test_create_hive_client_with_kerberos_service_host() -> None:
+    properties = {
+        "uri": "thrift://localhost:10000",
+        "ugi": "user",
+        HIVE_KERBEROS_AUTH: "true",
+        HIVE_KERBEROS_SERVICE_NAME: "hiveuser",
+        HIVE_KERBEROS_SERVICE_HOST: "hive-host.example.com",
+    }
+    with patch("pyiceberg.catalog.hive._HiveClient", return_value=MagicMock()) as mock_hive_client:
+        client = HiveCatalog._create_hive_client(properties)
+        mock_hive_client.assert_called_once_with("thrift://localhost:10000", "user", True, "hiveuser", "hive-host.example.com")
         assert client is not None
 
 
@@ -1356,7 +1371,10 @@ def test_create_hive_client_multiple_uris() -> None:
         client = HiveCatalog._create_hive_client(properties)
         assert mock_hive_client.call_count == 2
         mock_hive_client.assert_has_calls(
-            [call("thrift://localhost:10000", "user", False, "hive"), call("thrift://localhost:10001", "user", False, "hive")]
+            [
+                call("thrift://localhost:10000", "user", False, "hive", None),
+                call("thrift://localhost:10001", "user", False, "hive", None),
+            ]
         )
         assert client is not None
 
@@ -1445,3 +1463,22 @@ def test_kerberized_client_uses_fresh_transport_on_reuse(
             second_transport_id = id(client._transport)
 
         assert first_transport_id != second_transport_id
+
+
+def test_kerberized_client_uses_configured_service_host() -> None:
+    """The SASL host must come from hive.kerberos-service-host, or the URI host when unset."""
+    configured = _HiveClient(
+        uri="thrift://metastore-lb:9083",
+        kerberos_auth=True,
+        kerberos_service_name="hive",
+        kerberos_service_host="metastore-host",
+    )
+    assert configured._transport.sasl.host == "metastore-host"
+    assert configured._transport.sasl.service == "hive"
+
+    default = _HiveClient(
+        uri="thrift://metastore-lb:9083",
+        kerberos_auth=True,
+        kerberos_service_name="hive",
+    )
+    assert default._transport.sasl.host == "metastore-lb"

--- a/tests/catalog/test_hive.py
+++ b/tests/catalog/test_hive.py
@@ -1465,6 +1465,7 @@ def test_kerberized_client_uses_fresh_transport_on_reuse(
         assert first_transport_id != second_transport_id
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Kerberos/puresasl not available on Windows")
 def test_kerberized_client_uses_configured_service_host() -> None:
     """The SASL host must come from hive.kerberos-service-host, or the URI host when unset."""
     configured = _HiveClient(


### PR DESCRIPTION
Closes #3787

# Rationale for this change

The Hive catalog derives the Kerberos SASL `host` (the hostname component of the service principal) from the metastore URI, with no way to override it. Authentication therefore fails whenever the service principal's hostname component differs from the host being connected to, for example in an HA setup where `uri` has to list the real metastore hosts while the principal uses a single fixed hostname.

This adds an optional `hive.kerberos-service-host` property, mirroring the existing `hive.kerberos-service-name` for the `service` component. When it is not set, the URI host is used, so existing behavior is unchanged.

## Are these changes tested?

Yes.

- `test_create_hive_client_with_kerberos_service_host` verifies the property is passed through to `_HiveClient`.
- `test_kerberized_client_uses_configured_service_host` verifies at the transport level that the SASL host is the configured value, and falls back to the URI host when the property is not set.
- The existing `_create_hive_client` assertions were updated for the new argument.

I also verified it end-to-end against a Hive Metastore with Kerberos: without the property the connection fails with a KDC `LOOKING_UP_SERVER` error, and with it the correct service ticket is issued and the catalog works.

## Are there any user-facing changes?

Yes, a new optional Hive catalog property `hive.kerberos-service-host`. It defaults to the metastore URI host, so there is no change for existing users. The documentation table has been updated.
