### PR TITLE
CI: Avoid redundant post-merge runs

### DIFF
--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -26,9 +26,6 @@ name: "ASF Allowlist Check"
 on:
   pull_request:
   merge_group:
-  push:
-    branches:
-      - main
 
 permissions:
   contents: read

--- a/.github/workflows/check-md-link.yml
+++ b/.github/workflows/check-md-link.yml
@@ -20,12 +20,6 @@
 name: Check Markdown links
 
 on:
-  push:
-    paths:
-      - '.github/workflows/check-md-link.yml'
-      - 'mkdocs/**'
-    branches:
-    - 'main'
   pull_request:
   merge_group:
   workflow_dispatch:

--- a/.github/workflows/python-ci-docs.yml
+++ b/.github/workflows/python-ci-docs.yml
@@ -20,9 +20,6 @@
 name: "Python CI Docs"
 
 on:
-  push:
-    branches:
-      - 'main'
   pull_request:
   merge_group:
 
@@ -49,5 +46,3 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Build docs
         run: make docs-build
-      - name: Run linters
-        run: make lint

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -20,9 +20,6 @@
 name: "Python CI"
 
 on:
-  push:
-    branches:
-    - 'main'
   pull_request:
   merge_group:
 

--- a/.github/workflows/python-integration.yml
+++ b/.github/workflows/python-integration.yml
@@ -20,9 +20,6 @@
 name: "Python Integration"
 
 on:
-  push:
-    branches:
-    - 'main'
   pull_request:
   merge_group:
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -20,8 +20,6 @@
 name: GitHub Actions Security Analysis with zizmor 🌈
 
 on:
-  push:
-    branches: ["main"]
   pull_request:
     branches: ["**"]
   merge_group:


### PR DESCRIPTION
Relates to #3832

The merge queue runs required checks against the latest `main` before merging. Running the same workflows again after the merge adds no coverage and uses extra CI minutes.

Remove the `main` push trigger from Python CI, integration tests, docs, markdown links, zizmor, and the ASF allowlist. They still run for both `pull_request` and `merge_group`. Keep the CodeQL trigger because its default-branch scan feeds code-scanning results.

Also remove `make lint` from the docs workflow since Python CI already runs it.