### PR TITLE
PyArrow: Keep the storage account out of ADLS paths in `parse_location`

### DIFF
--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -209,6 +209,7 @@ MAP_KEY_NAME = "key"
 MAP_VALUE_NAME = "value"
 DOC = "doc"
 UTC_ALIASES = {"UTC", "+00:00", "Etc/UTC", "Z"}
+ADLS_SCHEMES = frozenset({"abfs", "abfss", "wasb", "wasbs"})
 
 T = TypeVar("T")
 
@@ -421,6 +422,11 @@ class PyArrowFileIO(FileIO):
             return default_scheme, default_netloc, os.path.abspath(location)
         elif uri.scheme in ("hdfs", "viewfs"):
             return uri.scheme, uri.netloc, uri.path
+        elif uri.scheme in ADLS_SCHEMES and uri.username:
+            # Azure locations are <container>@<account>.<host>/<path>. The account is
+            # configured on the AzureFileSystem itself, which expects paths of the form
+            # <container>/<path>, so only the container belongs in the path here.
+            return uri.scheme, uri.netloc, f"{uri.username}{uri.path}"
         else:
             return uri.scheme, uri.netloc, f"{uri.netloc}{uri.path}"
 
@@ -438,7 +444,7 @@ class PyArrowFileIO(FileIO):
         elif scheme in {"gs", "gcs"}:
             return self._initialize_gcs_fs()
 
-        elif scheme in {"abfs", "abfss", "wasb", "wasbs"}:
+        elif scheme in ADLS_SCHEMES:
             return self._initialize_azure_fs()
 
         elif scheme in {"file"}:

--- a/tests/io/test_pyarrow.py
+++ b/tests/io/test_pyarrow.py
@@ -2326,6 +2326,30 @@ def test_parse_location() -> None:
     check_results("/root/foo.txt", "file", "", os.path.abspath("/root/foo.txt"))
     check_results("/root/tmp/foo.txt", "file", "", os.path.abspath("/root/tmp/foo.txt"))
 
+    check_results("s3://bucket/root/foo.txt", "s3", "bucket", "bucket/root/foo.txt")
+
+
+@pytest.mark.parametrize("scheme", ["abfs", "abfss", "wasb", "wasbs"])
+def test_parse_location_adls_account_qualified(scheme: str) -> None:
+    """The account must not leak into the path, PyArrow takes it on the filesystem instead."""
+    scheme_, netloc, path = PyArrowFileIO.parse_location(
+        f"{scheme}://mycontainer@myaccount.dfs.core.windows.net/wh/db/tbl/data.parquet"
+    )
+
+    assert scheme_ == scheme
+    assert netloc == "mycontainer@myaccount.dfs.core.windows.net"
+    assert path == "mycontainer/wh/db/tbl/data.parquet"
+
+
+@pytest.mark.parametrize("scheme", ["abfs", "abfss", "wasb", "wasbs"])
+def test_parse_location_adls_container_only(scheme: str) -> None:
+    """Locations without an account keep the netloc as the container."""
+    scheme_, netloc, path = PyArrowFileIO.parse_location(f"{scheme}://mycontainer/wh/db/tbl/data.parquet")
+
+    assert scheme_ == scheme
+    assert netloc == "mycontainer"
+    assert path == "mycontainer/wh/db/tbl/data.parquet"
+
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only behavior")
 def test_parse_location_windows_drive_letter() -> None:


### PR DESCRIPTION
# Rationale for this change

`parse_location` builds the path as `f"{uri.netloc}{uri.path}"`. That is correct for S3, where the netloc is the bucket. For Azure the netloc is `container@account.dfs.core.windows.net`, so the account ends up inside the path and PyArrow reads that whole first segment as the container name. Every `PyArrowFileIO` call on a canonical ABFS location is therefore pointed at a container that cannot exist, since container names allow only lowercase letters, numbers and hyphens.

PyArrow itself handles these locations correctly. `FileSystem.from_uri("abfss://myfs@myacct.dfs.core.windows.net/wh/d.parquet")` returns `myfs/wh/d.parquet`, so the problem is only on our side. After this change `parse_location` returns the same path that PyArrow does.

The full trace and the Azure documentation references are in #2698.

This is the path half only. The other half is that `_initialize_azure_fs` takes no netloc, so the account can come only from `adls.account-name` and never from the location itself. I will send that separately, it needs a call on precedence when the property and the location disagree.

Related to #2698. Not closing it here, since the account derivation is still pending.

## Are these changes tested?

Yes. Two new parametrised tests over `abfs`, `abfss`, `wasb` and `wasbs`, one for the account qualified form and one for the container only form.

I also added an S3 case to `test_parse_location`. That function has to keep serving both shapes and there was nothing pinning the S3 behaviour that the new branch has to preserve.

`make lint` is clean and `tests/io/test_pyarrow.py` passes.

## Are there any user-facing changes?

Yes. Locations of the form `abfs[s]://<container>@<account>.dfs.core.windows.net/<path>` now resolve to the correct container under `PyArrowFileIO`. Earlier they resolved to a container named after the entire netloc. S3, HDFS and the container only Azure form are unchanged.
