### PR TITLE
Fix DataFile spec ID and reject unknown record fields

### DIFF
--- a/pyiceberg/manifest.py
+++ b/pyiceberg/manifest.py
@@ -464,9 +464,14 @@ def data_file_with_partition(partition_type: StructType, format_version: TableVe
 
 class DataFile(Record):
     @classmethod
-    def from_args(cls, _table_format_version: TableVersion = DEFAULT_READ_VERSION, **arguments: Any) -> DataFile:
+    def from_args(
+        cls, _table_format_version: TableVersion = DEFAULT_READ_VERSION, *, spec_id: int | None = None, **arguments: Any
+    ) -> DataFile:
         struct = DATA_FILE_TYPE[_table_format_version]
-        return super()._bind(struct, **arguments)
+        data_file = super()._bind(struct, **arguments)
+        if spec_id is not None:
+            data_file.spec_id = spec_id
+        return data_file
 
     @property
     def content(self) -> DataFileContent:

--- a/pyiceberg/typedef.py
+++ b/pyiceberg/typedef.py
@@ -179,6 +179,9 @@ class Record(StructProtocol):
 
     @classmethod
     def _bind(cls, struct: StructType, **arguments: Any) -> Self:
+        field_names = {field.name for field in struct.fields}
+        if unknown_fields := arguments.keys() - field_names:
+            raise TypeError(f"Unexpected {cls.__name__} fields: {', '.join(sorted(unknown_fields))}")
         return cls(*[arguments[field.name] if field.name in arguments else field.initial_default for field in struct.fields])
 
     def __init__(self, *data: Any) -> None:

--- a/tests/avro/test_file.py
+++ b/tests/avro/test_file.py
@@ -233,8 +233,7 @@ def test_write_manifest_entry_with_iceberg_read_with_fastavro_v2() -> None:
 
 @pytest.mark.parametrize("format_version", [1, 2])
 def test_write_manifest_entry_with_fastavro_read_with_iceberg(format_version: TableVersion) -> None:
-    data_file_dict = {
-        "content": DataFileContent.DATA,
+    common_data_file_args = {
         "file_path": "s3://some-path/some-file.parquet",
         "file_format": FileFormat.PARQUET,
         "partition": Record(),
@@ -248,11 +247,11 @@ def test_write_manifest_entry_with_fastavro_read_with_iceberg(format_version: Ta
         "upper_bounds": {1: b"zzzzzzzzzzzzzzzz"},
         "key_metadata": b"\xde\xad\xbe\xef",
         "split_offsets": [4, 133697593],
-        "equality_ids": [],
         "sort_order_id": 4,
         "spec_id": 3,
     }
-    data_file_v2 = DataFile.from_args(**data_file_dict)  # type: ignore
+    data_file_v2 = DataFile.from_args(content=DataFileContent.DATA, **common_data_file_args)  # type: ignore
+    assert data_file_v2.spec_id == 3
 
     entry = ManifestEntry.from_args(
         status=ManifestEntryStatus.ADDED,
@@ -289,7 +288,11 @@ def test_write_manifest_entry_with_fastavro_read_with_iceberg(format_version: Ta
             avro_entry = next(it)
 
             if format_version == 1:
-                data_file_v1 = DataFile.from_args(**data_file_dict, _table_format_version=format_version)
+                data_file_v1 = DataFile.from_args(
+                    block_size_in_bytes=DEFAULT_BLOCK_SIZE,
+                    _table_format_version=format_version,
+                    **common_data_file_args,  # type: ignore
+                )
 
                 assert avro_entry == ManifestEntry.from_args(
                     status=1,

--- a/tests/integration/test_rest_manifest.py
+++ b/tests/integration/test_rest_manifest.py
@@ -90,7 +90,7 @@ def test_write_sample_manifest(table_test_all_types: Table, compression: AvroCom
     test_schema = table_test_all_types.schema()
     test_spec = table_test_all_types.spec()
     wrapped_data_file_v2_debug = DataFile.from_args(
-        format_version=2,
+        _table_format_version=2,
         content=entry.data_file.content,
         file_path=entry.data_file.file_path,
         file_format=entry.data_file.file_format,

--- a/tests/test_typedef.py
+++ b/tests/test_typedef.py
@@ -17,6 +17,7 @@
 import pytest
 
 from pyiceberg.typedef import FrozenDict, KeyDefaultDict, Record
+from pyiceberg.types import IntegerType, NestedField, StructType
 
 
 def test_setitem_frozendict() -> None:
@@ -47,3 +48,20 @@ def test_record_named_args() -> None:
     assert r[2] is True
 
     assert repr(r) == "Record[1, a, True]"
+
+
+def test_record_bind_rejects_unknown_arguments() -> None:
+    struct = StructType(NestedField(1, "known", IntegerType()))
+
+    with pytest.raises(TypeError, match="Unexpected Record fields: unknown"):
+        Record._bind(struct, known=1, unknown=2)
+
+
+def test_record_bind_rejects_non_schema_property() -> None:
+    class RecordWithProperty(Record):
+        @property
+        def computed(self) -> int:
+            return 1
+
+    with pytest.raises(TypeError, match="Unexpected RecordWithProperty fields: computed"):
+        RecordWithProperty._bind(StructType(), computed=1)


### PR DESCRIPTION
## Summary

This PR fixes two related constructor issues:

1. `DataFile.from_args` now sets `spec_id` when it is provided. `spec_id` remains transient runtime context and is not included in the serialized `data_file` record.
2. `Record._bind` now raises `TypeError` for fields that are not part of the selected struct instead of silently dropping them.

## Motivation

`DataFile.from_args(spec_id=...)` previously accepted the argument, but `_bind` discarded it because `spec_id` belongs to the containing manifest rather than the serialized data-file schema. The resulting `DataFile` had no spec context, and accessing `spec_id` could raise `AttributeError`.

More generally, silently ignoring unknown fields is a footgun: misspelled, unsupported, or wrong-version arguments appear to work while producing an incomplete record. Validating arguments in `_bind` makes these mistakes fail immediately for all record types.

## Tests

- `make lint`
- `make test PYTEST_ARGS="-q"`
- `pytest -v -x -m integration tests/integration/test_rest_manifest.py::test_write_sample_manifest`