### PR TITLE
CI: Run lint checks once

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -57,12 +57,12 @@ jobs:
     - name: Install system dependencies
       run: sudo apt-get update && sudo apt-get install -y libkrb5-dev # for kerberos
     - name: Check uv.lock is up to date
-      if: matrix.python == '3.12'
+      if: matrix.python == '3.10'
       run: uv lock --check
     - name: Install
       run: make install
     - name: Run linters
-      if: matrix.python == '3.12'
+      if: matrix.python == '3.10'
       run: make lint
     - name: Run unit tests with coverage
       run: COVERAGE=1 make test

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -57,10 +57,12 @@ jobs:
     - name: Install system dependencies
       run: sudo apt-get update && sudo apt-get install -y libkrb5-dev # for kerberos
     - name: Check uv.lock is up to date
+      if: matrix.python == '3.12'
       run: uv lock --check
     - name: Install
       run: make install
     - name: Run linters
+      if: matrix.python == '3.12'
       run: make lint
     - name: Run unit tests with coverage
       run: COVERAGE=1 make test


### PR DESCRIPTION
Run the lockfile check and linters only on Python 3.12 instead of repeating them across the full matrix.

The matrix still installs, tests, and reports coverage for every supported Python version.