### PR TITLE
PyArrow: NotEqualTo push-down drops null rows (draft, see description)

### DIFF
--- a/pyiceberg/io/pyarrow.py
+++ b/pyiceberg/io/pyarrow.py
@@ -919,7 +919,10 @@ class _ConvertToArrowExpression(BoundBooleanExpressionVisitor[pc.Expression]):
         return pc.field(self._get_field_name(term)) == _convert_scalar(literal.value, term.ref().field.field_type)
 
     def visit_not_equal(self, term: BoundTerm, literal: Literal[Any]) -> pc.Expression:
-        return pc.field(self._get_field_name(term)) != _convert_scalar(literal.value, term.ref().field.field_type)
+        # A null is not equal to the literal, but an Arrow comparison yields null for it and
+        # the row would be dropped. Keep it explicitly to match the other evaluators.
+        ref = pc.field(self._get_field_name(term))
+        return ref.is_null(nan_is_null=False) | (ref != _convert_scalar(literal.value, term.ref().field.field_type))
 
     def visit_greater_than_or_equal(self, term: BoundTerm, literal: Literal[Any]) -> pc.Expression:
         return pc.field(self._get_field_name(term)) >= _convert_scalar(literal.value, term.ref().field.field_type)

--- a/tests/io/test_pyarrow.py
+++ b/tests/io/test_pyarrow.py
@@ -60,6 +60,7 @@ from pyiceberg.expressions import (
     BoundStartsWith,
     GreaterThan,
     Not,
+    NotEqualTo,
     Or,
 )
 from pyiceberg.expressions.literals import literal
@@ -785,8 +786,21 @@ def test_expr_equal_to_pyarrow(bound_reference: BoundReference) -> None:
 def test_expr_not_equal_to_pyarrow(bound_reference: BoundReference) -> None:
     assert (
         repr(expression_to_pyarrow(BoundNotEqualTo(bound_reference, literal("hello"))))
-        == '<pyarrow.compute.Expression (foo != "hello")>'
+        == '<pyarrow.compute.Expression (is_null(foo, {nan_is_null=false}) or (foo != "hello"))>'
     )
+
+
+def test_expr_not_equal_to_pyarrow_keeps_nulls(bound_reference: BoundReference) -> None:
+    """A null is not equal to the literal, so it satisfies NotEqualTo, as it does in the other evaluators."""
+    from pyiceberg.expressions.visitors import expression_evaluator
+
+    values = ["hello", "world", None]
+    pushed_down = pa.table({"foo": values}).filter(expression_to_pyarrow(BoundNotEqualTo(bound_reference, literal("hello"))))
+    schema = Schema(NestedField(field_id=1, name="foo", field_type=StringType(), required=False))
+    in_memory = expression_evaluator(schema, NotEqualTo("foo", "hello"), True)
+
+    assert pushed_down.column("foo").to_pylist() == ["world", None]
+    assert [value for value in values if in_memory(Record(value))] == ["world", None]
 
 
 def test_expr_greater_than_or_equal_equal_to_pyarrow(bound_reference: BoundReference) -> None:


### PR DESCRIPTION
# Rationale for this change

Draft: the change below is not the right fix, and the table explains why. Opening it as a draft to record the finding.

Pushing `NotEqualTo` down to Arrow drops rows where the column is null, while `_ExpressionEvaluationVisitor.visit_not_equal` returns `None != value` and `_StrictMetricsEvaluationVisitor` reports `ROWS_MUST_MATCH` for a column proven to hold only nulls. `Evaluator.notEq` in the reference implementation is `!eq`, and `eq` uses a nulls-first comparator, so it agrees with the evaluators.

Making the push-down agree with them is not enough. `_expression_to_complementary_pyarrow` ORs `is_null` back into the preserve filter for every term `_NullNaNUnmentionedTermsCollector` treats as null-unmentioned, `NotEqualTo` among them, so a scan starts matching null rows while a delete with the same filter still keeps them:

| filter | Arrow path | scan | delete removes | agree on main | with this change |
| --- | --- | --- | --- | --- | --- |
| `NOT IN (a, b)` | `~isin` | `[null, c]` | `[c]` | no | no |
| `NOT IN (a)` | `!=` | `[b, c]` | `[b, c]` | yes | no |
| `!= a` | `!=` | `[b, c]` | `[b, c]` | yes | no |

The layer is already inconsistent, but in `visit_not_in`, and this change moves two agreeing cases into the disagreeing column rather than fixing the one that is broken. Completing it means `delete`/`overwrite` would start removing null rows for a `!=` filter. That is a semantics change to a destructive operation, and it needs a decision on which convention to keep: the three-valued logic the Arrow layer follows today, or null-satisfies-negation as in the evaluators.

## Are these changes tested?

Only the scan path, which is why this is a draft.

## Are there any user-facing changes?

None proposed yet.
