### PR TITLE
Fix release docs push

### DIFF
--- a/.github/workflows/python-release-docs.yml
+++ b/.github/workflows/python-release-docs.yml
@@ -49,6 +49,8 @@ jobs:
         working-directory: ./mkdocs
         run: mv ./site /tmp/site
       - name: Push changes to gh-pages branch
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           git checkout --orphan gh-pages-tmp
           git rm --quiet -rf .
@@ -58,4 +60,4 @@ jobs:
           echo "py.iceberg.apache.org" > CNAME
           git add --all
           git commit -m 'Publish Python docs'
-          git push -f origin gh-pages-tmp:gh-pages || true
+          git push -f "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" gh-pages-tmp:gh-pages


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
We did a docs release for 0.12 this morning...and nothing happened.

It looks like our docs release GitHub action shows success, but the push is failing. The `|| true` on the git push is hiding errors. 

## Are these changes tested?
We'll need to test with another docs push.

## Are there any user-facing changes?

<!-- In the case of user-facing changes, please add the changelog label. -->
