### PR TITLE
fix: treat a .pyiceberg.yaml without a mapping as no config

### DIFF
--- a/pyiceberg/utils/config.py
+++ b/pyiceberg/utils/config.py
@@ -79,6 +79,9 @@ class Config:
                     with open(path, encoding=UTF8) as f:
                         yml_str = f.read()
                     file_config = strictyaml.load(yml_str).data
+                    if not isinstance(file_config, dict):
+                        # An empty or comment-only document parses as a string
+                        return None
                     file_config_lowercase = _lowercase_dictionary_keys(file_config)
                     return file_config_lowercase
             return None

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -183,3 +183,20 @@ def test_config_lookup_order(
     assert (
         result["catalog"]["default"]["uri"] if result else None  # type: ignore
     ) == expected_result, f"Unexpected configuration result. Expected: {expected_result}, Actual: {result}"
+
+
+@pytest.mark.parametrize("content", ["", "\n", "# only a comment\n"])
+def test_from_configuration_files_without_a_mapping(
+    monkeypatch: pytest.MonkeyPatch, tmp_path_factory: pytest.TempPathFactory, content: str
+) -> None:
+    """A file that holds no mapping should be treated as absent."""
+    pyiceberg_home = str(tmp_path_factory.mktemp("pyiceberg_home"))
+    empty_dir = str(tmp_path_factory.mktemp("empty"))
+    with open(os.path.join(pyiceberg_home, ".pyiceberg.yaml"), "w", encoding=UTF8) as file:
+        file.write(content)
+
+    monkeypatch.setenv("PYICEBERG_HOME", pyiceberg_home)
+    monkeypatch.setattr(os.path, "expanduser", lambda _: empty_dir)
+    monkeypatch.chdir(empty_dir)
+
+    assert Config()._from_configuration_files() is None


### PR DESCRIPTION
# Rationale for this change

`_load_yaml` passes `strictyaml.load(...).data` straight to `_lowercase_dictionary_keys`. For an empty or comment-only document that value is a `str`, not a mapping, so the call raises `AttributeError: 'str' object has no attribute 'items'`.

`Config()` runs at import time, so commenting out `~/.pyiceberg.yaml` makes the import fail with an error that names neither YAML nor the file:

```
>>> import pyiceberg.catalog
AttributeError: 'str' object has no attribute 'items'
```

Return `None` instead. The annotated return type is already `RecursiveDict | None`, and the caller already treats `None` as "keep looking in the next directory".

## Are these changes tested?

Yes, `test_from_configuration_files_without_a_mapping` in `tests/utils/test_config.py`, parametrized over an empty file, a newline, and a comment-only file. All three fail with the `AttributeError` without the change.

## Are there any user-facing changes?

A `.pyiceberg.yaml` that holds no mapping is skipped instead of raising.
