### PR TITLE
fix: serialize purgeRequested as lowercase boolean in REST drop_table

### DIFF
--- a/pyiceberg/catalog/rest/__init__.py
+++ b/pyiceberg/catalog/rest/__init__.py
@@ -1339,7 +1339,7 @@ class RestCatalog(Catalog):
         self._check_endpoint(Capability.V1_DELETE_TABLE)
         response = self._session.delete(
             self.url(Endpoints.drop_table, prefixed=True, **self._split_identifier_for_path(identifier)),
-            params={"purgeRequested": purge_requested},
+            params={"purgeRequested": "true" if purge_requested else "false"},
         )
         try:
             response.raise_for_status()

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -2015,6 +2015,21 @@ def test_delete_table_204(rest_mock: Mocker) -> None:
     RestCatalog("rest", uri=TEST_URI, token=TEST_TOKEN).drop_table(("example", "fokko"))
 
 
+def test_drop_table_serializes_purge_requested_as_lowercase_bool(rest_mock: Mocker) -> None:
+    rest_mock.delete(
+        f"{TEST_URI}v1/namespaces/example/tables/fokko",
+        json={},
+        status_code=204,
+        request_headers=TEST_HEADERS,
+    )
+    RestCatalog("rest", uri=TEST_URI, token=TEST_TOKEN).drop_table(("example", "fokko"), purge_requested=True)
+    assert rest_mock.last_request is not None
+    assert rest_mock.last_request.qs == {"purgerequested": ["true"]}
+
+    RestCatalog("rest", uri=TEST_URI, token=TEST_TOKEN).drop_table(("example", "fokko"), purge_requested=False)
+    assert rest_mock.last_request.qs == {"purgerequested": ["false"]}
+
+
 def test_delete_table_from_self_identifier_204(
     rest_mock: Mocker, example_table_metadata_with_snapshot_v1_rest_json: dict[str, Any]
 ) -> None:


### PR DESCRIPTION
## Problem
`RestCatalog.drop_table()` passed a Python `bool` as a query param. `requests` serializes `True`/`False` as `"True"`/`"False"`, which is invalid for OpenAPI `type: boolean` query parameters and causes 400s on strict REST catalogs (e.g. Aliyun OSS Tables).

## Solution
Serialize explicitly as lowercase `"true"` / `"false"`.

## Test plan
- [x] added unit test asserting query string is `purgeRequested=true|false`
- [x] `pytest tests/catalog/test_rest.py -k "drop_table_serializes_purge or delete_table_204"`

Fixes #3836