### PR TITLE
Infra: Fix Hive Dockerfile apt failure on EOL Debian bullseye

### DIFF
--- a/dev/hive/Dockerfile
+++ b/dev/hive/Dockerfile
@@ -23,7 +23,10 @@ ARG MAVEN_MIRROR=https://repo1.maven.org/maven2
 USER root
 
 # Install curl (separate layer - rarely changes)
-RUN apt-get update -qq && \
+# Debian bullseye (the apache/hive:4.0.0 base) is EOL, so its security repo
+# metadata is no longer refreshed and apt rejects the expired Release file.
+# Skip the freshness check; the signature is still verified.
+RUN apt-get -o Acquire::Check-Valid-Until=false update -qq && \
     apt-get -qq -y install --no-install-recommends curl && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The apache/hive:4.0.0 base image is built on Debian bullseye, which reached end of life on 2026-08-31. Its security repository metadata is no longer refreshed, so the signed Release file has expired and apt-get update fails with a non-zero exit, breaking the integration-test image build on every PR.

Pass Acquire::Check-Valid-Until=false so apt tolerates the stale (but still signature-verified) metadata. This is a minimal unblock; a follow-up can drop the apt-get layer entirely.

Closes #3922

<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change

## Are these changes tested?

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
