### PR TITLE
Infra: Switch Dependabot to a monthly cadence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,7 @@ updates:
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 50
     ignore:
       - dependency-name: "datafusion"
@@ -31,7 +31,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     cooldown:
       default-days: 7
     groups:

--- a/mkdocs/docs/how-to-release.md
+++ b/mkdocs/docs/how-to-release.md
@@ -34,6 +34,8 @@ This guide outlines the process for releasing PyIceberg in accordance with the [
 * SVN Access
     * Permission to upload artifacts to the [Apache development distribution](https://dist.apache.org/repos/dist/dev/iceberg/) (requires Apache Committer access).
     * Permission to upload artifacts to the [Apache release distribution](https://dist.apache.org/repos/dist/release/iceberg/) (requires Apache PMC access).
+* GitHub Access
+    * Write access to the [apache/iceberg-python](https://github.com/apache/iceberg-python) repository for triggering Dependabot (requires Apache Committer access).
 * PyPI Access
     * The `twine` package must be installed for uploading releases to PyPi.
     * A PyPI account with publishing permissions for the [pyiceberg project](https://pypi.org/project/pyiceberg/).
@@ -68,6 +70,13 @@ deprecation_message(
 ### Update Dependencies
 
 Dependabot runs monthly to keep the noise down, so the pinned dependencies in `uv.lock` may be stale by the time of a release. Before cutting the release candidate, go to the [Dependabot page](https://github.com/apache/iceberg-python/network/updates) in the repository's Insights tab and trigger a manual check for both the `uv` and `github-actions` ecosystems. Review and merge the resulting PRs so the release ships with up-to-date dependencies.
+
+<!-- prettier-ignore-start -->
+
+!!! note
+    Only a committer with write access to the repository can trigger Dependabot manually. Please work with a committer if you do not have write access.
+
+<!-- prettier-ignore-end -->
 
 ### Update Library Version
 

--- a/mkdocs/docs/how-to-release.md
+++ b/mkdocs/docs/how-to-release.md
@@ -69,7 +69,8 @@ deprecation_message(
 
 ### Update Dependencies
 
-Dependabot runs monthly to keep the noise down, so the pinned dependencies in `uv.lock` may be stale by the time of a release. Before cutting the release candidate, open the repository's **Insights** tab, select **Dependabot**, and trigger a manual check for both the `uv` and `github-actions` ecosystems. Review and merge the resulting PRs so the release ships with up-to-date dependencies. See the [GitHub documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/listing-dependencies-configured-for-version-updates) for details.
+<!-- markdown-link-check-disable-next-line -->
+Dependabot runs monthly to keep the noise down, so the pinned dependencies in `uv.lock` may be stale by the time of a release. Before cutting the release candidate, go to the [Dependabot page](https://github.com/apache/iceberg-python/network/updates) in the repository's Insights tab and trigger a manual check for both the `uv` and `github-actions` ecosystems. Review and merge the resulting PRs so the release ships with up-to-date dependencies.
 
 <!-- prettier-ignore-start -->
 

--- a/mkdocs/docs/how-to-release.md
+++ b/mkdocs/docs/how-to-release.md
@@ -69,7 +69,7 @@ deprecation_message(
 
 ### Update Dependencies
 
-Dependabot runs monthly to keep the noise down, so the pinned dependencies in `uv.lock` may be stale by the time of a release. Before cutting the release candidate, go to the [Dependabot page](https://github.com/apache/iceberg-python/network/updates) in the repository's Insights tab and trigger a manual check for both the `uv` and `github-actions` ecosystems. Review and merge the resulting PRs so the release ships with up-to-date dependencies.
+Dependabot runs monthly to keep the noise down, so the pinned dependencies in `uv.lock` may be stale by the time of a release. Before cutting the release candidate, open the repository's **Insights** tab, select **Dependabot**, and trigger a manual check for both the `uv` and `github-actions` ecosystems. Review and merge the resulting PRs so the release ships with up-to-date dependencies. See the [GitHub documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/listing-dependencies-configured-for-version-updates) for details.
 
 <!-- prettier-ignore-start -->
 

--- a/mkdocs/docs/how-to-release.md
+++ b/mkdocs/docs/how-to-release.md
@@ -65,6 +65,10 @@ deprecation_message(
 )
 ```
 
+### Update Dependencies
+
+Dependabot runs monthly to keep the noise down, so the pinned dependencies in `uv.lock` may be stale by the time of a release. Before cutting the release candidate, go to the [Dependabot page](https://github.com/apache/iceberg-python/network/updates) in the repository's Insights tab and trigger a manual check for both the `uv` and `github-actions` ecosystems. Review and merge the resulting PRs so the release ships with up-to-date dependencies.
+
 ### Update Library Version
 
 Update the release version by running `uv version <release-version>`, which updates both `pyproject.toml` and `uv.lock`. Then update the version in `pyiceberg/__init__.py` to match.


### PR DESCRIPTION
## Rationale

Weekly Dependabot runs are noisy, and dependency bumps only need to land before a release. Over the last 12 months (2025-09-06 to 2026-09-06):

| Metric | Value |
|---|---|
| Dependabot PRs | 560 |
| All PRs in the repo | 1,217 |
| Share of PRs from Dependabot | 46% |
| Average Dependabot PRs per week | ~11 |
| Average Dependabot PRs per month | ~47 |

## Changes

- Change both the `uv` and `github-actions` Dependabot schedules from `weekly` to `monthly`. Cooldown, ignore list, and the codeql-action grouping are unchanged.
- Add an "Update Dependencies" step to the release guide, before the version bump, that tells the release manager to manually trigger a Dependabot check and merge the resulting PRs before cutting the RC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)