### PR TITLE
Hive: document hive2-compatible and fix commit locks on Hive 2.1

### DIFF
--- a/mkdocs/docs/configuration.md
+++ b/mkdocs/docs/configuration.md
@@ -746,12 +746,12 @@ catalog:
 
 | Key                          | Example | Description                          |
 |------------------------------| ------- | ------------------------------------ |
-| hive.hive2-compatible        | true    | Using Hive 2.x compatibility mode    |
+| hive.hive2-compatible        | true    | Set to `true` when using a Hive 2.x metastore |
 | hive.kerberos-authentication | true    | Using authentication via Kerberos    |
 | hive.kerberos-service-name   | hive    | Kerberos service name (default hive) |
 | ugi                 | t-1234:secret                    | Hadoop UGI for Hive client.                                                                        |
 
-When using Hive 2.x, make sure to set the compatibility flag:
+Hive 3 and newer need no extra configuration. When using a Hive 2.x metastore, set the compatibility flag:
 
 ```yaml
 catalog:

--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -30,6 +30,7 @@ from hive_metastore.ThriftHiveMetastore import Client
 from hive_metastore.ttypes import (
     AlreadyExistsException,
     CheckLockRequest,
+    DataOperationType,
     EnvironmentContext,
     FieldSchema,
     GetTableRequest,
@@ -506,8 +507,15 @@ class HiveCatalog(MetastoreCatalog):
         raise NotImplementedError
 
     def _create_lock_request(self, database_name: str, table_name: str) -> LockRequest:
+        # Iceberg commits do not open a metastore transaction, so the lock is marked NO_TXN. Setting it explicitly
+        # also matters for Hive 2.1, which rejects a lock component left at the default UNSET operation type.
         lock_component: LockComponent = LockComponent(
-            level=LockLevel.TABLE, type=LockType.EXCLUSIVE, dbname=database_name, tablename=table_name, isTransactional=True
+            level=LockLevel.TABLE,
+            type=LockType.EXCLUSIVE,
+            dbname=database_name,
+            tablename=table_name,
+            operationType=DataOperationType.NO_TXN,
+            isTransactional=True,
         )
 
         lock_request: LockRequest = LockRequest(component=[lock_component], user=getpass.getuser(), hostname=socket.gethostname())

--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -508,7 +508,9 @@ class HiveCatalog(MetastoreCatalog):
 
     def _create_lock_request(self, database_name: str, table_name: str) -> LockRequest:
         # Iceberg commits are not executed within a Hive transaction, so the lock component uses operationType=NO_TXN.
-        # Setting it explicitly also matters for Hive 2.1, which rejects a lock component left at the default UNSET
+        # Setting it explicitly also matters for Hive 2.1.0, which rejects a lock component left at the default UNSET
+        # operation type. Hive 2.1.1 relaxed this validation:
+        # https://github.com/apache/hive/blob/rel/release-2.1.1/metastore/src/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java#L939-L947
         # operation type.
         lock_component: LockComponent = LockComponent(
             level=LockLevel.TABLE,

--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -508,7 +508,8 @@ class HiveCatalog(MetastoreCatalog):
 
     def _create_lock_request(self, database_name: str, table_name: str) -> LockRequest:
         # Iceberg commits are not executed within a Hive transaction, so the lock component uses operationType=NO_TXN.
-        # Setting it explicitly also matters for Hive 2.1, which rejects a lock component left at the default UNSET operation type.
+        # Setting it explicitly also matters for Hive 2.1, which rejects a lock component left at the default UNSET
+        # operation type.
         lock_component: LockComponent = LockComponent(
             level=LockLevel.TABLE,
             type=LockType.EXCLUSIVE,

--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -507,8 +507,8 @@ class HiveCatalog(MetastoreCatalog):
         raise NotImplementedError
 
     def _create_lock_request(self, database_name: str, table_name: str) -> LockRequest:
-        # Iceberg commits do not open a metastore transaction, so the lock is marked NO_TXN. Setting it explicitly
-        # also matters for Hive 2.1, which rejects a lock component left at the default UNSET operation type.
+        # Iceberg commits are not executed within a Hive transaction, so the lock component uses operationType=NO_TXN.
+        # Setting it explicitly also matters for Hive 2.1, which rejects a lock component left at the default UNSET operation type.
         lock_component: LockComponent = LockComponent(
             level=LockLevel.TABLE,
             type=LockType.EXCLUSIVE,

--- a/pyiceberg/catalog/hive.py
+++ b/pyiceberg/catalog/hive.py
@@ -384,7 +384,7 @@ class HiveCatalog(MetastoreCatalog):
             raise TableAlreadyExistsError(f"Table {hive_table.dbName}.{hive_table.tableName} already exists") from e
 
     def _fetch_hive_table(self, open_client: Client, database_name: str, table_name: str) -> HiveTable:
-        # Hive 4.0.1 removed get_table, and Hive 2 does not have get_table_req
+        # Hive 4.0.1 removed get_table, and Hive 2.2 and older do not have get_table_req
         if self._hive2_compatible:
             return open_client.get_table(dbname=database_name, tbl_name=table_name)
         return open_client.get_table_req(GetTableRequest(dbName=database_name, tblName=table_name)).table


### PR DESCRIPTION
Follow up to #3924.

# Rationale for this change

Two small things after moving CI to Hive 4.2.1:

- Docs: `hive.hive2-compatible` now also selects the legacy thrift calls, so document it as "set this if you're on Hive 2". Hive 3+ works by default.
- Lock: set `operationType=NO_TXN` on the commit lock. Hive 2.1.0 rejects a lock component left at the default `UNSET` (HMS bug, relaxed in 2.1.1), which broke every commit on that version. Every other version accepts `NO_TXN`.

Related: #1222, #1653

# Are these changes tested?

Ran the catalog against a metastore for each Hive line: create, load, list, append, rename, drop.

| Hive  | setting  | result |
|-------|----------|--------|
| 2.0.0 | flag on  | pass   |
| 2.1.0 | flag on  | pass   |
| 2.3.2 | flag on  | pass   |
| 3.1.3 | default  | pass   |
| 4.0.0 | default  | pass   |
| 4.0.1 | default  | pass   |
| 4.1.0 | default  | pass   |
| 4.2.1 | default  | pass   |

The wrong setting fails right away with `Invalid method name`, so a misconfig is obvious. Integration tests pass against 4.2.1.

# Are there any user-facing changes?

Yes. Since #3924, Hive 2.0-2.2 users need `hive.hive2-compatible: true` (2.3 has both sets of calls but still needs the flag for timestamptz columns). Commits now work on Hive 2.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
