### PR TITLE
Add some docker images to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,3 +41,16 @@ updates:
       codeql-action:
         patterns:
           - "github/codeql-action*"
+  # dev/spark/Dockerfile is not listed: its base image tag comes from an ARG, which Dependabot cannot resolve
+  - package-ecosystem: "docker"
+    directory: "/dev/hive"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "docker-compose"
+    directory: "/dev"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
Now that we're off EOL on Hive, let's have Dependabot attempt to upgrade some of these Docker images for the future. When our Docker images fail, it causes our CI to completely break.

I'm not having Dependabot do Spark, since we've seen issues like #3436 in the past. We can add it later.

## Are these changes tested?
GitHub infra changes only.

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
