### PR TITLE
Fix NaN upper-bound check in strict metrics NotIn

### DIFF
--- a/pyiceberg/expressions/visitors.py
+++ b/pyiceberg/expressions/visitors.py
@@ -1784,6 +1784,11 @@ class _StrictMetricsEvaluationVisitor(_MetricsEvaluationVisitor):
         if upper_bytes is not None:
             upper = _from_byte_buffer(field.field_type, upper_bytes)
 
+            if self._is_nan(upper):
+                # NaN indicates unreliable bounds.
+                # See the StrictMetricsEvaluator docs for more.
+                return ROWS_MIGHT_NOT_MATCH
+
             literals = {val for val in literals if upper >= val}
 
             if len(literals) == 0:

--- a/tests/expressions/test_evaluator.py
+++ b/tests/expressions/test_evaluator.py
@@ -1359,6 +1359,31 @@ def test_strict_not_equal_and_not_in_with_mixed_nans_and_matching_bounds(field_t
 
 
 @pytest.mark.parametrize("field_type", [FloatType(), DoubleType()])
+def test_strict_not_in_with_nan_upper_bound(field_type: PrimitiveType) -> None:
+    schema = Schema(NestedField(1, "x", field_type, required=False))
+    # Column contains {1.0, NaN}: min is 1.0, max is NaN (NaN sorts greatest).
+    # No NaN stats are present, but the row 1.0 is in the literal set, so the
+    # file cannot be proven to fully match NotIn.
+    data_file = DataFile.from_args(
+        file_path="file.parquet",
+        file_format=FileFormat.PARQUET,
+        partition={},
+        record_count=2,
+        file_size_in_bytes=1,
+        value_counts={1: 2},
+        null_value_counts={1: 0},
+        nan_value_counts={1: 1},
+        lower_bounds={1: to_bytes(field_type, 1.0)},
+        upper_bounds={1: to_bytes(field_type, float("nan"))},
+    )
+
+    should_read = _StrictMetricsEvaluator(schema, NotIn("x", {1.0, 2.0})).eval(data_file)
+    assert should_read == ROWS_MIGHT_NOT_MATCH, (
+        "NaN upper bound makes the bounds unusable: the non-NaN row 1.0 is in the literal set"
+    )
+
+
+@pytest.mark.parametrize("field_type", [FloatType(), DoubleType()])
 def test_strict_not_equal_and_not_in_with_all_nans(field_type: PrimitiveType) -> None:
     schema = Schema(NestedField(1, "x", field_type, required=False))
     data_file = DataFile.from_args(

--- a/tests/expressions/test_evaluator.py
+++ b/tests/expressions/test_evaluator.py
@@ -1362,8 +1362,8 @@ def test_strict_not_equal_and_not_in_with_mixed_nans_and_matching_bounds(field_t
 def test_strict_not_in_with_nan_upper_bound(field_type: PrimitiveType) -> None:
     schema = Schema(NestedField(1, "x", field_type, required=False))
     # Column contains {1.0, NaN}: min is 1.0, max is NaN (NaN sorts greatest).
-    # No NaN stats are present, but the row 1.0 is in the literal set, so the
-    # file cannot be proven to fully match NotIn.
+    # The non-NaN row 1.0 is in the literal set, so the file cannot be proven
+    # to fully match NotIn, even though the NaN count is known.
     data_file = DataFile.from_args(
         file_path="file.parquet",
         file_format=FileFormat.PARQUET,


### PR DESCRIPTION
# Rationale for this change

`_StrictMetricsEvaluationVisitor.visit_not_in` returns a false `ROWS_MUST_MATCH` when the
upper bound of a float column is NaN.

`NaN >= val` is `False` for every value, so the `upper >= val` filter drops every literal
from the set and the empty set is read as proof that no row can match. But a NaN upper
bound only means NaN sorts greatest in the writer's min/max: the file can still contain
non-NaN values that are in the literal set.

Reproducer (offline, no catalog):

```python
schema = Schema(NestedField(1, "x", DoubleType(), required=False))
data_file = DataFile.from_args(
    file_path="file.parquet",
    file_format=FileFormat.PARQUET,
    partition={},
    record_count=2,
    file_size_in_bytes=1,
    value_counts={1: 2},
    null_value_counts={1: 0},
    nan_value_counts={1: 1},
    lower_bounds={1: to_bytes(DoubleType(), 1.0)},
    upper_bounds={1: to_bytes(DoubleType(), float("nan"))},
)

_StrictMetricsEvaluator(schema, NotIn("x", {1.0, 2.0})).eval(data_file)
# main: True (ROWS_MUST_MATCH)
# fixed: False (ROWS_MIGHT_NOT_MATCH)
```

The file describes a column `{1.0, NaN}`. Evaluating the predicate on the actual rows
with `expression_evaluator` gives `[False, True]`: the row `1.0` does not match
`NotIn("x", {1.0, 2.0})`, so `ROWS_MUST_MATCH` is impossible.

This is not just a wrong pruning verdict. `_DeleteFiles._compute_deletes`
(pyiceberg/table/update/snapshot.py:612) drops a whole data file when the strict
evaluator returns `ROWS_MUST_MATCH`, so a `Table.delete(...)` with a `NotIn` filter can
delete rows that should be kept.

Java parity: `StrictEvalVisitor.notIn`
(api/src/main/java/org/apache/iceberg/expressions/StrictEvalVisitor.java:358-383)
guards the lower bound explicitly with `NaNUtil.isNaN(lower)` and its comparator orders
NaN greatest, so a NaN upper bound never excludes literals there. The Python port
already mirrors the lower-bound guard (visitors.py:1774); this adds the missing
upper-bound guard with the same comment, matching the Java docs note that NaN bounds
are unreliable when the column can contain non-NaN data.

Same genre as #3891 (NaN/null-bound handling in the metrics evaluators).

## Are these changes tested?

Yes. `test_strict_not_in_with_nan_upper_bound` in tests/expressions/test_evaluator.py,
parametrized over FloatType/DoubleType, modeled on the neighboring
`test_strict_not_equal_and_not_in_with_mixed_nans_and_matching_bounds`. It fails on
main and passes with the fix. Full unit suite: 4019 passed, 3 skipped.

## Are there any user-facing changes?

Yes, bug fix: `Table.delete` with a `NotIn` row filter no longer drops data files whose
float column has a NaN upper bound and partially-matching rows. No API changes.
