### PR TITLE
feat: Support passing kwargs to polars.scan_iceberg in Table.to_polars

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -1893,15 +1893,19 @@ class Table:
 
         return bd.read_iceberg_table(self)
 
-    def to_polars(self) -> pl.LazyFrame:
+    def to_polars(self, **kwargs: Any) -> pl.LazyFrame:
         """Lazily read from this Apache Iceberg table.
 
+        Args:
+            **kwargs: Additional keyword arguments to forward to :func:`polars.scan_iceberg`
+                (e.g. ``storage_options``, ``snapshot_id``, ``reader_override``).
+
         Returns:
-            pl.LazyFrame: Unmaterialized Polars LazyFrame created from the Iceberg table
+            pl.LazyFrame: Unmaterialized Polars LazyFrame created from the Iceberg table.
         """
         import polars as pl
 
-        return pl.scan_iceberg(self)
+        return pl.scan_iceberg(self, **kwargs)
 
     def __datafusion_table_provider__(self, session: Any | None = None) -> IcebergDataFusionTable:
         """Return the DataFusion table provider PyCapsule interface.

--- a/tests/table/test_init.py
+++ b/tests/table/test_init.py
@@ -2036,3 +2036,29 @@ def test_static_table_forwards_location_to_table_file_io(metadata_location: str,
 
     assert seen_locations, "expected at least one load_file_io call"
     assert all(loc is not None for loc in seen_locations), f"load_file_io called without a location: {seen_locations}"
+
+
+def test_table_to_polars_forwards_kwargs(table_v2: Table, monkeypatch: pytest.MonkeyPatch) -> None:
+    import polars as pl
+
+    recorded_calls: list[tuple[Any, dict[str, Any]]] = []
+
+    def mock_scan_iceberg(source: Any, **kwargs: Any) -> Any:
+        recorded_calls.append((source, kwargs))
+        return "mock_lazy_frame"
+
+    monkeypatch.setattr(pl, "scan_iceberg", mock_scan_iceberg)
+
+    # Test without kwargs
+    res1 = table_v2.to_polars()
+    assert res1 == "mock_lazy_frame"
+    assert recorded_calls[0] == (table_v2, {})
+
+    # Test with kwargs
+    storage_options = {"s3": {"endpoint": "https://s3.custom.endpoint"}}
+    res2 = table_v2.to_polars(storage_options=storage_options, snapshot_id=12345, reader_override="native")
+    assert res2 == "mock_lazy_frame"
+    assert recorded_calls[1] == (
+        table_v2,
+        {"storage_options": storage_options, "snapshot_id": 12345, "reader_override": "native"},
+    )


### PR DESCRIPTION
Closes #3128

# Rationale for this change

Currently, `Table.to_polars()` does not accept keyword arguments and calls `polars.scan_iceberg(self)` directly without forwarding options. This prevents users from passing crucial scan configurations such as `storage_options` (cloud credentials for S3/GCS/Azure), `snapshot_id` (time-travel queries), or `reader_override`.

This change updates `Table.to_polars()` to accept `**kwargs: Any` and forward them to `polars.scan_iceberg(self, **kwargs)`.

## Are these changes tested?

Yes, tested with:
- `tests/table/test_init.py::test_table_to_polars_forwards_kwargs`: Unit test verifying exact forwarding of keyword arguments (both empty and populated) matching the convention of other engine bridges (`to_daft`, `to_bodo`, `to_ray`).
- All 114 tests in `tests/table/test_init.py` and 468 tests in `tests/table/` pass cleanly.
- All pre-commit static analysis checks (`uv run prek run -a`) pass 100%.

## Are there any user-facing changes?

Yes, `Table.to_polars()` now accepts `**kwargs` forwarded to `polars.scan_iceberg`, enabling users to supply `storage_options`, `snapshot_id`, `reader_override`, etc.