### PR TITLE
Update hive docker to 4.2.1

### DIFF
--- a/dev/docker-compose-integration.yml
+++ b/dev/docker-compose-integration.yml
@@ -98,8 +98,6 @@ services:
     image: pyiceberg-hive:latest
     build:
       context: hive/
-      args:
-        MAVEN_MIRROR: ${MAVEN_MIRROR:-https://repo1.maven.org/maven2}
     container_name: pyiceberg-hive
     hostname: hive
     networks:

--- a/dev/docker-compose-integration.yml
+++ b/dev/docker-compose-integration.yml
@@ -98,6 +98,8 @@ services:
     image: pyiceberg-hive:latest
     build:
       context: hive/
+      args:
+        MAVEN_MIRROR: ${MAVEN_MIRROR:-https://repo1.maven.org/maven2}
     container_name: pyiceberg-hive
     hostname: hive
     networks:

--- a/dev/hive/Dockerfile
+++ b/dev/hive/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM apache/hive:4.0.0
+FROM apache/hive:4.2.1
 
 # Dependency versions - changing these invalidates the JAR download layer
 ARG HADOOP_VERSION=3.3.6

--- a/dev/hive/Dockerfile
+++ b/dev/hive/Dockerfile
@@ -15,28 +15,14 @@
 
 FROM apache/hive:4.2.1
 
-# Dependency versions - changing these invalidates the JAR download layer
-ARG HADOOP_VERSION=3.3.6
-ARG AWS_SDK_BUNDLE=1.12.753
-ARG MAVEN_MIRROR=https://repo1.maven.org/maven2
-
 USER root
 
-# Install curl (separate layer - rarely changes)
-RUN apt-get update -qq && \
-    apt-get -qq -y install --no-install-recommends curl && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+# Link the hadoop-aws and AWS SDK jars that the image ships into the metastore classpath
+RUN ln -s /opt/hadoop/share/hadoop/tools/lib/hadoop-aws-*.jar /opt/hive/lib/ && \
+    ln -s /opt/hadoop/share/hadoop/tools/lib/bundle-*.jar /opt/hive/lib/
 
-# Download JARs with retry logic (slow layer - only changes when versions change)
-RUN curl -fsSL --retry 3 --retry-delay 5 \
-        -o /opt/hive/lib/hadoop-aws-${HADOOP_VERSION}.jar \
-        "${MAVEN_MIRROR}/org/apache/hadoop/hadoop-aws/${HADOOP_VERSION}/hadoop-aws-${HADOOP_VERSION}.jar" && \
-    curl -fsSL --retry 3 --retry-delay 5 \
-        -o /opt/hive/lib/aws-java-sdk-bundle-${AWS_SDK_BUNDLE}.jar \
-        "${MAVEN_MIRROR}/com/amazonaws/aws-java-sdk-bundle/${AWS_SDK_BUNDLE}/aws-java-sdk-bundle-${AWS_SDK_BUNDLE}.jar"
-
-# Copy configuration last (changes more frequently than JARs)
-COPY core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
+# The entrypoint links this directory into the Hive config directory, over its own core-site.xml
+ENV HIVE_CUSTOM_CONF_DIR=/opt/hive/custom-conf
+COPY core-site.xml ${HIVE_CUSTOM_CONF_DIR}/core-site.xml
 
 USER hive

--- a/dev/spark/Dockerfile
+++ b/dev/spark/Dockerfile
@@ -23,6 +23,7 @@ ARG ICEBERG_VERSION=1.11.0
 ARG ICEBERG_SPARK_RUNTIME_VERSION=4.0_2.13
 ARG HADOOP_VERSION=3.4.1
 ARG AWS_SDK_VERSION=2.24.6
+ARG HIVE_METASTORE_VERSION=4.0.1
 ARG MAVEN_MIRROR=https://repo.maven.apache.org/maven2
 
 USER root
@@ -36,6 +37,11 @@ RUN apt-get update -qq && \
     mkdir -p /home/iceberg/spark-events && \
     chown -R spark:spark /home/iceberg
 
+# Iceberg's Hive catalog uses the metastore client from the class path, and the bundled
+# Hive 2.3 one calls get_table, which Hive dropped in 4.0.1. Move it aside for a Hive 4 client.
+RUN mkdir -p "${SPARK_HOME}/hive-metastore-jars" && \
+    mv "${SPARK_HOME}"/jars/hive-metastore-*.jar "${SPARK_HOME}/hive-metastore-jars/"
+
 # Download JARs with retry logic (most cacheable - only changes when versions change)
 # This is the slowest step, so we do it before copying config files
 RUN set -e && \
@@ -44,6 +50,7 @@ RUN set -e && \
         "org/apache/iceberg/iceberg-spark-runtime-${ICEBERG_SPARK_RUNTIME_VERSION}/${ICEBERG_VERSION}/iceberg-spark-runtime-${ICEBERG_SPARK_RUNTIME_VERSION}-${ICEBERG_VERSION}.jar" \
         "org/apache/iceberg/iceberg-aws-bundle/${ICEBERG_VERSION}/iceberg-aws-bundle-${ICEBERG_VERSION}.jar" \
         "org/apache/hadoop/hadoop-aws/${HADOOP_VERSION}/hadoop-aws-${HADOOP_VERSION}.jar" \
+        "org/apache/hive/hive-standalone-metastore-common/${HIVE_METASTORE_VERSION}/hive-standalone-metastore-common-${HIVE_METASTORE_VERSION}.jar" \
         "software/amazon/awssdk/bundle/${AWS_SDK_VERSION}/bundle-${AWS_SDK_VERSION}.jar"; \
     do \
         jar_name=$(basename "${jar_path}") && \

--- a/dev/spark/spark-defaults.conf
+++ b/dev/spark/spark-defaults.conf
@@ -42,6 +42,11 @@ spark.hadoop.fs.s3a.endpoint           http://minio:9000
 spark.sql.catalogImplementation        hive
 spark.sql.warehouse.dir                s3a://warehouse/hive/
 
+# Spark's own Hive client speaks the Hive 2.3 API, so keep it off the Hive 4 client on the class path
+spark.sql.hive.metastore.version       2.3.10
+spark.sql.hive.metastore.jars          path
+spark.sql.hive.metastore.jars.path     file:///opt/spark/hive-metastore-jars/*,file:///opt/spark/jars/*
+
 spark.sql.defaultCatalog               rest
 
 # Configure Spark UI and event logging

--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -32,6 +32,8 @@ from hive_metastore.ttypes import (
     CheckLockRequest,
     EnvironmentContext,
     FieldSchema,
+    GetTableRequest,
+    GetTablesRequest,
     InvalidOperationException,
     LockComponent,
     LockLevel,
@@ -297,6 +299,7 @@ class HiveCatalog(MetastoreCatalog):
     def __init__(self, name: str, **properties: str):
         super().__init__(name, **properties)
         self._client = self._create_hive_client(properties)
+        self._hive2_compatible = property_as_bool(properties, HIVE2_COMPATIBLE, HIVE2_COMPATIBLE_DEFAULT)
 
         self._lock_check_min_wait_time = property_as_float(properties, LOCK_CHECK_MIN_WAIT_TIME, DEFAULT_LOCK_CHECK_MIN_WAIT_TIME)
         self._lock_check_max_wait_time = property_as_float(properties, LOCK_CHECK_MAX_WAIT_TIME, DEFAULT_LOCK_CHECK_MAX_WAIT_TIME)
@@ -367,7 +370,7 @@ class HiveCatalog(MetastoreCatalog):
             sd=_construct_hive_storage_descriptor(
                 table.schema(),
                 table.location(),
-                property_as_bool(self.properties, HIVE2_COMPATIBLE, HIVE2_COMPATIBLE_DEFAULT),
+                self._hive2_compatible,
             ),
             tableType=EXTERNAL_TABLE,
             parameters=_construct_parameters(metadata_location=table.metadata_location, metadata_properties=table.properties),
@@ -379,9 +382,21 @@ class HiveCatalog(MetastoreCatalog):
         except AlreadyExistsException as e:
             raise TableAlreadyExistsError(f"Table {hive_table.dbName}.{hive_table.tableName} already exists") from e
 
+    def _fetch_hive_table(self, open_client: Client, database_name: str, table_name: str) -> HiveTable:
+        # Hive 4.0.1 removed get_table, and Hive 2 does not have get_table_req
+        if self._hive2_compatible:
+            return open_client.get_table(dbname=database_name, tbl_name=table_name)
+        return open_client.get_table_req(GetTableRequest(dbName=database_name, tblName=table_name)).table
+
+    def _fetch_hive_tables(self, open_client: Client, database_name: str) -> list[HiveTable]:
+        table_names = open_client.get_all_tables(db_name=database_name)
+        if self._hive2_compatible:
+            return open_client.get_table_objects_by_name(dbname=database_name, tbl_names=table_names)
+        return open_client.get_table_objects_by_name_req(GetTablesRequest(dbName=database_name, tblNames=table_names)).tables
+
     def _get_hive_table(self, open_client: Client, database_name: str, table_name: str) -> HiveTable:
         try:
-            return open_client.get_table(dbname=database_name, tbl_name=table_name)
+            return self._fetch_hive_table(open_client, database_name, table_name)
         except NoSuchObjectException as e:
             raise NoSuchTableError(f"Table does not exists: {table_name}") from e
 
@@ -428,7 +443,7 @@ class HiveCatalog(MetastoreCatalog):
 
         with self._client as open_client:
             self._create_hive_table(open_client, tbl)
-            hive_table = open_client.get_table(dbname=database_name, tbl_name=table_name)
+            hive_table = self._fetch_hive_table(open_client, database_name, table_name)
 
         return self._convert_hive_into_iceberg(hive_table)
 
@@ -474,7 +489,7 @@ class HiveCatalog(MetastoreCatalog):
         tbl = self._convert_iceberg_into_hive(staged_table)
         with self._client as open_client:
             self._create_hive_table(open_client, tbl)
-            hive_table = open_client.get_table(dbname=database_name, tbl_name=table_name)
+            hive_table = self._fetch_hive_table(open_client, database_name, table_name)
 
         return self._convert_hive_into_iceberg(hive_table)
 
@@ -603,7 +618,7 @@ class HiveCatalog(MetastoreCatalog):
                     hive_table.sd = _construct_hive_storage_descriptor(
                         updated_staged_table.schema(),
                         updated_staged_table.location(),
-                        property_as_bool(self.properties, HIVE2_COMPATIBLE, HIVE2_COMPATIBLE_DEFAULT),
+                        self._hive2_compatible,
                     )
                     open_client.alter_table_with_environment_context(
                         dbname=database_name,
@@ -703,7 +718,7 @@ class HiveCatalog(MetastoreCatalog):
 
         try:
             with self._client as open_client:
-                tbl = open_client.get_table(dbname=from_database_name, tbl_name=from_table_name)
+                tbl = self._fetch_hive_table(open_client, from_database_name, from_table_name)
                 tbl.dbName = to_database_name
                 tbl.tableName = to_table_name
                 open_client.alter_table_with_environment_context(
@@ -778,9 +793,7 @@ class HiveCatalog(MetastoreCatalog):
         with self._client as open_client:
             return [
                 (database_name, table.tableName)
-                for table in open_client.get_table_objects_by_name(
-                    dbname=database_name, tbl_names=open_client.get_all_tables(db_name=database_name)
-                )
+                for table in self._fetch_hive_tables(open_client, database_name)
                 if table.parameters.get(TABLE_TYPE, "").lower() == ICEBERG
             ]
 

--- a/tests/catalog/test_hive.py
+++ b/tests/catalog/test_hive.py
@@ -31,6 +31,10 @@ from hive_metastore.ttypes import (
     AlreadyExistsException,
     EnvironmentContext,
     FieldSchema,
+    GetTableRequest,
+    GetTableResult,
+    GetTablesRequest,
+    GetTablesResult,
     InvalidOperationException,
     LockResponse,
     LockState,
@@ -293,6 +297,7 @@ def test_create_table(
     catalog._client = MagicMock()
     catalog._client.__enter__().create_table.return_value = None
     catalog._client.__enter__().get_table.return_value = hive_table
+    catalog._client.__enter__().get_table_req.return_value = GetTableResult(table=hive_table)
     catalog._client.__enter__().get_database.return_value = hive_database
     catalog.create_table(("default", "table"), schema=table_schema_with_all_types, properties={"owner": "javaberg"})
 
@@ -472,6 +477,7 @@ def test_create_table_with_given_location_removes_trailing_slash(
     catalog._client = MagicMock()
     catalog._client.__enter__().create_table.return_value = None
     catalog._client.__enter__().get_table.return_value = hive_table
+    catalog._client.__enter__().get_table_req.return_value = GetTableResult(table=hive_table)
     catalog._client.__enter__().get_database.return_value = hive_database
     catalog.create_table(
         ("default", "table"), schema=table_schema_with_all_types, properties={"owner": "javaberg"}, location=f"{location}/"
@@ -645,7 +651,7 @@ def test_create_v1_table(table_schema_simple: Schema, hive_database: HiveDatabas
 
     catalog._client = MagicMock()
     catalog._client.__enter__().create_table.return_value = None
-    catalog._client.__enter__().get_table.return_value = hive_table
+    catalog._client.__enter__().get_table_req.return_value = GetTableResult(table=hive_table)
     catalog._client.__enter__().get_database.return_value = hive_database
     catalog.create_table(
         ("default", "table"), schema=table_schema_simple, properties={"owner": "javaberg", "format-version": "1"}
@@ -696,10 +702,10 @@ def test_load_table(hive_table: HiveTable) -> None:
     catalog = HiveCatalog(HIVE_CATALOG_NAME, uri=HIVE_METASTORE_FAKE_URL)
 
     catalog._client = MagicMock()
-    catalog._client.__enter__().get_table.return_value = hive_table
+    catalog._client.__enter__().get_table_req.return_value = GetTableResult(table=hive_table)
     table = catalog.load_table(("default", "new_tabl2e"))
 
-    catalog._client.__enter__().get_table.assert_called_with(dbname="default", tbl_name="new_tabl2e")
+    catalog._client.__enter__().get_table_req.assert_called_with(GetTableRequest(dbName="default", tblName="new_tabl2e"))
 
     expected = TableMetadataV2(
         location="s3://bucket/test/location",
@@ -796,11 +802,11 @@ def test_load_table_from_self_identifier(hive_table: HiveTable) -> None:
     catalog = HiveCatalog(HIVE_CATALOG_NAME, uri=HIVE_METASTORE_FAKE_URL)
 
     catalog._client = MagicMock()
-    catalog._client.__enter__().get_table.return_value = hive_table
+    catalog._client.__enter__().get_table_req.return_value = GetTableResult(table=hive_table)
     intermediate = catalog.load_table(("default", "new_tabl2e"))
     table = catalog.load_table(intermediate.name())
 
-    catalog._client.__enter__().get_table.assert_called_with(dbname="default", tbl_name="new_tabl2e")
+    catalog._client.__enter__().get_table_req.assert_called_with(GetTableRequest(dbName="default", tblName="new_tabl2e"))
 
     expected = TableMetadataV2(
         location="s3://bucket/test/location",
@@ -902,7 +908,10 @@ def test_rename_table(hive_table: HiveTable) -> None:
     renamed_table.tableName = "new_tabl3e"
 
     catalog._client = MagicMock()
-    catalog._client.__enter__().get_table.side_effect = [hive_table, renamed_table]
+    catalog._client.__enter__().get_table_req.side_effect = [
+        GetTableResult(table=hive_table),
+        GetTableResult(table=renamed_table),
+    ]
     catalog._client.__enter__().alter_table_with_environment_context.return_value = None
 
     from_identifier = ("default", "new_tabl2e")
@@ -911,8 +920,11 @@ def test_rename_table(hive_table: HiveTable) -> None:
 
     assert table.name() == to_identifier
 
-    calls = [call(dbname="default", tbl_name="new_tabl2e"), call(dbname="default", tbl_name="new_tabl3e")]
-    catalog._client.__enter__().get_table.assert_has_calls(calls)
+    calls = [
+        call(GetTableRequest(dbName="default", tblName="new_tabl2e")),
+        call(GetTableRequest(dbName="default", tblName="new_tabl3e")),
+    ]
+    catalog._client.__enter__().get_table_req.assert_has_calls(calls)
     catalog._client.__enter__().alter_table_with_environment_context.assert_called_with(
         dbname="default",
         tbl_name="new_tabl2e",
@@ -926,25 +938,31 @@ def test_rename_table_from_self_identifier(hive_table: HiveTable) -> None:
     catalog.table_exists = MagicMock(return_value=False)  # type: ignore[method-assign]
 
     catalog._client = MagicMock()
-    catalog._client.__enter__().get_table.return_value = hive_table
+    catalog._client.__enter__().get_table_req.return_value = GetTableResult(table=hive_table)
 
     from_identifier = ("default", "new_tabl2e")
     from_table = catalog.load_table(from_identifier)
-    catalog._client.__enter__().get_table.assert_called_with(dbname="default", tbl_name="new_tabl2e")
+    catalog._client.__enter__().get_table_req.assert_called_with(GetTableRequest(dbName="default", tblName="new_tabl2e"))
 
     renamed_table = copy.deepcopy(hive_table)
     renamed_table.dbName = "default"
     renamed_table.tableName = "new_tabl3e"
 
-    catalog._client.__enter__().get_table.side_effect = [hive_table, renamed_table]
+    catalog._client.__enter__().get_table_req.side_effect = [
+        GetTableResult(table=hive_table),
+        GetTableResult(table=renamed_table),
+    ]
     catalog._client.__enter__().alter_table_with_environment_context.return_value = None
     to_identifier = ("default", "new_tabl3e")
     table = catalog.rename_table(from_table.name(), to_identifier)
 
     assert table.name() == to_identifier
 
-    calls = [call(dbname="default", tbl_name="new_tabl2e"), call(dbname="default", tbl_name="new_tabl3e")]
-    catalog._client.__enter__().get_table.assert_has_calls(calls)
+    calls = [
+        call(GetTableRequest(dbName="default", tblName="new_tabl2e")),
+        call(GetTableRequest(dbName="default", tblName="new_tabl3e")),
+    ]
+    catalog._client.__enter__().get_table_req.assert_has_calls(calls)
     catalog._client.__enter__().alter_table_with_environment_context.assert_called_with(
         dbname="default",
         tbl_name="new_tabl2e",
@@ -1042,13 +1060,13 @@ def test_list_tables(hive_table: HiveTable) -> None:
 
     catalog._client = MagicMock()
     catalog._client.__enter__().get_all_tables.return_value = ["table1", "table2", "table3", "table4"]
-    catalog._client.__enter__().get_table_objects_by_name.return_value = [tbl1, tbl2, tbl3, tbl4]
+    catalog._client.__enter__().get_table_objects_by_name_req.return_value = GetTablesResult(tables=[tbl1, tbl2, tbl3, tbl4])
 
     got_tables = catalog.list_tables("database")
     assert got_tables == [("database", "table1"), ("database", "table2")]
     catalog._client.__enter__().get_all_tables.assert_called_with(db_name="database")
-    catalog._client.__enter__().get_table_objects_by_name.assert_called_with(
-        dbname="database", tbl_names=["table1", "table2", "table3", "table4"]
+    catalog._client.__enter__().get_table_objects_by_name_req.assert_called_with(
+        GetTablesRequest(dbName="database", tblNames=["table1", "table2", "table3", "table4"])
     )
 
 
@@ -1078,7 +1096,7 @@ def test_drop_table_from_self_identifier(hive_table: HiveTable) -> None:
     catalog = HiveCatalog(HIVE_CATALOG_NAME, uri=HIVE_METASTORE_FAKE_URL)
 
     catalog._client = MagicMock()
-    catalog._client.__enter__().get_table.return_value = hive_table
+    catalog._client.__enter__().get_table_req.return_value = GetTableResult(table=hive_table)
     table = catalog.load_table(("default", "new_tabl2e"))
 
     catalog._client.__enter__().get_all_databases.return_value = ["namespace1", "namespace2"]

--- a/tests/integration/test_reads.py
+++ b/tests/integration/test_reads.py
@@ -27,7 +27,9 @@ from urllib.parse import urlparse
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
-from hive_metastore.ttypes import LockRequest, LockResponse, LockState, UnlockRequest
+from hive_metastore.ThriftHiveMetastore import Client
+from hive_metastore.ttypes import GetTableRequest, LockRequest, LockResponse, LockState, UnlockRequest
+from hive_metastore.ttypes import Table as HiveTable
 from pyarrow.fs import S3FileSystem
 from pydantic_core import ValidationError
 from pyspark.sql import SparkSession
@@ -67,6 +69,11 @@ DEFAULT_PROPERTIES = {"write.parquet.compression-codec": "zstd"}
 
 
 TABLE_NAME = ("default", "t1")
+
+
+def _get_hive_table(open_client: Client) -> HiveTable:
+    database_name, table_name = TABLE_NAME
+    return open_client.get_table_req(GetTableRequest(dbName=database_name, tblName=table_name)).table
 
 
 def create_table(catalog: Catalog) -> Table:
@@ -124,7 +131,7 @@ def test_hive_properties(catalog: Catalog) -> None:
     hive_client: _HiveClient = _HiveClient(catalog.properties["uri"])
 
     with hive_client as open_client:
-        hive_table = open_client.get_table(*TABLE_NAME)
+        hive_table = _get_hive_table(open_client)
         assert hive_table.parameters.get("abc") == "def"
         assert hive_table.parameters.get("p1") == "123"
         assert hive_table.parameters.get("not_exist_parameter") is None
@@ -132,7 +139,7 @@ def test_hive_properties(catalog: Catalog) -> None:
     table.transaction().remove_properties("abc").commit_transaction()
 
     with hive_client as open_client:
-        hive_table = open_client.get_table(*TABLE_NAME)
+        hive_table = _get_hive_table(open_client)
         assert hive_table.parameters.get("abc") is None
 
 
@@ -149,14 +156,14 @@ def test_hive_preserves_hms_specific_properties(catalog: Catalog) -> None:
     table = create_table(catalog)
     hive_client: _HiveClient = _HiveClient(catalog.properties["uri"])
     with hive_client as open_client:
-        hive_table = open_client.get_table(*TABLE_NAME)
+        hive_table = _get_hive_table(open_client)
         # Add HMS-specific properties that aren't managed by Iceberg
         hive_table.parameters["table_category"] = "production"
         hive_table.parameters["data_owner"] = "data_team"
         open_client.alter_table(TABLE_NAME[0], TABLE_NAME[1], hive_table)
 
     with hive_client as open_client:
-        hive_table = open_client.get_table(*TABLE_NAME)
+        hive_table = _get_hive_table(open_client)
         assert hive_table.parameters.get("table_category") == "production"
         assert hive_table.parameters.get("data_owner") == "data_team"
 
@@ -164,7 +171,7 @@ def test_hive_preserves_hms_specific_properties(catalog: Catalog) -> None:
 
     # Verify that HMS-specific properties are STILL present after commit
     with hive_client as open_client:
-        hive_table = open_client.get_table(*TABLE_NAME)
+        hive_table = _get_hive_table(open_client)
         # HMS-specific properties should be preserved
         assert hive_table.parameters.get("table_category") == "production", (
             "HMS property 'table_category' was lost during commit!"
@@ -189,7 +196,7 @@ def test_iceberg_property_deletion_not_restored_from_old_hms_state(session_catal
 
     # Verify both properties exist
     with hive_client as open_client:
-        hive_table = open_client.get_table(*TABLE_NAME)
+        hive_table = _get_hive_table(open_client)
         assert hive_table.parameters.get("prop_to_keep") == "keep_value"
         assert hive_table.parameters.get("prop_to_delete") == "delete_me"
 
@@ -198,7 +205,7 @@ def test_iceberg_property_deletion_not_restored_from_old_hms_state(session_catal
 
     # Verify property is deleted from HMS
     with hive_client as open_client:
-        hive_table = open_client.get_table(*TABLE_NAME)
+        hive_table = _get_hive_table(open_client)
         assert hive_table.parameters.get("prop_to_keep") == "keep_value"
         assert hive_table.parameters.get("prop_to_delete") is None, "Deleted property should not exist in HMS!"
 
@@ -207,7 +214,7 @@ def test_iceberg_property_deletion_not_restored_from_old_hms_state(session_catal
 
     # Ensure deleted property doesn't come back from old state
     with hive_client as open_client:
-        hive_table = open_client.get_table(*TABLE_NAME)
+        hive_table = _get_hive_table(open_client)
         assert hive_table.parameters.get("prop_to_keep") == "keep_value"
         assert hive_table.parameters.get("new_prop") == "new_value"
         assert hive_table.parameters.get("prop_to_delete") is None, "Deleted property should NOT be restored from old HMS state!"
@@ -229,13 +236,13 @@ def test_iceberg_metadata_is_source_of_truth(catalog: Catalog) -> None:
 
     # External tool modifies the same property in HMS
     with hive_client as open_client:
-        hive_table = open_client.get_table(*TABLE_NAME)
+        hive_table = _get_hive_table(open_client)
         hive_table.parameters["my_prop"] = "hms_value"  # Conflicting value
         open_client.alter_table(TABLE_NAME[0], TABLE_NAME[1], hive_table)
 
     # Verify HMS has the external value
     with hive_client as open_client:
-        hive_table = open_client.get_table(*TABLE_NAME)
+        hive_table = _get_hive_table(open_client)
         assert hive_table.parameters.get("my_prop") == "hms_value"
 
     # Perform another Iceberg commit
@@ -243,7 +250,7 @@ def test_iceberg_metadata_is_source_of_truth(catalog: Catalog) -> None:
 
     # Iceberg's value should take precedence
     with hive_client as open_client:
-        hive_table = open_client.get_table(*TABLE_NAME)
+        hive_table = _get_hive_table(open_client)
         assert hive_table.parameters.get("my_prop") == "iceberg_value", (
             "Iceberg property value should take precedence over conflicting HMS value!"
         )
@@ -262,7 +269,7 @@ def test_hive_critical_properties_always_from_iceberg(catalog: Catalog) -> None:
 
     # Get original metadata_location
     with hive_client as open_client:
-        hive_table = open_client.get_table(*TABLE_NAME)
+        hive_table = _get_hive_table(open_client)
         original_metadata_location = hive_table.parameters.get("metadata_location")
         assert original_metadata_location is not None
         assert hive_table.parameters.get("EXTERNAL") == "TRUE"
@@ -270,7 +277,7 @@ def test_hive_critical_properties_always_from_iceberg(catalog: Catalog) -> None:
 
     # Try to tamper with critical properties via HMS
     with hive_client as open_client:
-        hive_table = open_client.get_table(*TABLE_NAME)
+        hive_table = _get_hive_table(open_client)
         hive_table.parameters["EXTERNAL"] = "FALSE"  # Try to change
         open_client.alter_table(TABLE_NAME[0], TABLE_NAME[1], hive_table)
 
@@ -279,7 +286,7 @@ def test_hive_critical_properties_always_from_iceberg(catalog: Catalog) -> None:
 
     # Critical properties should be restored by Iceberg
     with hive_client as open_client:
-        hive_table = open_client.get_table(*TABLE_NAME)
+        hive_table = _get_hive_table(open_client)
         assert hive_table.parameters.get("EXTERNAL") == "TRUE", "EXTERNAL should always be TRUE from Iceberg!"
         assert hive_table.parameters.get("table_type") == "ICEBERG", "table_type should always be ICEBERG!"
         # metadata_location should be updated (new metadata file)
@@ -301,13 +308,13 @@ def test_hive_native_properties_cannot_be_deleted_via_iceberg(catalog: Catalog) 
 
     # Set an HMS-native property directly (not through Iceberg)
     with hive_client as open_client:
-        hive_table = open_client.get_table(*TABLE_NAME)
+        hive_table = _get_hive_table(open_client)
         hive_table.parameters["hms_native_prop"] = "native_value"
         open_client.alter_table(TABLE_NAME[0], TABLE_NAME[1], hive_table)
 
     # Verify the HMS-native property exists in HMS
     with hive_client as open_client:
-        hive_table = open_client.get_table(*TABLE_NAME)
+        hive_table = _get_hive_table(open_client)
         assert hive_table.parameters.get("hms_native_prop") == "native_value"
 
     # Refresh the Iceberg table to get the latest state
@@ -323,7 +330,7 @@ def test_hive_native_properties_cannot_be_deleted_via_iceberg(catalog: Catalog) 
 
     # HMS-native property should still exist (cannot be deleted via Iceberg)
     with hive_client as open_client:
-        hive_table = open_client.get_table(*TABLE_NAME)
+        hive_table = _get_hive_table(open_client)
         assert hive_table.parameters.get("hms_native_prop") == "native_value", (
             "HMS-native property should still exist since Iceberg removal failed!"
         )
@@ -333,7 +340,7 @@ def test_hive_native_properties_cannot_be_deleted_via_iceberg(catalog: Catalog) 
 
     # Verify it's updated in both places
     with hive_client as open_client:
-        hive_table = open_client.get_table(*TABLE_NAME)
+        hive_table = _get_hive_table(open_client)
         assert hive_table.parameters.get("hms_native_prop") == "iceberg_value"
 
     # Now we CAN delete it via Iceberg (because it's now tracked in Iceberg metadata)
@@ -341,7 +348,7 @@ def test_hive_native_properties_cannot_be_deleted_via_iceberg(catalog: Catalog) 
 
     # Property should be deleted from HMS
     with hive_client as open_client:
-        hive_table = open_client.get_table(*TABLE_NAME)
+        hive_table = _get_hive_table(open_client)
         assert hive_table.parameters.get("hms_native_prop") is None, (
             "Property should be deletable after being SET via Iceberg (making it tracked)!"
         )


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
Closes #3922 

# Rationale for this change
Right now, integration tests are failing because Debian Bullseye has officially reached EOL. We should move our Hive images to the newest version (4.2.1).

Hive 4.0.1 removed `get_table` so there is some changes to the underlying Hive code to make this work properly. There's also some changes to the Dockerfiles outside of just bumping the version.

This is a larger lift than just removing the Debian EOL check, but we should do this at some point.

## Are these changes tested?
Integration tests should pass.

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
