### PR TITLE
Add last two versions to bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/iceberg_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/iceberg_bug_report.yml
@@ -28,7 +28,9 @@ body:
       description: What Apache Iceberg version are you using?
       multiple: false
       options:
-        - "0.11.0 (latest release)"
+        - "0.12.0 (latest release)"
+        - "0.11.1"
+        - "0.11.0"
         - "0.10.0"
         - "0.9.1"
         - "0.9.0"


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
This adds 0.11.1 and 0.12.0 to the list of versions on the Iceberg Bug Report template.

## Are these changes tested?
Markdown only.

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
