### PR TITLE
Register `to_bytes` for `UnknownType`

### DIFF
--- a/pyiceberg/conversions.py
+++ b/pyiceberg/conversions.py
@@ -321,6 +321,12 @@ def _(primitive_type: DecimalType, value: Decimal) -> bytes:
     return decimal_to_bytes(value)
 
 
+@to_bytes.register(UnknownType)
+def _(_: UnknownType, value: Any) -> None:
+    """Return None since the unknown type has no binary representation."""
+    return None
+
+
 @singledispatch  # type: ignore
 def from_bytes(primitive_type: PrimitiveType, b: bytes) -> L:  # type: ignore
     """Convert bytes to a built-in python value.

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -109,6 +109,7 @@ from pyiceberg.types import (
     TimestamptzNanoType,
     TimestamptzType,
     TimeType,
+    UnknownType,
     UUIDType,
 )
 
@@ -606,3 +607,20 @@ def test_json_single_serialization(primitive_type: PrimitiveType, value: Any, ex
 )
 def test_json_serialize_roundtrip(primitive_type: PrimitiveType, value: Any) -> None:
     assert value == conversions.from_json(primitive_type, conversions.to_json(primitive_type, value))
+
+
+def test_unknown_type_conversions() -> None:
+    """Unknown values are always null, so they have no binary or partition representation."""
+    unknown = UnknownType()
+
+    assert conversions.to_bytes(unknown, "iceberg") is None
+    assert conversions.from_bytes(unknown, b"\x01\x02\x03\xff") is None
+    assert conversions.partition_to_py(unknown, "iceberg") is None
+
+    # The spec defines no JSON single-value representation for unknown, since a
+    # non-null initial-default or write-default is invalid for the type.
+    with pytest.raises(TypeError):
+        conversions.to_json(unknown, "iceberg")
+
+    with pytest.raises(TypeError):
+        conversions.from_json(unknown, "iceberg")


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
`from_bytes` and `partition_to_py` both handle `UnknownType`, but `to_bytes` did not.

## Are these changes tested?
Just added unit tests

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
