### PR TITLE
Skip surrogates when truncating string upper bounds

### DIFF
--- a/pyiceberg/utils/truncate.py
+++ b/pyiceberg/utils/truncate.py
@@ -16,20 +16,31 @@
 #  under the License.
 
 
+_SURROGATE_START = 0xD800
+_SURROGATE_END = 0xDFFF
+_MAX_CODE_POINT = 0x10FFFF
+
+
+def _next_code_point(char: str) -> str | None:
+    """Return the next Unicode scalar value after char, or None if there is none."""
+    code_point = ord(char) + 1
+    # Surrogates are not scalar values and cannot be encoded as UTF-8, so skip the range.
+    if _SURROGATE_START <= code_point <= _SURROGATE_END:
+        code_point = _SURROGATE_END + 1
+    if code_point > _MAX_CODE_POINT:
+        return None
+    return chr(code_point)
+
+
 def truncate_upper_bound_text_string(value: str, trunc_length: int | None) -> str | None:
     result = value[:trunc_length]
     if result != value:
         chars = [*result]
 
         for i in range(-1, -len(result) - 1, -1):
-            try:
-                to_inc = ord(chars[i])
-                # will raise exception if the highest unicode code is reached
-                _next = chr(to_inc + 1)
-                chars[i] = _next
+            if (next_char := _next_code_point(chars[i])) is not None:
+                chars[i] = next_char
                 return "".join(chars)
-            except ValueError:
-                pass
         return None  # didn't find a valid upper bound
     return result
 

--- a/tests/io/test_pyarrow_stats.py
+++ b/tests/io/test_pyarrow_stats.py
@@ -651,6 +651,60 @@ def test_metrics_invalid_upper_bound() -> None:
     assert datafile.upper_bounds[3] == "".join([chr(0x10FFFF), chr(0x10FFFF)]).encode()
 
 
+def construct_test_table_surrogate_boundary_upper_bound() -> tuple[pq.FileMetaData, TableMetadataV1 | TableMetadataV2]:
+    table_metadata = {
+        "format-version": 2,
+        "location": "s3://bucket/test/location",
+        "last-column-id": 1,
+        "current-schema-id": 0,
+        "schemas": [
+            {
+                "type": "struct",
+                "schema-id": 0,
+                "fields": [
+                    {"id": 1, "name": "surrogate_boundary_string", "required": False, "type": "string"},
+                ],
+            },
+        ],
+        "default-spec-id": 0,
+        "partition-specs": [{"spec-id": 0, "fields": []}],
+        "properties": {},
+    }
+
+    table_metadata = TableMetadataUtil.parse_obj(table_metadata)
+    arrow_schema = schema_to_pyarrow(table_metadata.schemas[0])
+
+    # The truncation boundary lands on U+D7FF, whose successor code point is a lone surrogate.
+    strings = ["a" + chr(0xD7FF) + "tail"]
+
+    table = pa.Table.from_pydict({"surrogate_boundary_string": strings}, schema=arrow_schema)
+
+    metadata_collector: list[Any] = []
+
+    with pa.BufferOutputStream() as f:
+        with pq.ParquetWriter(f, table.schema, metadata_collector=metadata_collector) as writer:
+            writer.write_table(table)
+
+    return metadata_collector[0], table_metadata
+
+
+def test_metrics_surrogate_boundary_upper_bound() -> None:
+    metadata, table_metadata = construct_test_table_surrogate_boundary_upper_bound()
+
+    schema = get_current_schema(table_metadata)
+    table_metadata.properties["write.metadata.metrics.default"] = "truncate(2)"
+    statistics = data_file_statistics_from_parquet_metadata(
+        parquet_metadata=metadata,
+        stats_columns=compute_statistics_plan(schema, table_metadata.properties),
+        parquet_column_mapping=parquet_path_to_id_mapping(schema),
+    )
+    datafile = DataFile.from_args(**statistics.to_serialized_dict())
+
+    # The upper bound skips the surrogate range and stays a valid, encodable upper bound.
+    assert datafile.upper_bounds[1] == ("a" + chr(0xE000)).encode()
+    assert datafile.upper_bounds[1].decode() >= "a" + chr(0xD7FF)
+
+
 def test_offsets() -> None:
     metadata, table_metadata = construct_test_table()
 

--- a/tests/utils/test_truncate.py
+++ b/tests/utils/test_truncate.py
@@ -22,6 +22,30 @@ def test_upper_bound_string_truncation() -> None:
     assert truncate_upper_bound_text_string("".join([chr(0x10FFFF), chr(0x10FFFF), chr(0x0)]), 2) is None
 
 
+def test_upper_bound_string_truncation_skips_surrogates() -> None:
+    # U+D7FF is the last scalar value before the surrogate range, so incrementing it
+    # must skip to U+E000 rather than produce an unencodable lone surrogate.
+    value = "a" + chr(0xD7FF) + "tail"
+
+    result = truncate_upper_bound_text_string(value, 2)
+
+    assert result == "a" + chr(0xE000)
+    assert result >= value
+    result.encode("utf-8")
+
+
+def test_upper_bound_string_truncation_skips_surrogates_in_earlier_position() -> None:
+    # The last character is at the maximum code point, so the increment falls back to the
+    # previous character, which is also on the surrogate boundary.
+    value = chr(0xD7FF) + chr(0x10FFFF) + "tail"
+
+    result = truncate_upper_bound_text_string(value, 2)
+
+    assert result == chr(0xE000) + chr(0x10FFFF)
+    assert result >= value
+    result.encode("utf-8")
+
+
 def test_upper_bound_binary_truncation() -> None:
     assert truncate_upper_bound_binary_string(b"\x01\x02\x03", 2) == b"\x01\x03"
     assert truncate_upper_bound_binary_string(b"\xff\xff\x00", 2) is None


### PR DESCRIPTION
# Rationale for this change

`truncate_upper_bound_text_string()` (`pyiceberg/utils/truncate.py`) builds a truncated upper bound
by incrementing the last character of the truncated value. The increment is unconditional:

```python
to_inc = ord(chars[i])
# will raise exception if the highest unicode code is reached
_next = chr(to_inc + 1)
```

The comment covers only the `chr()` overflow case. It misses the surrogate range: when the
character being incremented is `U+D7FF`, the successor is `U+D800`, a lone surrogate. `chr()`
accepts it without raising, so an unencodable string is returned and the failure surfaces later,
at serialization:

```
UnicodeEncodeError: 'utf-8' codec can't encode character '\ud800' in position 15: surrogates not allowed
```

Surrogates are not Unicode scalar values and have no UTF-8 encoding, so the bound cannot be
written.

This is reachable from ordinary writes. `StatsAggregator.max_as_bytes()` calls this helper and
then serializes the result (`pyiceberg/io/pyarrow.py`), and it runs under the default metrics mode
(`DEFAULT_TRUNCATION_LENGTH = 16`). Any string value longer than the truncation length whose
character at the truncation boundary is `U+D7FF` aborts the write. Both stats call sites are
affected — the Parquet writer's `close()` on the append/overwrite path, and
`parquet_file_to_data_file()` used by `add_files`.

The fix skips the surrogate range when incrementing, so the successor of `U+D7FF` is `U+E000`.
Since `U+E000 > U+D7FF`, the result is still a valid upper bound, and it is encodable. Existing
behavior is otherwise unchanged: the `chr()` overflow case that previously raised `ValueError` and
fell through to the next character now returns `None` from the helper and falls through
identically.

`truncate_upper_bound_binary_string()` is not affected — it increments a byte guarded by `< 255`.

## Are these changes tested?

Yes.

- `tests/utils/test_truncate.py` — two regression tests: incrementing at the surrogate boundary,
  and the case where the last character is at the maximum code point so the increment falls back
  to an earlier character that is itself on the surrogate boundary. Both assert the result is a
  genuine upper bound and encodes as UTF-8.
- `tests/io/test_pyarrow_stats.py::test_metrics_surrogate_boundary_upper_bound` — covers the
  write path that actually breaks, computing statistics from real Parquet metadata via
  `data_file_statistics_from_parquet_metadata()`, mirroring the existing
  `test_metrics_invalid_upper_bound` case.

All three fail on `main` with the `UnicodeEncodeError` above and pass with the change; this was
checked in both directions by reverting only `pyiceberg/utils/truncate.py` and re-running
(`3 failed, 19 passed` reverted; `22 passed` with the fix).

I also swept all 1,112,064 Unicode scalar values through the helper and confirmed every returned
bound both encodes as UTF-8 and compares greater than or equal to the input value.

- `make lint` — passes, including mypy
- `make test` — 3972 passed, 3 skipped

Not run: the integration suites (`make test-integration` and the cloud-storage suites), which need
Docker and credentials unavailable here.

## Are there any user-facing changes?

No API change. Writes that previously failed with `UnicodeEncodeError` now succeed. Upper bounds
for affected values change from unencodable to `U+E000`-terminated; bounds for all other values
are unchanged.

## AI assistance

Claude Code was used to find the bug, write the change and the tests, and run the verification
described above.
