### PR TITLE
Fix inverted null-count check in inclusive metrics NotStartsWith

### DIFF
--- a/pyiceberg/expressions/visitors.py
+++ b/pyiceberg/expressions/visitors.py
@@ -1200,7 +1200,9 @@ class _InclusiveMetricsEvaluationVisitor(_MetricsEvaluationVisitor):
     """Evaluate inclusive metrics for one data file."""
 
     def _may_contain_null(self, field_id: int) -> bool:
-        return self.null_counts is None or (field_id in self.null_counts and self.null_counts.get(field_id) is not None)
+        # A missing null count means the count is unknown, so the column may contain nulls.
+        null_count = self.null_counts.get(field_id)
+        return null_count is None or null_count != 0
 
     def _contains_nans_only(self, field_id: int) -> bool:
         if (nan_count := self.nan_counts.get(field_id)) and (value_count := self.value_counts.get(field_id)):

--- a/tests/expressions/test_evaluator.py
+++ b/tests/expressions/test_evaluator.py
@@ -238,6 +238,38 @@ def data_file_4() -> DataFile:
     )
 
 
+@pytest.fixture
+def data_file_5() -> DataFile:
+    return DataFile.from_args(
+        file_path="file_5.parquet",
+        file_format=FileFormat.PARQUET,
+        partition={},
+        record_count=50,
+        file_size_in_bytes=3,
+        value_counts={3: 50},
+        null_value_counts={3: 0},
+        nan_value_counts=None,
+        lower_bounds={3: to_bytes(StringType(), "abc")},
+        upper_bounds={3: to_bytes(StringType(), "abcdefghi")},
+    )
+
+
+@pytest.fixture
+def data_file_6() -> DataFile:
+    return DataFile.from_args(
+        file_path="file_6.parquet",
+        file_format=FileFormat.PARQUET,
+        partition={},
+        record_count=50,
+        file_size_in_bytes=3,
+        value_counts={3: 50},
+        null_value_counts=None,
+        nan_value_counts=None,
+        lower_bounds={3: to_bytes(StringType(), "abc")},
+        upper_bounds={3: to_bytes(StringType(), "abcdefghi")},
+    )
+
+
 def test_all_null(schema_data_file: Schema, data_file: DataFile) -> None:
     should_read = _InclusiveMetricsEvaluator(schema_data_file, NotNull("all_nulls")).eval(data_file)
     assert not should_read, "Should skip: no non-null value in all null column"
@@ -1005,7 +1037,13 @@ def test_strict_metrics_evaluator_uses_empty_byte_bounds() -> None:
 
 
 def test_string_not_starts_with(
-    schema_data_file: Schema, data_file: DataFile, data_file_2: DataFile, data_file_3: DataFile, data_file_4: DataFile
+    schema_data_file: Schema,
+    data_file: DataFile,
+    data_file_2: DataFile,
+    data_file_3: DataFile,
+    data_file_4: DataFile,
+    data_file_5: DataFile,
+    data_file_6: DataFile,
 ) -> None:
     should_read = _InclusiveMetricsEvaluator(schema_data_file, NotStartsWith("required", "a")).eval(data_file)
     assert should_read, "Should read: no stats"
@@ -1044,6 +1082,15 @@ def test_string_not_starts_with(
 
     # should_read = _InclusiveMetricsEvaluator(schema_data_file, NotStartsWith("required", above_max)).eval(data_file_4)
     # assert should_read, "Should not read: range doesn't match"
+
+    should_read = _InclusiveMetricsEvaluator(schema_data_file, NotStartsWith("required", "abc")).eval(data_file_5)
+    assert not should_read, "Should not read: no nulls and all strings start with the prefix"
+
+    should_read = _InclusiveMetricsEvaluator(schema_data_file, NotStartsWith("required", "abcd")).eval(data_file_5)
+    assert should_read, "Should read: lower bound is shorter than the prefix"
+
+    should_read = _InclusiveMetricsEvaluator(schema_data_file, NotStartsWith("required", "abc")).eval(data_file_6)
+    assert should_read, "Should read: null count is unknown, so the file may contain nulls that match"
 
 
 @pytest.fixture


### PR DESCRIPTION
# Rationale for this change

`_InclusiveMetricsEvaluationVisitor._may_contain_null` is inverted relative to Java.

`visitors.py:1203` returns `self.null_counts is None or (field_id in self.null_counts and self.null_counts.get(field_id) is not None)`. `null_counts` is set to `EMPTY_DICT` in `_MetricsEvaluationVisitor.__init__`, so the first disjunct is dead and the rest means "may contain null iff a count is present" — backwards on both branches.

Java, `api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java:100-102`:

```java
return nullCounts == null || !nullCounts.containsKey(id) || nullCounts.get(id) != 0;
```

| null count for the field | here | Java |
|---|---|---|
| present, `0` | may contain null | proven no nulls |
| absent (unknown) | proven no nulls | may contain null |

The only caller is `visit_not_starts_with` (`visitors.py:1451`), which uses it to guard the bounds-pruning path. The first row makes that pruning dead code. The second row prunes a file whose null count is unknown, which drops rows that do match — the row-level evaluator returns `True` for `NotStartsWith` on a NULL (`visitors.py:523-524`).

I have not traced whether PyIceberg's own writer emits bounds without null counts, so treat the missed-pruning half as always reachable and the row-dropping half as reachable for any spec-legal manifest but not demonstrated end to end here.

## Are these changes tested?

`tests/expressions/test_evaluator.py::test_string_not_starts_with` is a port of Java's `testStringNotStartsWith` minus `FILE_5`, the one fixture that reaches the pruning branch. All 12 of its assertions are `assert should_read`; there are none of the other polarity, so a function that always answers "may contain null" cannot fail it.

Added `data_file_5` (mirrors Java's `FILE_5`: `null_value_counts={3: 0}`, bounds `abc`..`abcdefghi`) and `data_file_6` (same, `null_value_counts=None`), plus three assertions.

Full suite is `4001 passed, 3 skipped` on both `58749a3` and this branch — the new assertions live inside an existing test, so the count does not move and the mutants are the evidence. Reverting the source with the tests kept fails on `data_file_5` (`assert not True`). The naive fix `self.null_counts.get(field_id, 0) != 0` gets the zero-count case right and still fails on `data_file_6`, which is why that second fixture is there.

`make lint` passes all 12 hooks. Integration tests were not run.

## Are there any user-facing changes?

A `NotStartsWith` scan now skips data files that have a zero null count and bounds entirely inside the prefix, and stops skipping files whose null count is unknown. Fewer files read in the first case, more in the second.

---

Written with AI assistance (Claude Opus 5). The Java references above were read from `apache/iceberg` `main`, and the measurements were run against this branch.

